### PR TITLE
fix: export IMemory

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,6 +4,7 @@ export { MCPModule } from "./mcp/mcp.module.js";
 export type {
 	IAgentMemory,
 	IIntentMemory,
+	IMemory,
 	IThreadMemory,
 } from "./memory/base.memory.js";
 export { MemoryModule } from "./memory/memory.module.js";


### PR DESCRIPTION
Memory module 구현 시 IMemory 를 import 하는 경우가 있어 export 추가합니다.
ex) [Mongodb Provider](https://github.com/ainetwork-ai/ain-adk-providers/blob/develop/packages/memory/mongodb/implements/base.memory.ts#L1)