### PR TITLE
Fix: A2A infinite call

### DIFF
--- a/src/intent/analyzer.ts
+++ b/src/intent/analyzer.ts
@@ -130,11 +130,17 @@ export class IntentAnalyzer {
             const result = await this.a2a!.useTool(
               selectedTool as A2ATool, messagePayload!, threadId
             );
-            finalText.push(...result);
+
+            const toolResult =
+              `[Bot Called Tool ${toolName}]\n` +
+              result.join('\n');
+            console.log('toolResult :>> ', toolResult);
+            
+            finalText.push(toolResult);
 
             messages.push({
               role: 'user',
-              content: result.join('\n'),
+              content: toolResult,
             });
           }
         }


### PR DESCRIPTION
Updates
- tool result에 `[Bot Called Tool ${toolName}]` 를 포함해야 tool이 사용되었음을 llm이 알 수 있다고 합니다.
- a2a result에도 위 annotation 문장 포함하도록 수정했습니다.

Thanks to @jiwoochris 