### PR TITLE
feat: add multimodal query input normalization and validation

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -22,8 +22,14 @@ Completed groundwork so far:
 - added `IArtifactStore` abstraction and `ArtifactModule`
 - wired optional `artifactModule` into the SDK module registry and `AINAgent`
 - exported artifact module types from the public module surface
+- added structured query input types for multipart request normalization
+- added initial query input validation and normalization utilities
+- added legacy `message: string` to structured-input adapter logic at the query controller boundary
+- added structured error code support for request validation failures
 - updated README to mention the optional artifact layer
 - added initial tests for artifact module wiring
+- added tests for query input normalization and controller-level query input adaptation
+- moved repository tests into the top-level `tests/` directory so they are not emitted in build artifacts
 - updated Jest and TypeScript config so test files and Jest globals are recognized correctly
 
 Not completed yet:
@@ -778,6 +784,11 @@ This phase should happen before broad service refactors so all later logic share
 - add upload validation for size and mime type
 - implement structured error code responses while preserving a compatibility `message`
 
+Completed groundwork in this phase:
+
+- query input validation added for legacy and structured request shapes
+- structured error code support added to `AinHttpError` and error responses
+
 ## Phase 6. Query Contract Refactor and Internal Message Flow Migration
 
 - add multipart input contract
@@ -788,6 +799,12 @@ This phase should happen before broad service refactors so all later logic share
 - persist user messages as multipart messages
 - persist model messages as multipart messages
 - stop assuming final output is only a string
+
+Completed groundwork in this phase:
+
+- structured query input types added
+- legacy `message` requests are normalized into structured input at the controller boundary
+- structured `input.parts` requests are accepted and converted into the current text-based query flow
 
 ## Phase 7. Stream Event Redesign
 
@@ -860,6 +877,8 @@ Completed groundwork in this phase:
 
 - README updated with optional artifact layer/module references
 - initial tests added for artifact module and SDK wiring
+- query input normalization and controller adaptation tests added
+- tests moved out of `src/` into `tests/` so package builds no longer include test files
 - Jest and TypeScript test configuration updated for this repository
 
 Important note:

--- a/README.md
+++ b/README.md
@@ -198,10 +198,14 @@ modelLogger.error('Model API error');
 ### Standard Endpoints
 - `GET /` - Welcome message and health check
 - `POST /query` - Process queries (non-streaming)
-  - Request: `{ query: string, threadId?: string, type?: string, displayQuery?: string }`
+  - Request:
+    - Legacy: `{ message: string, threadId?: string, type?: string, displayMessage?: string }`
+    - Structured: `{ input: { parts: [...] }, threadId?: string, type?: string, displayMessage?: string }`
   - Response: `{ content: string, threadId: string }`
 - `POST /query/stream` - Process queries with streaming (SSE)
-  - Request: `{ query: string, threadId?: string, type?: string, displayQuery?: string }`
+  - Request:
+    - Legacy: `{ message: string, threadId?: string, type?: string, displayMessage?: string }`
+    - Structured: `{ input: { parts: [...] }, threadId?: string, type?: string, displayMessage?: string }`
   - Response: Server-Sent Events stream with event types:
     - `text_chunk`: Incremental text response
     - `tool_start`: Tool execution started

--- a/src/controllers/query.controller.ts
+++ b/src/controllers/query.controller.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
+import { getArtifactModule } from "@/config/modules";
 import type { QueryService } from "@/services";
 import { MessageRole } from "@/types/memory";
 import { loggers } from "@/utils/logger";
