### PR TITLE
refactor: return canonical messages from /query

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -36,11 +36,15 @@ Completed groundwork so far:
 - updated new thread message writes to use canonical multipart messages
 - updated intent-trigger history serialization to use shared canonical helpers
 - added tests for legacy-to-canonical message normalization and multipart serialization
+- updated non-stream `/query` responses to include a canonical `message` payload alongside compatibility `content`
+- updated query/fulfillment service boundaries to return the final canonical model message
+- added text-content extraction helpers so compatibility response text can be derived from canonical message parts
+- updated controller tests and README examples for the structured `/query` response shape
 
 Not completed yet:
 
 - full multipart `MessageObject` migration across all runtime paths
-- query/request/response contract refactor
+- full query/request/response contract refactor across streaming and provider-facing paths
 - artifact upload/download runtime APIs
 - stream event redesign
 - A2A artifact reference support
@@ -55,7 +59,8 @@ The current implementation is effectively text-only, even though some types are 
 
 ### Text-only assumptions in the current code
 
-- `/query` and `/query/stream` now accept legacy `message` and structured `input.parts`, but normalize both into a text-first runtime path
+- `/query` and `/query/stream` now accept legacy `message` and structured `input.parts`, but inference still normalizes both into a text-first runtime path
+- non-stream `/query` now returns a canonical `message` object plus compatibility `content`, but `/query/stream` still emits text-first events
 - `QueryService` still processes `query: string` for inference, even though it can now receive structured input for persistence
 - some runtime paths still assume `query: string`, but new message writes now converge on canonical `parts[]` messages
 - thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
@@ -821,6 +826,9 @@ Completed groundwork in this phase:
 - structured query input types added
 - legacy `message` requests are normalized into structured input at the controller boundary
 - structured `input.parts` requests are accepted and converted into the current text-based query flow
+- non-stream `/query` responses now include a canonical `message` payload plus compatibility `content`
+- `QueryService` and `IntentFulfillService` now return the final canonical model message for non-stream callers
+- final text responses saved by the current fulfillment flow are now persisted and returned through a shared canonical text-message shape
 
 ## Phase 7. Stream Event Redesign
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ modelLogger.error('Model API error');
   - Request:
     - Legacy: `{ message: string, threadId?: string, type?: string, displayMessage?: string }`
     - Structured: `{ input: { parts: [...] }, threadId?: string, type?: string, displayMessage?: string }`
-  - Response: `{ content: string, threadId: string }`
+  - Response: `{ threadId: string, message?: { messageId, role, schemaVersion, parts, timestamp, metadata? }, content: string }`
+    - `message` is the canonical multipart response message
+    - `content` is kept as a text-only compatibility field derived from the text parts in `message`
 - `POST /query/stream` - Process queries with streaming (SSE)
   - Request:
     - Legacy: `{ message: string, threadId?: string, type?: string, displayMessage?: string }`

--- a/src/controllers/query.controller.ts
+++ b/src/controllers/query.controller.ts
@@ -2,9 +2,9 @@ import { randomUUID } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { getArtifactModule } from "@/config/modules";
 import type { QueryService } from "@/services";
-import { MessageRole } from "@/types/memory";
+import { type CanonicalMessageObject, MessageRole } from "@/types/memory";
 import { loggers } from "@/utils/logger";
