### PR TITLE
feat: introduce canonical message parts and serialization groundwork

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-10`
+Last updated: `2026-04-14`
 
 Completed groundwork so far:
 
@@ -31,10 +31,15 @@ Completed groundwork so far:
 - added tests for query input normalization and controller-level query input adaptation
 - moved repository tests into the top-level `tests/` directory so they are not emitted in build artifacts
 - updated Jest and TypeScript config so test files and Jest globals are recognized correctly
+- introduced canonical multipart message part types alongside legacy message compatibility
+- added shared message normalization and intent-serialization utilities
+- updated new thread message writes to use canonical multipart messages
+- updated intent-trigger history serialization to use shared canonical helpers
+- added tests for legacy-to-canonical message normalization and multipart serialization
 
 Not completed yet:
 
-- multipart `MessageObject` migration
+- full multipart `MessageObject` migration across all runtime paths
 - query/request/response contract refactor
 - artifact upload/download runtime APIs
 - stream event redesign
@@ -50,10 +55,10 @@ The current implementation is effectively text-only, even though some types are 
 
 ### Text-only assumptions in the current code
 
-- `/query` and `/query/stream` accept `message` and `displayMessage` as strings
-- `QueryService` processes `query: string`
-- user and model messages are stored as `content: { type: "text", parts: [...] }`
-- thread history is flattened into strings for intent triggering
+- `/query` and `/query/stream` now accept legacy `message` and structured `input.parts`, but normalize both into a text-first runtime path
+- `QueryService` still processes `query: string` for inference, even though it can now receive structured input for persistence
+- some runtime paths still assume `query: string`, but new message writes now converge on canonical `parts[]` messages
+- thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
 - stream output is centered on `text_chunk`
 - A2A paths read and write only text parts
 - server middleware only handles JSON and URL-encoded input, not multipart uploads
@@ -154,6 +159,17 @@ Migration note:
 
 - old records may be read through an adapter
 - new writes should converge on a single canonical schema as early as possible
+
+Completed groundwork in this phase:
+
+- added canonical multipart `MessageContentPart` types
+- preserved backward-compatible legacy message reads via a union `MessageObject`
+- added shared helpers for:
+  - canonical message creation
+  - legacy-to-canonical normalization
+  - thread/message serialization for intent prompts
+- updated current `QueryService`, `QueryController`, and fulfillment flows to write new text messages in canonical form
+- replaced direct `content.parts.join(" ")` logic in trigger services with shared serialization utilities
 
 ## 2. Artifact Model
 

--- a/src/controllers/query.controller.ts
+++ b/src/controllers/query.controller.ts
@@ -4,6 +4,7 @@ import { getArtifactModule } from "@/config/modules";
 import type { QueryService } from "@/services";
 import { MessageRole } from "@/types/memory";
 import { loggers } from "@/utils/logger";
+import { createTextMessage } from "@/utils/message";
 import { normalizeQueryRequest } from "@/utils/query-input";
 
 export class QueryController {
@@ -22,12 +23,12 @@ export class QueryController {
 		const userId = res.locals.userId;
 
 		try {
-			const { query, displayQuery } = normalizeQueryRequest(req.body, {
+			const { input, query, displayQuery } = normalizeQueryRequest(req.body, {
 				artifactModuleConfigured: !!getArtifactModule(),
 			});
 			const stream = this.queryService.handleQuery(
 				{ type, userId, threadId, workflowId, title },
-				{ query, displayQuery },
+				{ input, query, displayQuery },
 			);
 
 			let content = "";
@@ -54,7 +55,7 @@ export class QueryController {
 	) => {
 		const { type, threadId, workflowId, title } = req.body;
 		const userId = res.locals.userId;
-		const { query, displayQuery } = normalizeQueryRequest(req.body, {
+		const { input, query, displayQuery } = normalizeQueryRequest(req.body, {
 			artifactModuleConfigured: !!getArtifactModule(),
 		});
 
@@ -84,7 +85,7 @@ export class QueryController {
 		let currentThreadId = threadId;
 		const stream = this.queryService.handleQuery(
 			{ type, userId, threadId, workflowId, title },
-			{ query, displayQuery },
+			{ input, query, displayQuery },
 		);
 
 		try {
@@ -98,16 +99,16 @@ export class QueryController {
 				} else if (event.event === "thinking_process") {
 					// a2a 호출에 대해서는 데이터베이스에 추가하지 않기 위해 여기서 thread message에 기록
 					this.queryService.addToThreadMessages(userId, currentThreadId, [
-						{
+						createTextMessage({
 							messageId: randomUUID(),
 							role: MessageRole.MODEL,
 							timestamp: Date.now(),
-							content: { type: "text", parts: [event.data.title] },
+							text: event.data.title,
 							metadata: {
 								isThinking: true,
 								thinkData: event.data,
 							},
-						},
+						}),
 					]);
 				}
 

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -18,6 +18,7 @@ import {
 } from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger";
+import { createTextMessage } from "@/utils/message";
 import { PIIFilterMode, type PIIService } from "../pii.service";
 import fulfillPrompt from "../prompts/fulfill";
 import toolSelectPrompt from "../prompts/tool-select";
@@ -60,13 +61,13 @@ export class IntentFulfillService {
 		try {
 			const threadMemory = this.memoryModule.getThreadMemory();
 			const { userId, threadId } = thread;
-			const newMessage: MessageObject = {
+			const newMessage: MessageObject = createTextMessage({
 				messageId: randomUUID(),
 				role: params.role,
 				timestamp: Date.now(),
-				content: { type: "text", parts: [params.content] },
+				text: params.content,
 				metadata: params.metadata,
-			};
+			});
 			thread.messages.push(newMessage);
 			await threadMemory?.addMessagesToThread(userId, threadId, [newMessage]);
 		} catch (error) {
@@ -383,13 +384,15 @@ export class IntentFulfillService {
 						}
 					}
 					// Add intermediate result to thread context for next intent
-					thread.messages.push({
-						messageId: randomUUID(),
-						role: MessageRole.MODEL,
-						timestamp: Date.now(),
-						content: { type: "text", parts: [responseText] },
-						metadata: { isThinking: true },
-					});
+					thread.messages.push(
+						createTextMessage({
+							messageId: randomUUID(),
+							role: MessageRole.MODEL,
+							timestamp: Date.now(),
+							text: responseText,
+							metadata: { isThinking: true },
+						}),
+					);
 				}
 			}
 		} else {
@@ -405,13 +408,15 @@ export class IntentFulfillService {
 				// Add previous result to thread context for inference (not stored in memory)
 				if (fulfillmentResults.length > 0) {
 					const lastResult = fulfillmentResults[fulfillmentResults.length - 1];
-					thread.messages.push({
-						messageId: randomUUID(),
-						role: MessageRole.MODEL,
-						timestamp: Date.now(),
-						content: { type: "text", parts: [lastResult.response] },
-						metadata: { isThinking: true },
-					});
+					thread.messages.push(
+						createTextMessage({
+							messageId: randomUUID(),
+							role: MessageRole.MODEL,
+							timestamp: Date.now(),
+							text: lastResult.response,
+							metadata: { isThinking: true },
+						}),
+					);
 				}
 
 				// Yield thinking_process for progress visibility

--- a/src/services/intents/multi-trigger.service.ts
+++ b/src/services/intents/multi-trigger.service.ts
@@ -1,11 +1,11 @@
 import type { MemoryModule, ModelModule } from "@/modules";
 import type {
 	IntentTriggerResult,
-	MessageObject,
 	ThreadObject,
 	TriggeredIntent,
 } from "@/types/memory";
 import { loggers } from "@/utils/logger";
+import { serializeThreadForIntent } from "@/utils/message";
 import multiTriggerPrompt from "../prompts/multi-trigger";
 
 /**
@@ -52,23 +52,7 @@ export class MultiIntentTriggerService {
 			.join("\n");
 
 		// Convert thread messages to a string
-		const threadMessages = !thread
-			? ""
-			: thread.messages
-					.sort((a, b) => a.timestamp - b.timestamp)
-					.map((message: MessageObject) => {
-						const role =
-							message.role === "USER"
-								? "User"
-								: message.role === "MODEL"
-									? "Assistant"
-									: "System";
-						const content = Array.isArray(message.content.parts)
-							? message.content.parts.join(" ")
-							: String(message.content.parts);
-						return `${role}: """${content}"""`;
-					})
-					.join("\n");
+		const threadMessages = serializeThreadForIntent(thread);
 
 		const systemPrompt = await multiTriggerPrompt(
 			this.memoryModule,

--- a/src/services/intents/single-trigger.service.ts
+++ b/src/services/intents/single-trigger.service.ts
@@ -1,11 +1,11 @@
 import type { MemoryModule, ModelModule } from "@/modules";
 import type {
 	IntentTriggerResult,
-	MessageObject,
 	ThreadObject,
 	TriggeredIntent,
 } from "@/types/memory";
 import { loggers } from "@/utils/logger";
+import { serializeThreadForIntent } from "@/utils/message";
 import singleTriggerPrompt from "../prompts/single-trigger";
 
 /**
@@ -51,23 +51,7 @@ export class SingleIntentTriggerService {
 			.join("\n");
 
 		// Convert thread messages to a string
-		const threadMessages = !thread
-			? ""
-			: thread.messages
-					.sort((a, b) => a.timestamp - b.timestamp)
-					.map((message: MessageObject) => {
-						const role =
-							message.role === "USER"
-								? "User"
-								: message.role === "MODEL"
-									? "Assistant"
-									: "System";
-						const content = Array.isArray(message.content.parts)
-							? message.content.parts.join(" ")
-							: String(message.content.parts);
-						return `${role}: """${content}"""`;
-					})
-					.join("\n");
+		const threadMessages = serializeThreadForIntent(thread);
 
 		const systemPrompt = await singleTriggerPrompt(
 			this.memoryModule,

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -13,8 +13,10 @@ import {
 	type ThreadObject,
 	ThreadType,
 } from "@/types/memory.js";
+import type { QueryMessageInput } from "@/types/message-input";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger.js";
+import { createMessageFromQueryInput } from "@/utils/message";
 import type { IntentFulfillService } from "./intents/fulfill.service";
 import type { IntentTriggerService } from "./intents/trigger.service";
 import { PIIFilterMode, type PIIService } from "./pii.service";
@@ -111,6 +113,7 @@ export class QueryService {
 		queryData: {
 			query: string;
 			displayQuery?: string;
+			input?: QueryMessageInput;
 		},
 		isA2A?: boolean,
 	): AsyncGenerator<StreamEvent> {
@@ -121,7 +124,7 @@ export class QueryService {
 			title: inputTitle,
 			options,
 		} = threadMetadata;
-		const { displayQuery } = queryData;
+		const { displayQuery, input } = queryData;
 		let { query } = queryData;
 		const threadMemory = this.memoryModule.getThreadMemory();
 
@@ -184,12 +187,15 @@ export class QueryService {
 
 		// only add for storage, not for inference
 		await this.addToThreadMessages(userId, threadId, [
-			{
+			createMessageFromQueryInput({
 				messageId: randomUUID(),
 				role: MessageRole.USER,
 				timestamp: Date.now(),
+				input: input ?? {
+					parts: [{ kind: "text", text: query }],
+				},
 				// use displayQuery for better UX in enterprise application
-				content: { type: "text", parts: [displayQuery || query] },
+				displayText: displayQuery,
 				metadata: {
 					intents: triggeredIntents
 						.filter((intent) => !!intent.intent)
@@ -199,7 +205,7 @@ export class QueryService {
 						})),
 					query: !displayQuery ? undefined : query,
 				},
-			},
+			}),
 		]);
 
 		// 3. intent fulfillment (with rewrite step)

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -8,18 +8,91 @@ export enum MessageRole {
 	SYSTEM = "SYSTEM",
 	/** AI model responses */
 	MODEL = "MODEL",
+	/** Tool-generated messages or results */
+	TOOL = "TOOL",
 }
 
 /**
- * Content structure for message content.
- *
- * Supports multi-part content with different types (text, images, etc.).
+ * Legacy message content structure kept for backward-compatible reads.
  */
-export type MessageContentObject = {
+export type LegacyMessageContentObject = {
 	/** Content type (e.g., "text", "image", "tool_use") */
 	type: string;
 	/** Array of content parts, structure depends on content type */
 	parts: any[];
+};
+
+export type TextContentPart = {
+	kind: "text";
+	text: string;
+};
+
+export type ArtifactContentPart = {
+	kind: "artifact";
+	artifactId: string;
+	name?: string;
+	mimeType?: string;
+	size?: number;
+	downloadUrl?: string;
+	previewText?: string;
+};
+
+export type DataContentPart = {
+	kind: "data";
+	mimeType: string;
+	data: unknown;
+};
+
+export type ToolCallContentPart = {
+	kind: "tool-call";
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+};
+
+export type ToolResultContentPart = {
+	kind: "tool-result";
+	toolCallId: string;
+	toolName: string;
+	result: unknown;
+};
+
+export type ThoughtContentPart = {
+	kind: "thought";
+	title: string;
+	description?: string;
+};
+
+export type MessageContentPart =
+	| TextContentPart
+	| ArtifactContentPart
+	| DataContentPart
+	| ToolCallContentPart
+	| ToolResultContentPart
+	| ThoughtContentPart;
+
+type MessageBase = {
+	messageId: string;
+	/** Role of the message sender */
+	role: MessageRole;
+	/** Unix timestamp when the message was created */
+	timestamp: number;
+	/** Optional metadata for additional context */
+	metadata?: { [key: string]: unknown };
+};
+
+export type LegacyMessageObject = MessageBase & {
+	schemaVersion?: 1;
+	/** Message content with type and parts */
+	content: LegacyMessageContentObject;
+	parts?: never;
+};
+
+export type CanonicalMessageObject = MessageBase & {
+	schemaVersion: 2;
+	/** Multipart-first message content */
+	parts: Array<MessageContentPart>;
+	content?: never;
 };
 
 /**
@@ -28,27 +101,15 @@ export type MessageContentObject = {
  * @example
  * ```typescript
  * const message: MessageObject = {
+ *   schemaVersion: 2,
  *   role: MessageRole.USER,
- *   content: {
- *     type: "text",
- *     parts: ["Hello, how can you help me?"]
- *   },
+ *   parts: [{ kind: "text", text: "Hello, how can you help me?" }],
  *   timestamp: Date.now(),
  *   metadata: { source: "web-ui" }
  * };
  * ```
  */
-export type MessageObject = {
-	messageId: string;
-	/** Role of the message sender */
-	role: MessageRole;
-	/** Message content with type and parts */
-	content: MessageContentObject;
-	/** Unix timestamp when the message was created */
-	timestamp: number;
-	/** Optional metadata for additional context */
-	metadata?: { [key: string]: unknown };
-};
+export type MessageObject = LegacyMessageObject | CanonicalMessageObject;
 
 export enum ThreadType {
 	WORKFLOW = "WORKFLOW",
@@ -85,8 +146,8 @@ export type ThreadMetadata = {
  * const thread: ThreadObject = {
  * 	 title: "New conversation",
  *   messages: [
- *     { messageId: <UUID_1>, role: MessageRole.USER, content: {...}, timestamp: 1234567890 },
- *     { messageId: <UUID_2> ,role: MessageRole.MODEL, content: {...}, timestamp: 1234567891 }
+ *     { messageId: <UUID_1>, role: MessageRole.USER, parts: [...], timestamp: 1234567890, schemaVersion: 2 },
+ *     { messageId: <UUID_2> ,role: MessageRole.MODEL, parts: [...], timestamp: 1234567891, schemaVersion: 2 }
  *   ]
  * };
  * ```

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,0 +1,356 @@
+import type {
+	ArtifactContentPart,
+	CanonicalMessageObject,
+	DataContentPart,
+	LegacyMessageObject,
+	MessageContentPart,
+	MessageObject,
+	MessageRole,
+	TextContentPart,
+	ThoughtContentPart,
+	ThreadObject,
+	ToolCallContentPart,
+	ToolResultContentPart,
+} from "@/types/memory";
+import type {
+	QueryArtifactInputPart,
+	QueryDataInputPart,
+	QueryMessageInput,
+	QueryTextInputPart,
+} from "@/types/message-input";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function isCanonicalMessageObject(
+	message: MessageObject,
+): message is CanonicalMessageObject {
+	return Array.isArray((message as CanonicalMessageObject).parts);
+}
+
+function normalizeTextPart(part: unknown): TextContentPart {
+	return {
+		kind: "text",
+		text: typeof part === "string" ? part : String(part ?? ""),
+	};
+}
+
+function normalizeArtifactPart(
+	part: Record<string, unknown>,
+): ArtifactContentPart {
+	return {
+		kind: "artifact",
+		artifactId: String(part.artifactId ?? ""),
+		name: typeof part.name === "string" ? part.name : undefined,
+		mimeType: typeof part.mimeType === "string" ? part.mimeType : undefined,
+		size: typeof part.size === "number" ? part.size : undefined,
+		downloadUrl:
+			typeof part.downloadUrl === "string" ? part.downloadUrl : undefined,
+		previewText:
+			typeof part.previewText === "string" ? part.previewText : undefined,
+	};
+}
+
+function normalizeDataPart(part: Record<string, unknown>): DataContentPart {
+	return {
+		kind: "data",
+		mimeType:
+			typeof part.mimeType === "string"
+				? part.mimeType
+				: "application/octet-stream",
+		data: part.data,
+	};
+}
+
+function normalizeToolCallPart(
+	part: Record<string, unknown>,
+): ToolCallContentPart {
+	return {
+		kind: "tool-call",
+		toolCallId: String(part.toolCallId ?? ""),
+		toolName: String(part.toolName ?? ""),
+		args: part.args,
+	};
+}
+
+function normalizeToolResultPart(
+	part: Record<string, unknown>,
+): ToolResultContentPart {
+	return {
+		kind: "tool-result",
+		toolCallId: String(part.toolCallId ?? ""),
+		toolName: String(part.toolName ?? ""),
+		result: part.result,
+	};
+}
+
+function normalizeThoughtPart(
+	part: Record<string, unknown>,
+): ThoughtContentPart {
+	return {
+		kind: "thought",
+		title: String(part.title ?? ""),
+		description:
+			typeof part.description === "string" ? part.description : undefined,
+	};
+}
+
+function normalizeKnownPart(
+	part: Record<string, unknown>,
+): MessageContentPart | undefined {
+	switch (part.kind) {
+		case "text":
+			return normalizeTextPart(part.text);
+		case "artifact":
+			return normalizeArtifactPart(part);
+		case "data":
+			return normalizeDataPart(part);
+		case "tool-call":
+			return normalizeToolCallPart(part);
+		case "tool-result":
+			return normalizeToolResultPart(part);
+		case "thought":
+			return normalizeThoughtPart(part);
+		default:
+			return undefined;
+	}
+}
+
+function normalizeLegacyContentPart(
+	legacyContent: LegacyMessageObject["content"],
+	part: unknown,
+): MessageContentPart {
+	if (isRecord(part) && typeof part.kind === "string") {
+		const normalized = normalizeKnownPart(part);
+		if (normalized) {
+			return normalized;
+		}
+	}
+
+	if (legacyContent.type === "data" && isRecord(part)) {
+		return normalizeDataPart(part);
+	}
+
+	return normalizeTextPart(part);
+}
+
+export function normalizeMessageParts(
+	message: MessageObject,
+): Array<MessageContentPart> {
+	if (isCanonicalMessageObject(message)) {
+		return message.parts;
+	}
+
+	const rawParts = Array.isArray(message.content.parts)
+		? message.content.parts
+		: [message.content.parts];
+
+	return rawParts.map((part) =>
+		normalizeLegacyContentPart(message.content, part),
+	);
+}
+
+export function normalizeMessageObject(
+	message: MessageObject,
+): CanonicalMessageObject {
+	return {
+		messageId: message.messageId,
+		role: message.role,
+		timestamp: message.timestamp,
+		metadata: message.metadata,
+		schemaVersion: 2,
+		parts: normalizeMessageParts(message),
+	};
+}
+
+export function createTextMessage(params: {
+	messageId: string;
+	role: MessageRole;
+	timestamp: number;
+	text: string;
+	metadata?: Record<string, unknown>;
+}): CanonicalMessageObject {
+	return {
+		messageId: params.messageId,
+		role: params.role,
+		timestamp: params.timestamp,
+		metadata: params.metadata,
+		schemaVersion: 2,
+		parts: [{ kind: "text", text: params.text }],
+	};
+}
+
+function queryTextPartToContentPart(part: QueryTextInputPart): TextContentPart {
+	return { kind: "text", text: part.text };
+}
+
+function queryDataPartToContentPart(part: QueryDataInputPart): DataContentPart {
+	return {
+		kind: "data",
+		mimeType: part.mimeType,
+		data: part.data,
+	};
+}
+
+function queryArtifactPartToContentPart(
+	part: QueryArtifactInputPart,
+): ArtifactContentPart {
+	return {
+		kind: "artifact",
+		artifactId: part.artifactId,
+		name: part.name,
+		mimeType: part.mimeType,
+		size: part.size,
+		downloadUrl: part.downloadUrl,
+		previewText: part.previewText,
+	};
+}
+
+export function createMessageFromQueryInput(params: {
+	messageId: string;
+	role: MessageRole;
+	timestamp: number;
+	input: QueryMessageInput;
+	displayText?: string;
+	metadata?: Record<string, unknown>;
+}): CanonicalMessageObject {
+	const parts = params.input.parts.map((part) => {
+		if (part.kind === "text") {
+			return queryTextPartToContentPart(part);
+		}
+		if (part.kind === "artifact") {
+			return queryArtifactPartToContentPart(part);
+		}
+		return queryDataPartToContentPart(part);
+	});
+
+	if (params.displayText?.trim()) {
+		const isSingleTextMessage = parts.length === 1 && parts[0]?.kind === "text";
+		const firstText =
+			isSingleTextMessage && parts[0]?.kind === "text"
+				? parts[0].text
+				: undefined;
+		if (!isSingleTextMessage || firstText !== params.displayText) {
+			parts.unshift({ kind: "text", text: params.displayText });
+		} else {
+			parts[0] = { kind: "text", text: params.displayText };
+		}
+	}
+
+	return {
+		messageId: params.messageId,
+		role: params.role,
+		timestamp: params.timestamp,
+		metadata: params.metadata,
+		schemaVersion: 2,
+		parts,
+	};
+}
+
+function serializeArtifactPart(part: ArtifactContentPart): string {
+	if (part.previewText?.trim()) {
+		return part.previewText;
+	}
+
+	const artifactLabel = part.name || part.artifactId;
+	const metadata: string[] = [];
+	if (part.mimeType) {
+		metadata.push(part.mimeType);
+	}
+	if (typeof part.size === "number") {
+		metadata.push(`${part.size} bytes`);
+	}
+
+	return metadata.length > 0
+		? `[Artifact: ${artifactLabel} (${metadata.join(", ")})]`
+		: `[Artifact: ${artifactLabel}]`;
+}
+
+function serializeDataPart(part: DataContentPart): string {
+	if (typeof part.data === "string") {
+		return part.data;
+	}
+
+	try {
+		return `${part.mimeType}: ${JSON.stringify(part.data)}`;
+	} catch {
+		return `[Data: ${part.mimeType}]`;
+	}
+}
+
+function serializeToolCallPart(part: ToolCallContentPart): string {
+	try {
+		return `[Tool Call: ${part.toolName}] ${JSON.stringify(part.args)}`;
+	} catch {
+		return `[Tool Call: ${part.toolName}]`;
+	}
+}
+
+function serializeToolResultPart(part: ToolResultContentPart): string {
+	if (typeof part.result === "string") {
+		return part.result;
+	}
+
+	try {
+		return `[Tool Result: ${part.toolName}] ${JSON.stringify(part.result)}`;
+	} catch {
+		return `[Tool Result: ${part.toolName}]`;
+	}
+}
+
+export function serializePartForIntent(part: MessageContentPart): string {
+	switch (part.kind) {
+		case "text":
+			return part.text;
+		case "artifact":
+			return serializeArtifactPart(part);
+		case "data":
+			return serializeDataPart(part);
+		case "tool-call":
+			return serializeToolCallPart(part);
+		case "tool-result":
+			return serializeToolResultPart(part);
+		case "thought":
+			return part.description
+				? `${part.title}\n${part.description}`
+				: part.title;
+	}
+}
+
+export function serializeMessageForIntent(message: MessageObject): string {
+	return normalizeMessageParts(message)
+		.map(serializePartForIntent)
+		.filter((value) => value.trim() !== "")
+		.join("\n");
+}
+
+function roleLabel(role: MessageRole): string {
+	switch (role) {
+		case "USER":
+			return "User";
+		case "MODEL":
+			return "Assistant";
+		case "TOOL":
+			return "Tool";
+		default:
+			return "System";
+	}
+}
+
+export function serializeThreadForIntent(
+	thread: ThreadObject | undefined,
+): string {
+	if (!thread) {
+		return "";
+	}
+
+	return thread.messages
+		.slice()
+		.sort((a, b) => a.timestamp - b.timestamp)
+		.map((message) => {
+			const content = serializeMessageForIntent(message);
+			return `${roleLabel(message.role)}: """${content}"""`;
+		})
+		.join("\n");
+}

