### PR TITLE
MCP connect after server starts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,7 @@ export class AINAgent {
 	 */
 	public async start(port: number): Promise<void> {
 		await this.memoryModule?.initialize();
+		await this.mcpModule?.connectToServers();
 		this.app.listen(port, () => {
 			loggers.agent.info(`AINAgent is running on port ${port}`);
 		});

--- a/src/modules/mcp/mcp.module.ts
+++ b/src/modules/mcp/mcp.module.ts
@@ -1,5 +1,8 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 import type { MCPConfig } from "@/types/mcp.js";
 import { loggers } from "@/utils/logger.js";
 import { MCPTool } from "./mcp.tool.js";
@@ -26,48 +29,68 @@ import { MCPTool } from "./mcp.tool.js";
  * ```
  */
 export class MCPModule {
+	private mcpConfigs: Map<string, MCPConfig> = new Map();
 	/** Map of MCP server names to their client instances */
-	private mcpMap: Map<string, Client> = new Map();
-	/** Map of MCP server names to their transport instances */
-	private transportMap: Map<string, StdioClientTransport> = new Map();
+	private mcpClientMap: Map<string, Client> = new Map();
 	/** Array of all discovered tools from connected MCP servers */
 	private tools: MCPTool[] = [];
 
-	/**
-	 * Connects to MCP servers based on the provided configuration.
-	 *
-	 * For each server in the config, establishes a connection, discovers
-	 * available tools, and adds them to the module's tool collection.
-	 * Skips servers that are already connected.
-	 *
-	 * @param mcpConfig - Configuration object mapping server names to connection details
-	 * @throws Error if connection to any MCP server fails
-	 */
-	async addMCPConfig(mcpConfig: MCPConfig) {
-		try {
-			for (const [name, conf] of Object.entries(mcpConfig)) {
-				// FIXME(yoojin): Need strict duplication check.
-				if (this.mcpMap.get(name) && this.transportMap.get(name)) continue; // Duplicated mcp: skip
+	addMCPServerConfig(configs: { [name: string]: MCPConfig }): void {
+		for (const [name, config] of Object.entries(configs)) {
+			this.mcpConfigs.set(name, config);
+		}
+	}
 
-				const transport = new StdioClientTransport(conf);
-				this.transportMap.set(name, transport);
-				const mcp = new Client({ name: "mcp-client-cli", version: "1.0.0" });
-				await mcp.connect(transport);
-				this.mcpMap.set(name, mcp);
+	async connectToServers(): Promise<void> {
+		for (const [name, config] of this.mcpConfigs.entries()) {
+			try {
+				const mcpClient = new Client({ name, version: "1.0.0" });
+				switch (config.type) {
+					case "stdio": {
+						const transport = new StdioClientTransport(config.params);
+						await mcpClient.connect(transport);
+						break;
+					}
+					case "websocket": {
+						const transport = new WebSocketClientTransport(config.url);
+						await mcpClient.connect(transport);
+						break;
+					}
+					case "sse": {
+						const transport = new SSEClientTransport(
+							config.url,
+							config.options,
+						);
+						await mcpClient.connect(transport);
+						break;
+					}
+					case "streamableHttp": {
+						const transport = new StreamableHTTPClientTransport(
+							config.url,
+							config.options,
+						);
+						await mcpClient.connect(transport);
+						break;
+					}
+					default:
+						// It cannot be happened.
+						loggers.mcp.error("Unsupported MCP config type");
+						break;
+				}
 
-				const toolsResult = await mcp.listTools();
+				this.mcpClientMap.set(name, mcpClient);
+				const toolList = await mcpClient.listTools();
 				this.tools.push(
-					...toolsResult.tools.map((tool) => {
+					...toolList.tools.map((tool) => {
 						return new MCPTool(name, tool);
 					}),
 				);
+				loggers.mcp.info("Connected to MCP server with tools:", {
+					tools: toolList.tools.map((tool) => tool.id),
+				});
+			} catch (error) {
+				loggers.mcp.error(`Failed to connect to MCP server ${name}`, { error });
 			}
-			loggers.mcp.info("Connected to MCP server with tools:", {
-				tools: this.tools.map((tool) => tool.id),
-			});
-		} catch (error: unknown) {
-			loggers.mcp.error("Failed to connect to MCP server:", { error });
-			throw error;
 		}
 	}
 
@@ -91,7 +114,7 @@ export class MCPModule {
 	async useTool(tool: MCPTool, _args?: any): Promise<string> {
 		const { serverName, mcpTool } = tool;
 		const toolName = mcpTool.name;
-		const mcp = this.mcpMap.get(serverName);
+		const mcp = this.mcpClientMap.get(serverName);
 
 		try {
 			if (!mcp) {
@@ -120,8 +143,8 @@ export class MCPModule {
 	 * all MCP connections are properly closed.
 	 */
 	async cleanup() {
-		this.mcpMap.forEach((mcp: Client) => {
-			mcp.close();
+		this.mcpClientMap.forEach((mcpClient: Client) => {
+			mcpClient.close();
 		});
 	}
 }

--- a/src/modules/mcp/mcp.module.ts
+++ b/src/modules/mcp/mcp.module.ts
@@ -73,7 +73,7 @@ export class MCPModule {
 						break;
 					}
 					default:
-						// It cannot be happened.
+						// This cannot happen.
 						loggers.mcp.error("Unsupported MCP config type");
 						break;
 				}

--- a/src/modules/mcp/mcp.module.ts
+++ b/src/modules/mcp/mcp.module.ts
@@ -80,13 +80,12 @@ export class MCPModule {
 
 				this.mcpClientMap.set(name, mcpClient);
 				const toolList = await mcpClient.listTools();
-				this.tools.push(
-					...toolList.tools.map((tool) => {
-						return new MCPTool(name, tool);
-					}),
-				);
+				const newToolList = toolList.tools.map((tool) => {
+					return new MCPTool(name, tool);
+				});
+				this.tools.push(...newToolList);
 				loggers.mcp.info("Connected to MCP server with tools:", {
-					tools: toolList.tools.map((tool) => tool.id),
+					tools: newToolList.map((tool) => tool.id),
 				});
 			} catch (error) {
 				loggers.mcp.error(`Failed to connect to MCP server ${name}`, { error });

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,5 +1,13 @@
+import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-export type MCPConfig = {
-	[name: string]: StdioServerParameters;
-};
+export type MCPConfig =
+	| { type: "stdio"; params: StdioServerParameters }
+	| { type: "websocket"; url: URL }
+	| { type: "sse"; url: URL; options?: SSEClientTransportOptions }
+	| {
+			type: "streamableHttp";
+			url: URL;
+			options?: StreamableHTTPClientTransportOptions;
+	  };


### PR DESCRIPTION
* Do not connect to mcp server on initializing stage
* Support various MCP server type (not tested)
  * `STDIO` / `websocket` / `sse` / `streamableHttp`
* Add gracefully shutdown logic