### PR TITLE
Fix FOL fact parsing

### DIFF
--- a/src/intent/modules/fol/client/folClient.ts
+++ b/src/intent/modules/fol/client/folClient.ts
@@ -36,7 +36,7 @@ export class FOLClient {
 			const existingFactsStr = existingFacts.facts
 				.map(
 					(f) =>
-						`${f.value}: ${f.description} [${f.predicate}(${(
+						`${f.value}: ${f.description} [${(f.predicates || []).join(",")}(${(
 							f.arguments || []
 						).join(", ")})]`,
 				)
@@ -203,7 +203,7 @@ ${predicatesStr}
 			const factsStr = facts
 				.map(
 					(f) =>
-						`${f.value}: ${f.description} [${f.predicate}(${(
+						`${f.value}: ${f.description} [${(f.predicates || []).join(",")}(${(
 							f.arguments || []
 						).join(", ")})]`,
 				)

--- a/src/intent/modules/fol/store/local.ts
+++ b/src/intent/modules/fol/store/local.ts
@@ -84,14 +84,14 @@ export class FOLLocalStore extends FOLStore {
 					const value = typeof item.value === "string" ? item.value : "";
 					const description =
 						typeof item.description === "string" ? item.description : "";
-					let predicate = "";
+					let predicatesArr: string[] = [];
 					let args: string[] = [];
 					// predicates 목록과 매칭
 					const matched = predicateNames.find((pred) =>
 						value.startsWith(`${pred}(`),
 					);
 					if (matched) {
-						predicate = matched;
+						predicatesArr = [matched];
 						const argMatch = value.match(/^.+\(([^)]*)\)$/);
 						if (argMatch) {
 							args = argMatch[1]
@@ -103,7 +103,7 @@ export class FOLLocalStore extends FOLStore {
 					return {
 						value,
 						description,
-						predicate,
+						predicates: predicatesArr,
 						arguments: args,
 						updatedAt:
 							typeof item.updatedAt === "string" ? item.updatedAt : undefined,
@@ -148,13 +148,13 @@ export class FOLLocalStore extends FOLStore {
 				facts.map((fact) => {
 					const value = fact.value;
 					const description = fact.description;
-					let predicate = "";
+					let predicatesArr: string[] = [];
 					let args: string[] = [];
 					const matched = predicateNames.find((pred) =>
 						value.startsWith(`${pred}(`),
 					);
 					if (matched) {
-						predicate = matched;
+						predicatesArr = [matched];
 						const argMatch = value.match(/^.+\(([^)]*)\)$/);
 						if (argMatch) {
 							args = argMatch[1]
@@ -166,7 +166,7 @@ export class FOLLocalStore extends FOLStore {
 					return {
 						value,
 						description,
-						predicate,
+						predicates: predicatesArr,
 						arguments: args,
 						...(fact.updatedAt ? { updatedAt: fact.updatedAt } : {}),
 					};
@@ -203,7 +203,7 @@ export class FOLLocalStore extends FOLStore {
 			});
 
 			const factsMap = new Map<string, FactItem>();
-			// value를 key로 하되, 최신 정보로 병합 (description, predicate, arguments, updatedAt)
+			// value를 key로 하되, 최신 정보로 병합 (description, predicates, arguments, updatedAt)
 			existingFacts.forEach((item) => {
 				factsMap.set(item.value, item);
 			});
@@ -212,7 +212,7 @@ export class FOLLocalStore extends FOLStore {
 				factsMap.set(item.value, {
 					value: item.value,
 					description: item.description,
-					predicate: item.predicate,
+					predicates: item.predicates,
 					arguments: item.arguments,
 					updatedAt: new Date().toISOString(),
 					...(prev ? { ...prev, ...item } : {}),

--- a/src/intent/modules/fol/types/index.ts
+++ b/src/intent/modules/fol/types/index.ts
@@ -15,7 +15,7 @@ export type FolItem = {
 export interface FactItem {
 	value: string;
 	description: string;
-	predicate: string;
+	predicates: string[];
 	arguments: string[];
 	updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- allow storing multiple predicates per fact
- parse predicate names into a list when reading/writing facts
- update client formatting when printing fact data

## Testing
- `npm run lint`
- `npm run test`
- `npm run build:esm`


------
https://chatgpt.com/codex/tasks/task_e_686f772003048321a4718976a7a50826