### PR TITLE
Fix issues

### DIFF
--- a/src/services/query-stream.service.ts
+++ b/src/services/query-stream.service.ts
@@ -378,6 +378,7 @@ ${intent?.prompt || ""}
 
 		await threadMemory?.addMessagesToThread(userId, threadId, [
 			{
+				messageId: randomUUID(),
 				role: MessageRole.USER,
 				timestamp: queryStartAt,
 				content: { type: "text", parts: [query] },
@@ -398,6 +399,7 @@ ${intent?.prompt || ""}
 			} else if (event.event === "tool_start") {
 				await threadMemory?.addMessagesToThread(userId, threadId, [
 					{
+						messageId: randomUUID(),
 						role: MessageRole.MODEL,
 						timestamp: Date.now(),
 						content: {
@@ -414,6 +416,7 @@ ${intent?.prompt || ""}
 			} else if (event.event === "tool_output") {
 				await threadMemory?.addMessagesToThread(userId, threadId, [
 					{
+						messageId: randomUUID(),
 						role: MessageRole.MODEL,
 						timestamp: Date.now(),
 						content: { type: "text", parts: [event.data.result] },
@@ -430,6 +433,7 @@ ${intent?.prompt || ""}
 
 		await threadMemory?.addMessagesToThread(userId, threadId, [
 			{
+				messageId: randomUUID(),
 				role: MessageRole.MODEL,
 				timestamp: Date.now(),
 				content: { type: "text", parts: [finalResponseText] },

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -337,11 +337,13 @@ ${intent?.prompt || ""}
 		const result = await this.intentFulfilling(query, threadId, thread, intent);
 		await threadMemory?.addMessagesToThread(userId, threadId, [
 			{
+				messageId: randomUUID(),
 				role: MessageRole.USER,
 				timestamp: queryStartAt,
 				content: { type: "text", parts: [query] },
 			},
 			{
+				messageId: randomUUID(),
 				role: MessageRole.MODEL,
 				timestamp: Date.now(),
 				content: { type: "text", parts: [result.response] },

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -39,6 +39,7 @@ export type MessageContentObject = {
  * ```
  */
 export type MessageObject = {
+	messageId: string;
 	/** Role of the message sender */
 	role: MessageRole;
 	/** Message content with type and parts */
@@ -71,20 +72,17 @@ export type ThreadMetadata = {
  * ```typescript
  * const thread: ThreadObject = {
  * 	 title: "New conversation",
- *   messages: {
- *     "<UUID_1>": { role: MessageRole.USER, content: {...}, timestamp: 1234567890 },
- *     "<UUID_2>": { role: MessageRole.MODEL, content: {...}, timestamp: 1234567891 }
- *   }
+ *   messages: [
+ *     { messageId: <UUID_1>, role: MessageRole.USER, content: {...}, timestamp: 1234567890 },
+ *     { messageId: <UUID_2> ,role: MessageRole.MODEL, content: {...}, timestamp: 1234567891 }
+ *   ]
  * };
  * ```
  */
 export type ThreadObject = {
 	type: ThreadType;
 	title: string;
-	/* Collection of messages indexed by unique message ID */
-	messages: {
-		[messageId: string]: MessageObject;
-	};
+	messages: Array<MessageObject>;
 };
 
 export interface Intent {


### PR DESCRIPTION
* Handling situations where queries are requested with non-existent Thread IDs
* Change the messages type in the getThread response from object to array