### PR TITLE
improve: clean up streaming response logs

### DIFF
--- a/src/services/intents/fulfill-stream.service.ts
+++ b/src/services/intents/fulfill-stream.service.ts
@@ -254,7 +254,6 @@ ${intent?.prompt || ""}
 		});
 
 		let finalResponseText = "";
-		let totalChunks = 0;
 
 		for (let i = 0; i < intents.length; i++) {
 			const { subquery, intent, actionPlan } = intents[i];
@@ -290,7 +289,6 @@ ${intent?.prompt || ""}
 			finalResponseText = "";
 			for await (const event of stream) {
 				if (event.event === "text_chunk" && event.data.delta) {
-					totalChunks++;
 					finalResponseText += event.data.delta;
 				}
 
@@ -312,7 +310,6 @@ ${intent?.prompt || ""}
 		loggers.intentStream.info("Stream session completed", {
 			threadId: thread.threadId,
 			duration: `${streamDuration}ms`,
-			totalChunks,
 			endTime: new Date(streamEndTime).toISOString(),
 		});
 	}


### PR DESCRIPTION
## 🎯 Problem
Agent의 스트리밍 응답 시 `text_chunk` debug 로그가 대량으로 출력되어 tool 실행 로그와 기타 중요한 디버깅 정보를 확인하기 어려웠습니다.

## 🔧 Solution  
- **로그 폭탄 제거**: `text_chunk` debug 로깅을 완전히 삭제
- **구조화된 세션 로깅**: 스트리밍 시작/종료 시점에 의미 있는 요약 정보만 기록
- **불필요한 메트릭 정리**: `finalTextLength` 같은 의미 없는 메트릭 제거

## 📊 Changes
### Before
```
[IntentStream] debug: text_chunk | {"event": {...}}
[IntentStream] debug: text_chunk | {"event": {...}}  
[IntentStream] debug: text_chunk | {"event": {...}}
... (수백 줄의 방해 로그)
```

### After  
```
[IntentStream] info: Stream session started | {"threadId":"thread456","intentCount":1}
[IntentStream] info: Stream session completed | {"threadId":"thread456","duration":"2340ms","totalChunks":45}
```

## ✅ Benefits
- **로그 가독성 대폭 향상**: Tool 실행 로그가 명확히 보임
- **디버깅 효율성 증대**: 중요한 정보에 집중 가능  
- **성능 개선**: 불필요한 로그 I/O 제거
- **유지보수성 향상**: 심플하고 깔끔한 코드 구조

## 🔍 File Changes
- `src/services/intents/fulfill-stream.service.ts`: 스트리밍 로그 개선

## ✨ Features Preserved
- Tool 호출 로그 (MCP/A2A) 완전 보존
- Error 로그 및 디버깅 정보 유지  
- 스트리밍 기능 정상 동작

## Issue
Fixes #71 