--- a/tests/controllers/query.controller.test.ts
+++ b/tests/controllers/query.controller.test.ts
@@ -67,6 +67,16 @@ describe("QueryController", () => {
 				title: undefined,
 			},
 			{
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this report" },
+						{
+							kind: "data",
+							mimeType: "application/json",
+							data: { quarter: "Q1", revenue: 1200 },
+						},
+					],
+				},
 				query:
 					'Summarize this report\napplication/json: {"quarter":"Q1","revenue":1200}',
 				displayQuery: undefined,

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -1,0 +1,134 @@
+import { MessageRole, type MessageObject, ThreadType } from "@/types/memory";
+import {
+	createMessageFromQueryInput,
+	createTextMessage,
+	normalizeMessageObject,
+	serializeMessageForIntent,
+	serializeThreadForIntent,
+} from "@/utils/message";
+
+describe("message utilities", () => {
+	it("normalizes legacy messages into canonical multipart messages", () => {
+		const legacyMessage: MessageObject = {
+			messageId: "msg-1",
+			role: MessageRole.USER,
+			timestamp: 100,
+			content: {
+				type: "text",
+				parts: ["hello", "world"],
+			},
+		};
+
+		expect(normalizeMessageObject(legacyMessage)).toEqual({
+			messageId: "msg-1",
+			role: MessageRole.USER,
+			timestamp: 100,
+			schemaVersion: 2,
+			metadata: undefined,
+			parts: [
+				{ kind: "text", text: "hello" },
+				{ kind: "text", text: "world" },
+			],
+		});
+	});
+
+	it("creates canonical user messages from structured query input", () => {
+		const message = createMessageFromQueryInput({
+			messageId: "msg-2",
+			role: MessageRole.USER,
+			timestamp: 200,
+			displayText: "Summarize the attached report",
+			input: {
+				parts: [
+					{
+						kind: "artifact",
+						artifactId: "art-1",
+						name: "report.pdf",
+						previewText: "Revenue increased by 20 percent.",
+					},
+				],
+			},
+		});
+
+		expect(message).toEqual({
+			messageId: "msg-2",
+			role: MessageRole.USER,
+			timestamp: 200,
+			schemaVersion: 2,
+			metadata: undefined,
+			parts: [
+				{ kind: "text", text: "Summarize the attached report" },
+				{
+					kind: "artifact",
+					artifactId: "art-1",
+					name: "report.pdf",
+					mimeType: undefined,
+					size: undefined,
+					downloadUrl: undefined,
+					previewText: "Revenue increased by 20 percent.",
+				},
+			],
+		});
+	});
+
+	it("serializes mixed thread history for intent prompts", () => {
+		const thread = {
+			userId: "user-1",
+			threadId: "thread-1",
+			type: ThreadType.CHAT,
+			title: "Thread",
+			messages: [
+				createTextMessage({
+					messageId: "msg-3",
+					role: MessageRole.USER,
+					timestamp: 1,
+					text: "Analyze this file",
+				}),
+				{
+					messageId: "msg-4",
+					role: MessageRole.MODEL,
+					timestamp: 2,
+					schemaVersion: 2 as const,
+					parts: [
+						{
+							kind: "artifact" as const,
+							artifactId: "art-2",
+							name: "summary.csv",
+							mimeType: "text/csv",
+							previewText: "month,revenue\nJan,100",
+						},
+					],
+				},
+			],
+		};
+
+		expect(serializeThreadForIntent(thread)).toBe(
+			'User: """Analyze this file"""\nAssistant: """month,revenue\nJan,100"""',
+		);
+	});
+
+	it("serializes thought and data parts consistently", () => {
+		const message: MessageObject = {
+			messageId: "msg-5",
+			role: MessageRole.TOOL,
+			timestamp: 300,
+			schemaVersion: 2,
+			parts: [
+				{
+					kind: "thought",
+					title: "Collecting data",
+					description: "Fetching the latest metrics.",
+				},
+				{
+					kind: "data",
+					mimeType: "application/json",
+					data: { total: 3 },
+				},
+			],
+		};
+
+		expect(serializeMessageForIntent(message)).toBe(
+			'Collecting data\nFetching the latest metrics.\napplication/json: {"total":3}',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This PR introduces the next foundational step for multimodal chat support by establishing a canonical multipart message model and shared serialization utilities.

The runtime is still text-first for inference, but internal message writes now start converging on a canonical `parts[]` structure while preserving backward compatibility with legacy `content: { type, parts }` message records.

## What Changed

- added canonical multipart message part types to the memory domain
- added `TOOL` as an explicit `MessageRole`
- updated `MessageObject` to support both:
  - legacy `content`-based records
  - canonical `parts[]`-based records with `schemaVersion: 2`
- added shared message utilities for:
  - legacy-to-canonical normalization
  - canonical text message creation
  - structured query input to canonical message conversion
  - multipart-aware thread/message serialization for intent prompts
- updated `QueryService` to persist user messages in canonical multipart form when structured input is available
- updated `QueryController` and intent fulfillment flows to use canonical text message helpers for new writes
- replaced direct `content.parts.join(" ")` thread-history flattening in intent trigger services with a shared serializer
- updated controller tests to reflect structured input forwarding
- added tests for:
  - legacy message normalization
  - canonical message creation from structured input
  - multipart thread serialization for intent prompts
  - mixed part serialization behavior
- updated the multimodal/artifact plan document to mark this groundwork as completed

## Why This PR

The previous PR opened the request boundary for structured multimodal input, but the internal runtime still treated messages as ad hoc text blobs.

This PR closes part of that gap by introducing a canonical multipart message shape and centralizing message serialization logic, without yet forcing a full migration of:
- model provider interfaces
- stream event contracts
- artifact upload/download APIs
- A2A payload handling
- workflow execution boundaries

That keeps the change reviewable while giving the next PRs a stable internal message foundation.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `yarn test --runInBand`
- `yarn build`

## Notes

- inference is still text-first and continues to use `query: string`
- legacy message records are still supported through compatibility helpers
- new runtime message writes added in this PR now prefer canonical `parts[]` messages
- this PR is intentionally focused on core message modeling and serialization groundwork