+import { normalizeQueryRequest } from "@/utils/query-input";
 
 export class QueryController {
 	private queryService: QueryService;
@@ -16,17 +18,13 @@ export class QueryController {
 		res: Response,
 		next: NextFunction,
 	) => {
-		const {
-			type,
-			threadId,
-			workflowId,
-			title,
-			message: query,
-			displayMessage: displayQuery,
-		} = req.body;
+		const { type, threadId, workflowId, title } = req.body;
 		const userId = res.locals.userId;
 
 		try {
+			const { query, displayQuery } = normalizeQueryRequest(req.body, {
+				artifactModuleConfigured: !!getArtifactModule(),
+			});
 			const stream = this.queryService.handleQuery(
 				{ type, userId, threadId, workflowId, title },
 				{ query, displayQuery },
@@ -54,15 +52,11 @@ export class QueryController {
 		res: Response,
 		_next: NextFunction,
 	) => {
-		const {
-			type,
-			threadId,
-			workflowId,
-			title,
-			message: query,
-			displayMessage: displayQuery,
-		} = req.body;
+		const { type, threadId, workflowId, title } = req.body;
 		const userId = res.locals.userId;
+		const { query, displayQuery } = normalizeQueryRequest(req.body, {
+			artifactModuleConfigured: !!getArtifactModule(),
+		});
 
 		res.writeHead(200, {
 			"Content-Type": "text/event-stream",

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -11,11 +11,12 @@ export const errorMiddleware = (
 	try {
 		const status: number = error.status || 500;
 		const message: string = error.message || "Something went wrong";
+		const code: string | undefined = error.code;
 
 		logger.error(
-			`[${req.method}] ${req.path} >> StatusCode:: ${status}, Message:: ${message}`,
+			`[${req.method}] ${req.path} >> StatusCode:: ${status}, Message:: ${message}, Code:: ${code || "UNKNOWN"}`,
 		);
-		res.status(status).json({ message });
+		res.status(status).json(code ? { message, code } : { message });
 	} catch (error) {
 		next(error);
 	}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -42,9 +42,11 @@ export type AinAgentManifest = {
 
 export class AinHttpError extends Error {
 	public status?: StatusCodes;
+	public code?: string;
 
-	constructor(status: StatusCodes, message: string) {
+	constructor(status: StatusCodes, message: string, code?: string) {
 		super(message);
 		this.status = status;
+		this.code = code;
 	}
 }

--- a/src/types/message-input.ts
+++ b/src/types/message-input.ts
@@ -1,0 +1,41 @@
+export type QueryTextInputPart = {
+	kind: "text";
+	text: string;
+};
+
+export type QueryDataInputPart = {
+	kind: "data";
+	mimeType: string;
+	data: unknown;
+};
+
+export type QueryArtifactInputPart = {
+	kind: "artifact";
+	artifactId: string;
+	name?: string;
+	mimeType?: string;
+	size?: number;
+	downloadUrl?: string;
+	previewText?: string;
+};
+
+export type QueryInputPart =
+	| QueryTextInputPart
+	| QueryDataInputPart
+	| QueryArtifactInputPart;
+
+export type QueryMessageInput = {
+	parts: QueryInputPart[];
+};
+
+export type QueryRequestInput = {
+	message?: string;
+	displayMessage?: string;
+	input?: QueryMessageInput;
+};
+
+export type NormalizedQueryRequest = {
+	input: QueryMessageInput;
+	query: string;
+	displayQuery?: string;
+};

--- a/src/utils/query-input.ts
+++ b/src/utils/query-input.ts
@@ -1,0 +1,244 @@
+import { StatusCodes } from "http-status-codes";
+import { AinHttpError } from "@/types/agent";
+import type {
+	NormalizedQueryRequest,
+	QueryArtifactInputPart,
+	QueryDataInputPart,
+	QueryInputPart,
+	QueryMessageInput,
+	QueryRequestInput,
+	QueryTextInputPart,
+} from "@/types/message-input";
+
+type NormalizeQueryInputOptions = {
+	artifactModuleConfigured: boolean;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function serializeArtifactPart(part: QueryArtifactInputPart): string {
+	if (part.previewText?.trim()) {
+		return part.previewText;
+	}
+
+	const artifactLabel = part.name || part.artifactId;
+	const metadata: string[] = [];
+	if (part.mimeType) {
+		metadata.push(part.mimeType);
+	}
+	if (typeof part.size === "number") {
+		metadata.push(`${part.size} bytes`);
+	}
+
+	return metadata.length > 0
+		? `[Artifact: ${artifactLabel} (${metadata.join(", ")})]`
+		: `[Artifact: ${artifactLabel}]`;
+}
+
+function serializeDataPart(part: QueryDataInputPart): string {
+	if (typeof part.data === "string") {
+		return part.data;
+	}
+
+	try {
+		return `${part.mimeType}: ${JSON.stringify(part.data)}`;
+	} catch {
+		return `[Data: ${part.mimeType}]`;
+	}
+}
+
+function serializePart(part: QueryInputPart): string {
+	if (part.kind === "text") {
+		return part.text;
+	}
+	if (part.kind === "artifact") {
+		return serializeArtifactPart(part);
+	}
+	return serializeDataPart(part);
+}
+
+function validateTextPart(part: Record<string, unknown>): QueryTextInputPart {
+	if (typeof part.text !== "string") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Text parts require a string 'text' field.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	return {
+		kind: "text",
+		text: part.text,
+	};
+}
+
+function validateDataPart(part: Record<string, unknown>): QueryDataInputPart {
+	if (typeof part.mimeType !== "string") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Data parts require a string 'mimeType' field.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	return {
+		kind: "data",
+		mimeType: part.mimeType,
+		data: part.data,
+	};
+}
+
+function validateArtifactPart(
+	part: Record<string, unknown>,
+	options: NormalizeQueryInputOptions,
+): QueryArtifactInputPart {
+	if (!options.artifactModuleConfigured) {
+		throw new AinHttpError(
+			StatusCodes.SERVICE_UNAVAILABLE,
+			"Artifact input requires an artifact module to be configured.",
+			"ARTIFACT_STORE_NOT_CONFIGURED",
+		);
+	}
+
+	if (typeof part.artifactId !== "string") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact parts require a string 'artifactId' field.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	const artifactPart: QueryArtifactInputPart = {
+		kind: "artifact",
+		artifactId: part.artifactId,
+	};
+
+	if (typeof part.name === "string") {
+		artifactPart.name = part.name;
+	}
+	if (typeof part.mimeType === "string") {
+		artifactPart.mimeType = part.mimeType;
+	}
+	if (typeof part.size === "number") {
+		artifactPart.size = part.size;
+	}
+	if (typeof part.downloadUrl === "string") {
+		artifactPart.downloadUrl = part.downloadUrl;
+	}
+	if (typeof part.previewText === "string") {
+		artifactPart.previewText = part.previewText;
+	}
+
+	return artifactPart;
+}
+
+function validateStructuredInput(
+	input: unknown,
+	options: NormalizeQueryInputOptions,
+): QueryMessageInput {
+	if (!isObject(input) || !Array.isArray(input.parts)) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Structured query input requires an 'input.parts' array.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	if (input.parts.length === 0) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Structured query input requires at least one part.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	const parts = input.parts.map((part) => {
+		if (!isObject(part) || typeof part.kind !== "string") {
+			throw new AinHttpError(
+				StatusCodes.BAD_REQUEST,
+				"Each query input part must be an object with a valid 'kind'.",
+				"INVALID_QUERY_INPUT",
+			);
+		}
+
+		if (part.kind === "text") {
+			return validateTextPart(part);
+		}
+		if (part.kind === "data") {
+			return validateDataPart(part);
+		}
+		if (part.kind === "artifact") {
+			return validateArtifactPart(part, options);
+		}
+
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			`Unsupported query input part kind: ${part.kind}`,
+			"INVALID_QUERY_INPUT",
+		);
+	});
+
+	return { parts };
+}
+
+export function normalizeQueryRequest(
+	rawInput: unknown,
+	options: NormalizeQueryInputOptions,
+): NormalizedQueryRequest {
+	if (!isObject(rawInput)) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Query request body must be an object.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	const body = rawInput as QueryRequestInput;
+	const hasLegacyMessage = typeof body.message === "string";
+	const hasStructuredInput = body.input !== undefined;
+
+	if (hasLegacyMessage && hasStructuredInput) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Provide either 'message' or 'input', but not both.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	if (!hasLegacyMessage && !hasStructuredInput) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Query request requires either 'message' or 'input'.",
+			"INVALID_QUERY_INPUT",
+		);
+	}
+
+	if (hasLegacyMessage) {
+		const message = body.message as string;
+		return {
+			input: {
+				parts: [{ kind: "text", text: message }],
+			},
+			query: message,
+			displayQuery:
+				typeof body.displayMessage === "string"
+					? body.displayMessage
+					: undefined,
+		};
+	}
+
+	const input = validateStructuredInput(body.input, options);
+	const query = input.parts
+		.map(serializePart)
+		.filter((value) => value.trim() !== "")
+		.join("\n");
+
+	return {
+		input,
+		query,
+		displayQuery:
+			typeof body.displayMessage === "string" ? body.displayMessage : undefined,
+	};
+}

--- a/tests/controllers/query.controller.test.ts
+++ b/tests/controllers/query.controller.test.ts
@@ -1,0 +1,109 @@
+import type { NextFunction, Request, Response } from "express";
+import { getArtifactModule } from "@/config/modules";
+import { QueryController } from "@/controllers/query.controller";
+
+jest.mock("@/config/modules", () => ({
+	getArtifactModule: jest.fn(),
+}));
+
+describe("QueryController", () => {
+	beforeEach(() => {
+		jest.mocked(getArtifactModule).mockReturnValue(undefined);
+	});
+
+	it("normalizes structured query input before calling QueryService", async () => {
+		const handleQuery = jest.fn(async function* () {
+			yield {
+				event: "thread_id" as const,
+				data: {
+					type: "CHAT" as const,
+					userId: "user-1",
+					threadId: "thread-1",
+					title: "Thread",
+				},
+			};
+			yield {
+				event: "text_chunk" as const,
+				data: { delta: "ok" },
+			};
+		});
+
+		const queryController = new QueryController({
+			handleQuery,
+		} as any);
+
+		const req = {
+			body: {
+				type: "CHAT",
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this report" },
+						{
+							kind: "data",
+							mimeType: "application/json",
+							data: { quarter: "Q1", revenue: 1200 },
+						},
+					],
+				},
+			},
+		} as Request;
+
+		const json = jest.fn();
+		const status = jest.fn().mockReturnValue({ json });
+		const res = {
+			locals: { userId: "user-1" },
+			status,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await queryController.handleQueryRequest(req, res, next);
+
+		expect(handleQuery).toHaveBeenCalledWith(
+			{
+				type: "CHAT",
+				userId: "user-1",
+				threadId: undefined,
+				workflowId: undefined,
+				title: undefined,
+			},
+			{
+				query:
+					'Summarize this report\napplication/json: {"quarter":"Q1","revenue":1200}',
+				displayQuery: undefined,
+			},
+		);
+		expect(status).toHaveBeenCalledWith(200);
+		expect(json).toHaveBeenCalledWith({
+			content: "ok",
+			threadId: "thread-1",
+		});
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("passes validation errors to next", async () => {
+		const queryController = new QueryController({
+			handleQuery: jest.fn(),
+		} as any);
+
+		const req = {
+			body: {
+				input: {
+					parts: [{ kind: "artifact", artifactId: "art_123" }],
+				},
+			},
+		} as Request;
+		const res = {
+			locals: { userId: "user-1" },
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await queryController.handleQueryRequest(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		const error = (next as jest.Mock).mock.calls[0][0];
+		expect(error.message).toBe(
+			"Artifact input requires an artifact module to be configured.",
+		);
+		expect(error.code).toBe("ARTIFACT_STORE_NOT_CONFIGURED");
+	});
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,9 @@
-import { getArtifactModule } from "./config/modules";
-import { AINAgent } from "./index";
-import { ArtifactModule } from "./modules/artifacts/artifact.module";
-import type { IArtifactStore } from "./modules/artifacts/base.artifact";
-import { AuthModule } from "./modules/auth/auth.module";
+import { AINAgent } from "@/index";
+import { getArtifactModule } from "@/config/modules";
+import { ArtifactModule } from "@/modules/artifacts/artifact.module";
+import type { IArtifactStore } from "@/modules/artifacts/base.artifact";
+import { AuthModule } from "@/modules/auth/auth.module";
+import { MemoryModule } from "@/modules/memory/memory.module";
 import type {
 	IAgentMemory,
 	IIntentMemory,
@@ -10,20 +11,18 @@ import type {
 	IThreadMemory,
 	IUserWorkflowMemory,
 	IWorkflowTemplateMemory,
-} from "./modules/memory/base.memory";
-import { MemoryModule } from "./modules/memory/memory.module";
-import { BaseModel } from "./modules/models/base.model";
-import { ModelModule } from "./modules/models/model.module";
-import type { AuthResponse } from "./types/auth";
-import type { ConnectorTool, FetchResponse } from "./types/connector";
+} from "@/modules/memory/base.memory";
+import { BaseModel } from "@/modules/models/base.model";
+import { ModelModule } from "@/modules/models/model.module";
+import type { AuthResponse } from "@/types/auth";
+import type { ConnectorTool, FetchResponse } from "@/types/connector";
 import type {
 	Intent,
 	ThreadMetadata,
-	ThreadObject,
 	UserWorkflow,
 	WorkflowTemplate,
-} from "./types/memory";
-import type { LLMStream } from "./types/stream";
+} from "@/types/memory";
+import type { LLMStream } from "@/types/stream";
 
 class TestAuthModule extends AuthModule {
 	async authenticate(): Promise<AuthResponse> {
@@ -87,9 +86,7 @@ const workflowTemplateMemory: IWorkflowTemplateMemory = {
 	createTemplate: jest.fn(),
 	updateTemplate: jest.fn(),
 	deleteTemplate: jest.fn(),
-	listTemplates: jest
-		.fn<Promise<WorkflowTemplate[]>, []>()
-		.mockResolvedValue([]),
+	listTemplates: jest.fn<Promise<WorkflowTemplate[]>, []>().mockResolvedValue([]),
 };
 
 const userWorkflowMemory: IUserWorkflowMemory = {
@@ -97,9 +94,7 @@ const userWorkflowMemory: IUserWorkflowMemory = {
 	createUserWorkflow: jest.fn(),
 	updateUserWorkflow: jest.fn(),
 	deleteUserWorkflow: jest.fn(),
-	listUserWorkflows: jest
-		.fn<Promise<UserWorkflow[]>, []>()
-		.mockResolvedValue([]),
+	listUserWorkflows: jest.fn<Promise<UserWorkflow[]>, []>().mockResolvedValue([]),
 	listActiveScheduledWorkflows: jest
 		.fn<Promise<UserWorkflow[]>, []>()
 		.mockResolvedValue([]),

--- a/tests/modules/artifacts/artifact.module.test.ts
+++ b/tests/modules/artifacts/artifact.module.test.ts
@@ -1,5 +1,5 @@
-import { ArtifactModule } from "./artifact.module";
-import type { IArtifactStore } from "./base.artifact";
+import { ArtifactModule } from "@/modules/artifacts/artifact.module";
+import type { IArtifactStore } from "@/modules/artifacts/base.artifact";
 
 describe("ArtifactModule", () => {
 	it("returns the configured artifact store", () => {

--- a/tests/utils/query-input.test.ts
+++ b/tests/utils/query-input.test.ts
@@ -1,0 +1,82 @@
+import { normalizeQueryRequest } from "@/utils/query-input";
+
+describe("normalizeQueryRequest", () => {
+	it("supports legacy message input", () => {
+		const result = normalizeQueryRequest(
+			{
+				message: "hello world",
+				displayMessage: "Hello",
+			},
+			{ artifactModuleConfigured: false },
+		);
+
+		expect(result.query).toBe("hello world");
+		expect(result.displayQuery).toBe("Hello");
+		expect(result.input.parts).toEqual([{ kind: "text", text: "hello world" }]);
+	});
+
+	it("supports structured text input", () => {
+		const result = normalizeQueryRequest(
+			{
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this" },
+						{ kind: "text", text: "Please keep it short" },
+					],
+				},
+			},
+			{ artifactModuleConfigured: false },
+		);
+
+		expect(result.query).toBe("Summarize this\nPlease keep it short");
+	});
+
+	it("serializes structured artifact input using preview text", () => {
+		const result = normalizeQueryRequest(
+			{
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this report" },
+						{
+							kind: "artifact",
+							artifactId: "art_123",
+							name: "report.pdf",
+							previewText: "Quarterly revenue increased by 20 percent.",
+						},
+					],
+				},
+			},
+			{ artifactModuleConfigured: true },
+		);
+
+		expect(result.query).toBe(
+			"Summarize this report\nQuarterly revenue increased by 20 percent.",
+		);
+	});
+
+	it("rejects artifact input when artifact storage is not configured", () => {
+		expect(() =>
+			normalizeQueryRequest(
+				{
+					input: {
+						parts: [{ kind: "artifact", artifactId: "art_123" }],
+					},
+				},
+				{ artifactModuleConfigured: false },
+			),
+		).toThrow("Artifact input requires an artifact module to be configured.");
+	});
+
+	it("rejects malformed structured input", () => {
+		expect(() =>
+			normalizeQueryRequest(
+				{
+					input: {
+						parts: [{ kind: "text" }],
+					},
+				},
+				{ artifactModuleConfigured: false },
+			),
+		).toThrow("Text parts require a string 'text' field.");
+	});
+});


### PR DESCRIPTION
## Summary

This PR introduces the next foundational step for multimodal chat support by adding a structured query input contract, request validation, and normalization at the query-controller boundary.

The runtime chat pipeline is still text-based internally, but it can now accept structured `input.parts` requests and normalize them into the current flow while preserving backward compatibility with legacy `message: string` requests.

## What Changed

- added structured query input types
- added query input validation and normalization utilities
- added legacy `message` to structured-input adapter logic
- added structured error code support for validation failures
- updated query controller to accept both legacy and structured input
- updated README request examples
- moved tests into the top-level `tests/` directory so build outputs do not include test files
- updated multimodal plan progress tracking

## Why This PR

This PR opens the public request contract for multimodal inputs without yet forcing a full migration of:
- `MessageObject`
- `QueryService` persistence
- stream event schema
- model-provider interfaces
- A2A payloads

That keeps the change reviewable while preparing the next PRs.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `yarn test --runInBand`
- `yarn build`

## Notes

- legacy `message: string` requests still work
- structured `input.parts` requests are normalized into the current text-based query path
- artifact input currently requires an artifact module to be configured
- tests were moved out of `src/` to avoid shipping them in build artifacts