-import { createTextMessage } from "@/utils/message";
+import { createTextMessage, extractTextContent } from "@/utils/message";
 import { normalizeQueryRequest } from "@/utils/query-input";
 
 export class QueryController {
@@ -31,18 +31,27 @@ export class QueryController {
 				{ input, query, displayQuery },
 			);
 
-			let content = "";
 			let responseThreadId = threadId;
+			let message: CanonicalMessageObject | undefined;
 
-			for await (const event of stream) {
+			while (true) {
+				const result = await stream.next();
+				if (result.done) {
+					message = result.value;
+					break;
+				}
+
+				const event = result.value;
 				if (event.event === "thread_id") {
 					responseThreadId = event.data.threadId;
-				} else if (event.event === "text_chunk" && event.data.delta) {
-					content += event.data.delta;
 				}
 			}
 
-			res.status(200).json({ content, threadId: responseThreadId });
+			res.status(200).json({
+				content: message ? extractTextContent(message) : "",
+				message,
+				threadId: responseThreadId,
+			});
 		} catch (error) {
 			next(error);
 		}

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -9,9 +9,9 @@ import type {
 import type { OnIntentFallback } from "@/types/agent";
 import { CONNECTOR_PROTOCOL_TYPE, type ConnectorTool } from "@/types/connector";
 import {
+	type CanonicalMessageObject,
 	type FulfillmentResult,
 	type Intent,
-	type MessageObject,
 	MessageRole,
 	type ThreadObject,
 	type TriggeredIntent,
@@ -50,31 +50,6 @@ export class IntentFulfillService {
 		this.piiService = piiService;
 	}
 
-	private async addToThreadMessages(
-		thread: ThreadObject,
-		params: {
-			role: MessageRole;
-			content: string;
-			metadata?: Record<string, unknown>;
-		},
-	) {
-		try {
-			const threadMemory = this.memoryModule.getThreadMemory();
-			const { userId, threadId } = thread;
-			const newMessage: MessageObject = createTextMessage({
-				messageId: randomUUID(),
-				role: params.role,
-				timestamp: Date.now(),
-				text: params.content,
-				metadata: params.metadata,
-			});
-			thread.messages.push(newMessage);
-			await threadMemory?.addMessagesToThread(userId, threadId, [newMessage]);
-		} catch (error) {
-			loggers.intentStream.error("Error adding message to thread", error);
-		}
-	}
-
 	/**
 	 * Fulfills the detected intent by generating a streaming response.
 	 *
@@ -95,7 +70,7 @@ export class IntentFulfillService {
 		query: string,
 		thread: ThreadObject,
 		intent?: Intent,
-	): AsyncGenerator<StreamEvent> {
+	): AsyncGenerator<StreamEvent, void, undefined> {
 		const prompt = await fulfillPrompt(this.memoryModule, intent);
 
 		const modelInstance = this.modelModule.getModel();
@@ -286,7 +261,11 @@ export class IntentFulfillService {
 		thread: ThreadObject,
 		originalQuery: string,
 		needsAggregation: boolean,
-	): AsyncGenerator<StreamEvent> {
+	): AsyncGenerator<
+		StreamEvent,
+		CanonicalMessageObject | undefined,
+		undefined
+	> {
 		const streamStartTime = Date.now();
 		loggers.intentStream.info("Stream session started", {
 			threadId: thread.threadId,
@@ -475,11 +454,23 @@ export class IntentFulfillService {
 		}
 
 		// Save final response to memory
-		await this.addToThreadMessages(thread, {
+		const finalMessage = createTextMessage({
+			messageId: randomUUID(),
 			role: MessageRole.MODEL,
-			content: finalResponseText,
+			timestamp: Date.now(),
+			text: finalResponseText,
 			metadata: collectionName ? { collectionName } : undefined,
 		});
+
+		try {
+			const threadMemory = this.memoryModule.getThreadMemory();
+			thread.messages.push(finalMessage);
+			await threadMemory?.addMessagesToThread(thread.userId, thread.threadId, [
+				finalMessage,
+			]);
+		} catch (error) {
+			loggers.intentStream.error("Error adding message to thread", error);
+		}
 
 		const streamEndTime = Date.now();
 		const streamDuration = streamEndTime - streamStartTime;
@@ -489,5 +480,7 @@ export class IntentFulfillService {
 			duration: `${streamDuration}ms`,
 			endTime: new Date(streamEndTime).toISOString(),
 		});
+
+		return finalMessage;
 	}
 }

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/modules/index.js";
 import { AinHttpError } from "@/types/agent.js";
 import {
+	type CanonicalMessageObject,
 	type MessageObject,
 	MessageRole,
 	type ThreadMetadata,
@@ -116,7 +117,11 @@ export class QueryService {
 			input?: QueryMessageInput;
 		},
 		isA2A?: boolean,
-	): AsyncGenerator<StreamEvent> {
+	): AsyncGenerator<
+		StreamEvent,
+		CanonicalMessageObject | undefined,
+		undefined
+	> {
 		const {
 			type,
 			userId,
@@ -137,7 +142,19 @@ export class QueryService {
 					event: "text_chunk",
 					data: { delta: "개인정보 내역은 처리할 수 없습니다." },
 				};
-				return;
+				return createMessageFromQueryInput({
+					messageId: randomUUID(),
+					role: MessageRole.MODEL,
+					timestamp: Date.now(),
+					input: {
+						parts: [
+							{
+								kind: "text",
+								text: "개인정보 내역은 처리할 수 없습니다.",
+							},
+						],
+					},
+				});
 			}
 		} else if (piiMode === PIIFilterMode.MASK && this.piiService) {
 			query = await this.piiService.filterText(query);
@@ -216,8 +233,12 @@ export class QueryService {
 			needsAggregation,
 		);
 
-		for await (const event of stream) {
-			yield event;
+		while (true) {
+			const result = await stream.next();
+			if (result.done) {
+				return result.value;
+			}
+			yield result.value;
 		}
 	}
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -354,3 +354,11 @@ export function serializeThreadForIntent(
 		})
 		.join("\n");
 }
+
+export function extractTextContent(message: MessageObject): string {
+	return normalizeMessageParts(message)
+		.filter((part): part is TextContentPart => part.kind === "text")
+		.map((part) => part.text)
+		.filter((value) => value.trim() !== "")
+		.join("\n");
+}

--- a/tests/controllers/query.controller.test.ts
+++ b/tests/controllers/query.controller.test.ts
@@ -12,6 +12,14 @@ describe("QueryController", () => {
 	});
 
 	it("normalizes structured query input before calling QueryService", async () => {
+		const finalMessage = {
+			messageId: "msg-1",
+			role: "MODEL" as const,
+			timestamp: 123,
+			schemaVersion: 2 as const,
+			parts: [{ kind: "text" as const, text: "ok" }],
+		};
+
 		const handleQuery = jest.fn(async function* () {
 			yield {
 				event: "thread_id" as const,
@@ -26,6 +34,7 @@ describe("QueryController", () => {
 				event: "text_chunk" as const,
 				data: { delta: "ok" },
 			};
+			return finalMessage;
 		});
 
 		const queryController = new QueryController({
@@ -85,6 +94,7 @@ describe("QueryController", () => {
 		expect(status).toHaveBeenCalledWith(200);
 		expect(json).toHaveBeenCalledWith({
 			content: "ok",
+			message: finalMessage,
 			threadId: "thread-1",
 		});
 		expect(next).not.toHaveBeenCalled();

--- a/tests/services/query.service.test.ts
+++ b/tests/services/query.service.test.ts
@@ -1,0 +1,106 @@
+import { QueryService } from "@/services/query.service";
+import { createTextMessage } from "@/utils/message";
+import { MessageRole, ThreadType } from "@/types/memory";
+
+describe("QueryService", () => {
+	it("creates a new thread and returns the final message for an initial query without threadId", async () => {
+		const createThread = jest.fn(async (_type, _userId, threadId, title) => ({
+			type: ThreadType.CHAT,
+			userId: "user-1",
+			threadId,
+			title,
+		}));
+		const addMessagesToThread = jest.fn(async () => {});
+		const getThread = jest.fn(async () => undefined);
+
+		const queryService = new QueryService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					fetch: async () => ({ content: "New Chat" }),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getThreadMemory: () => ({
+					getThread,
+					createThread,
+					addMessagesToThread,
+				}),
+			} as any,
+			{
+				intentTriggering: async () => ({
+					intents: [{ subquery: "hello there" }],
+					needsAggregation: false,
+				}),
+			} as any,
+			{
+				intentFulfill: async function* () {
+					return createTextMessage({
+						messageId: "model-msg-1",
+						role: MessageRole.MODEL,
+						timestamp: 456,
+						text: "hi there",
+					});
+				},
+			} as any,
+		);
+
+		const stream = queryService.handleQuery(
+			{
+				type: ThreadType.CHAT,
+				userId: "user-1",
+			},
+			{
+				query: "hello there",
+			},
+		);
+
+		const first = await stream.next();
+		expect(first.done).toBe(false);
+		expect(first.value).toMatchObject({
+			event: "thread_id",
+			data: {
+				type: ThreadType.CHAT,
+				userId: "user-1",
+				title: "New Chat",
+			},
+		});
+
+		const createdThreadId = first.value.event === "thread_id"
+			? first.value.data.threadId
+			: undefined;
+		expect(createdThreadId).toBeTruthy();
+		expect(createThread).toHaveBeenCalledWith(
+			ThreadType.CHAT,
+			"user-1",
+			createdThreadId,
+			"New Chat",
+			undefined,
+		);
+
+		const second = await stream.next();
+		expect(second.done).toBe(true);
+		expect(second.value).toEqual(
+			createTextMessage({
+				messageId: "model-msg-1",
+				role: MessageRole.MODEL,
+				timestamp: 456,
+				text: "hi there",
+			}),
+		);
+
+		expect(addMessagesToThread).toHaveBeenCalledTimes(1);
+		expect(addMessagesToThread).toHaveBeenCalledWith(
+			"user-1",
+			createdThreadId,
+			[
+				expect.objectContaining({
+					role: MessageRole.USER,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "hello there" }],
+				}),
+			],
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This PR continues the multimodal migration by tightening the non-stream `/query` response contract without taking on the stream event redesign yet.

### What changed

- return a canonical multipart `message` object from non-stream `/query`
- keep `content` as a temporary compatibility field derived from the text parts in `message`
- update `QueryService` and `IntentFulfillService` so non-stream callers receive the final canonical model message
- persist final text responses through the shared canonical text-message path
- add a helper to extract compatibility text from canonical message parts
- update controller tests and README examples for the new `/query` response shape
- update `MULTIMODAL_ARTIFACT_PLAN.md` to reflect the progress made in this PR

### Why this PR is scoped this way

The goal here is to make the non-stream query contract structurally correct before touching the stream protocol.

Streaming is still centered on `text_chunk` and is used by downstream paths such as A2A, so changing it in the same PR would effectively mix:
- query response contract refactor
- stream event redesign
- A2A compatibility work

Instead, this PR locks in the canonical non-stream response shape first so the next streaming-focused PR can build on a clearer contract.

## API impact

### `/query`

Before:
```json
{
  "content": "ok",
  "threadId": "thread-1"
}
```

After:
```json
{
  "threadId": "thread-1",
  "message": {
    "messageId": "msg-1",
    "role": "MODEL",
    "schemaVersion": 2,
    "parts": [
      { "kind": "text", "text": "ok" }
    ],
    "timestamp": 123
  },
  "content": "ok"
}
```
