### PR TITLE
fix: lowercase log level

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,7 +4,7 @@ const { combine, timestamp, printf, colorize, errors } = winston.format;
 
 const createLogger = (service: string) => {
 	const logger = winston.createLogger({
-		level: process.env.LOG_LEVEL || "info",
+		level: (process.env.LOG_LEVEL || "info").toLowerCase(),
 		format: combine(
 			errors({ stack: true }),
 			colorize(),


### PR DESCRIPTION
Python 기반 MCP에서 `LOG_LEVEL`이 대문자가 표준이라, 소문자로 설정 시 에러가 발생합니다.
Winston Log level 적용할 때 소문자로 변환하도록 수정했습니다.