### PR TITLE
refactor: add canonical stream message events with text_chunk compati…

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -40,6 +40,10 @@ Completed groundwork so far:
 - updated query/fulfillment service boundaries to return the final canonical model message
 - added text-content extraction helpers so compatibility response text can be derived from canonical message parts
 - updated controller tests and README examples for the structured `/query` response shape
+- added canonical streaming message events: `message_start`, `part_delta`, and `message_complete`
+- kept `text_chunk` during the transition as a compatibility stream event for existing consumers
+- updated A2A consumption to fall back to canonical `message_complete` when compatibility text chunks are absent
+- added tests covering canonical stream event emission and A2A compatibility fallback
 
 Not completed yet:
 
@@ -60,7 +64,8 @@ The current implementation is effectively text-only, even though some types are 
 ### Text-only assumptions in the current code
 
 - `/query` and `/query/stream` now accept legacy `message` and structured `input.parts`, but inference still normalizes both into a text-first runtime path
-- non-stream `/query` now returns a canonical `message` object plus compatibility `content`, but `/query/stream` still emits text-first events
+- non-stream `/query` now returns a canonical `message` object plus compatibility `content`
+- `/query/stream` now emits canonical message lifecycle events, but still duplicates text through compatibility `text_chunk`
 - `QueryService` still processes `query: string` for inference, even though it can now receive structured input for persistence
 - some runtime paths still assume `query: string`, but new message writes now converge on canonical `parts[]` messages
 - thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
@@ -837,6 +842,14 @@ Completed groundwork in this phase:
 - add support for artifact readiness signaling
 
 This phase should land before downstream consumers such as A2A are updated.
+
+Completed groundwork in this phase:
+
+- added `message_start`, `part_delta`, and `message_complete` stream events for canonical text-message progression
+- updated current fulfillment flows to emit canonical stream events alongside compatibility `text_chunk`
+- updated `QueryService` PII-rejection streaming path to emit canonical stream events
+- updated A2A consumption to support canonical `message_complete` as a fallback completion signal
+- added targeted tests for canonical stream event emission and A2A compatibility
 
 ## Phase 8. Intent and Fulfillment Refactor
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ modelLogger.error('Model API error');
     - Legacy: `{ message: string, threadId?: string, type?: string, displayMessage?: string }`
     - Structured: `{ input: { parts: [...] }, threadId?: string, type?: string, displayMessage?: string }`
   - Response: Server-Sent Events stream with event types:
+    - `message_start`: Canonical response message has started
+    - `part_delta`: Incremental canonical message-part delta
+    - `message_complete`: Canonical response message is complete
     - `text_chunk`: Incremental text response
     - `tool_start`: Tool execution started
     - `tool_output`: Tool execution result
@@ -216,6 +219,7 @@ modelLogger.error('Model API error');
     - `intent_process`: Intent processing status
     - `thinking_process`: Thinking/reasoning steps
     - `error`: Error message
+    - `text_chunk` is currently kept as a compatibility event alongside the newer canonical message events
 
 ### Agent Management
 - `GET /api/threads` - List user threads (userId from auth)

--- a/src/services/a2a.service.ts
+++ b/src/services/a2a.service.ts
@@ -7,6 +7,7 @@ import type {
 } from "@a2a-js/sdk/server";
 import type { ThreadType } from "@/types/memory.js";
 import { loggers } from "@/utils/logger.js";
+import { extractTextContent } from "@/utils/message.js";
 import type { QueryService } from "./query.service.js";
 
 /**
@@ -112,6 +113,7 @@ export class A2AService implements AgentExecutor {
 
 		try {
 			let finalResponseText = "";
+			let sawCompatibilityTextChunk = false;
 			for await (const event of stream) {
 				if (this.canceledTasks.has(taskId)) {
 					loggers.server.info(`Task ${taskId} was canceled.`);
@@ -125,7 +127,13 @@ export class A2AService implements AgentExecutor {
 				}
 
 				if (event.event === "text_chunk") {
+					sawCompatibilityTextChunk = true;
 					finalResponseText += event.data.delta;
+				} else if (
+					event.event === "message_complete" &&
+					!sawCompatibilityTextChunk
+				) {
+					finalResponseText = extractTextContent(event.data.message);
 				} else if (event.event === "thinking_process") {
 					const thinkingProcessUpdate = this.createTaskStatusUpdateEvent(
 						taskId,

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -274,8 +274,38 @@ export class IntentFulfillService {
 			startTime: new Date(streamStartTime).toISOString(),
 		});
 
+		const finalMessageId = randomUUID();
 		let finalResponseText = "";
 		let collectionName: string | undefined;
+		let finalMessageStarted = false;
+
+		const emitFinalResponseEvent = function* (
+			event: StreamEvent,
+		): Generator<StreamEvent> {
+			if (event.event === "text_chunk" && event.data.delta) {
+				if (!finalMessageStarted) {
+					finalMessageStarted = true;
+					yield {
+						event: "message_start",
+						data: {
+							messageId: finalMessageId,
+							role: MessageRole.MODEL,
+						},
+					};
+				}
+				yield {
+					event: "part_delta",
+					data: {
+						messageId: finalMessageId,
+						partIndex: 0,
+						part: { kind: "text" },
+						delta: event.data.delta,
+					},
+				};
+			}
+
+			yield event;
+		};
 
 		if (intents.length <= 1) {
 			// Single intent: stream response directly
@@ -312,7 +342,7 @@ export class IntentFulfillService {
 				} else if (event.event === "collection_name") {
 					collectionName = event.data.name;
 				}
-				yield event;
+				yield* emitFinalResponseEvent(event);
 			}
 		} else if (!needsAggregation) {
 			// Multiple intents but no aggregation needed: collect intermediate results, stream only last
@@ -347,7 +377,7 @@ export class IntentFulfillService {
 						} else if (event.event === "collection_name") {
 							collectionName = event.data.name;
 						}
-						yield event;
+						yield* emitFinalResponseEvent(event);
 					}
 				} else {
 					// Collect intermediate results without streaming text_chunk
@@ -444,7 +474,7 @@ export class IntentFulfillService {
 				if (event.event === "text_chunk" && event.data.delta) {
 					finalResponseText += event.data.delta;
 				}
-				yield event;
+				yield* emitFinalResponseEvent(event);
 			}
 		}
 
@@ -455,7 +485,7 @@ export class IntentFulfillService {
 
 		// Save final response to memory
 		const finalMessage = createTextMessage({
-			messageId: randomUUID(),
+			messageId: finalMessageId,
 			role: MessageRole.MODEL,
 			timestamp: Date.now(),
 			text: finalResponseText,
@@ -480,6 +510,20 @@ export class IntentFulfillService {
 			duration: `${streamDuration}ms`,
 			endTime: new Date(streamEndTime).toISOString(),
 		});
+
+		if (!finalMessageStarted) {
+			yield {
+				event: "message_start",
+				data: {
+					messageId: finalMessageId,
+					role: MessageRole.MODEL,
+				},
+			};
+		}
+		yield {
+			event: "message_complete",
+			data: { message: finalMessage },
+		};
 
 		return finalMessage;
 	}

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -138,11 +138,7 @@ export class QueryService {
 		if (piiMode === PIIFilterMode.REJECT && this.piiService) {
 			const hasPII = await this.piiService.containsPII(query);
 			if (hasPII) {
-				yield {
-					event: "text_chunk",
-					data: { delta: "개인정보 내역은 처리할 수 없습니다." },
-				};
-				return createMessageFromQueryInput({
+				const rejectedMessage = createMessageFromQueryInput({
 					messageId: randomUUID(),
 					role: MessageRole.MODEL,
 					timestamp: Date.now(),
@@ -155,6 +151,33 @@ export class QueryService {
 						],
 					},
 				});
+				yield {
+					event: "message_start",
+					data: {
+						messageId: rejectedMessage.messageId,
+						role: rejectedMessage.role,
+					},
+				};
+				yield {
+					event: "part_delta",
+					data: {
+						messageId: rejectedMessage.messageId,
+						partIndex: 0,
+						part: { kind: "text" },
+						delta: "개인정보 내역은 처리할 수 없습니다.",
+					},
+				};
+				yield {
+					event: "text_chunk",
+					data: { delta: "개인정보 내역은 처리할 수 없습니다." },
+				};
+				yield {
+					event: "message_complete",
+					data: {
+						message: rejectedMessage,
+					},
+				};
+				return rejectedMessage;
 			}
 		} else if (piiMode === PIIFilterMode.MASK && this.piiService) {
 			query = await this.piiService.filterText(query);

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -1,8 +1,30 @@
-import type { ThreadMetadata } from "@/types/memory.js";
+import type {
+	CanonicalMessageObject,
+	MessageRole,
+	TextContentPart,
+	ThreadMetadata,
+} from "@/types/memory.js";
 import type { CONNECTOR_PROTOCOL_TYPE } from "./connector";
 
 export type StreamEvent =
 	| { event: "text_chunk"; data: { delta: string } }
+	| {
+			event: "message_start";
+			data: { messageId: string; role: MessageRole };
+	  }
+	| {
+			event: "part_delta";
+			data: {
+				messageId: string;
+				partIndex: number;
+				part: Pick<TextContentPart, "kind">;
+				delta: string;
+			};
+	  }
+	| {
+			event: "message_complete";
+			data: { message: CanonicalMessageObject };
+	  }
 	| {
 			event: "tool_start";
 			data: {

--- a/tests/services/a2a.service.test.ts
+++ b/tests/services/a2a.service.test.ts
@@ -1,0 +1,68 @@
+import { A2AService } from "@/services/a2a.service";
+import { MessageRole, ThreadType } from "@/types/memory";
+import { createTextMessage } from "@/utils/message";
+
+describe("A2AService", () => {
+	it("falls back to message_complete when compatibility text chunks are absent", async () => {
+		const finalMessage = createTextMessage({
+			messageId: "msg-1",
+			role: MessageRole.MODEL,
+			timestamp: 123,
+			text: "final response",
+		});
+
+		const a2aService = new A2AService({
+			handleQuery: async function* () {
+				yield {
+					event: "message_start" as const,
+					data: {
+						messageId: finalMessage.messageId,
+						role: MessageRole.MODEL,
+					},
+				};
+				yield {
+					event: "part_delta" as const,
+					data: {
+						messageId: finalMessage.messageId,
+						partIndex: 0,
+						part: { kind: "text" as const },
+						delta: "final response",
+					},
+				};
+				yield {
+					event: "message_complete" as const,
+					data: { message: finalMessage },
+				};
+				return finalMessage;
+			},
+		} as any);
+
+		const publish = jest.fn();
+		await a2aService.execute(
+			{
+				userMessage: {
+					contextId: "thread-1",
+					metadata: {
+						agentId: "agent-1",
+						type: ThreadType.CHAT,
+					},
+					parts: [{ kind: "text", text: "hello" }],
+				},
+			} as any,
+			{ publish } as any,
+		);
+
+		expect(publish).toHaveBeenCalledTimes(2);
+		expect(publish.mock.calls[1][0]).toMatchObject({
+			kind: "status-update",
+			contextId: "thread-1",
+			status: {
+				state: "completed",
+				message: {
+					parts: [{ kind: "text", text: "final response" }],
+				},
+			},
+			final: true,
+		});
+	});
+});

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -1,0 +1,91 @@
+import { setManifest } from "@/config/manifest";
+import { IntentFulfillService } from "@/services/intents/fulfill.service";
+import { MessageRole, ThreadType } from "@/types/memory";
+
+describe("IntentFulfillService", () => {
+	beforeEach(() => {
+		setManifest({
+			name: "Test Agent",
+			description: "Test agent",
+		});
+	});
+
+	it("emits canonical message stream events alongside compatibility text chunks", async () => {
+		const addMessagesToThread = jest.fn(async () => {});
+		const service = new IntentFulfillService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					convertToolsToFunctions: () => [],
+					appendMessages: jest.fn(),
+					fetchStreamWithContextMessage: async () => ({
+						async *[Symbol.asyncIterator]() {
+							yield {
+								delta: {
+									content: "streamed reply",
+								},
+							};
+						},
+					}),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAgentPrompt: async () => "",
+				}),
+				getThreadMemory: () => ({
+					addMessagesToThread,
+				}),
+			} as any,
+		);
+
+		const stream = service.intentFulfill(
+			[{ subquery: "hello there" }],
+			{
+				userId: "user-1",
+				threadId: "thread-1",
+				type: ThreadType.CHAT,
+				title: "Thread",
+				messages: [],
+			},
+			"hello there",
+			false,
+		);
+
+		const events: string[] = [];
+		let finalMessage;
+
+		while (true) {
+			const result = await stream.next();
+			if (result.done) {
+				finalMessage = result.value;
+				break;
+			}
+			events.push(result.value.event);
+		}
+
+		expect(events).toEqual([
+			"thinking_process",
+			"message_start",
+			"part_delta",
+			"text_chunk",
+			"message_complete",
+		]);
+		expect(finalMessage).toMatchObject({
+			role: MessageRole.MODEL,
+			schemaVersion: 2,
+			parts: [{ kind: "text", text: "streamed reply" }],
+		});
+		expect(addMessagesToThread).toHaveBeenCalledWith(
+			"user-1",
+			"thread-1",
+			[
+				expect.objectContaining({
+					messageId: finalMessage?.messageId,
+					role: MessageRole.MODEL,
+				}),
+			],
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This PR moves `/query/stream` toward the canonical multipart message model while preserving compatibility for existing text-stream consumers.

It introduces canonical message lifecycle stream events and keeps `text_chunk` during the migration window so downstream consumers do not break immediately.

## What changed

- add canonical stream events:
  - `message_start`
  - `part_delta`
  - `message_complete`
- update fulfillment streaming so final model responses emit canonical message lifecycle events
- keep existing `text_chunk` events alongside the new canonical events for compatibility
- update the PII rejection streaming path to emit canonical message events as well
- update A2A consumption to fall back to `message_complete` when compatibility `text_chunk` events are absent
- add targeted tests for canonical stream emission and A2A compatibility fallback
- update README and `MULTIMODAL_ARTIFACT_PLAN.md` to reflect the new streaming contract

## Why this PR exists

The previous PR made non-stream `/query` return a canonical `message`, but `/query/stream` was still text-first.

This PR closes that gap by making the streaming path aware of canonical message progression without forcing an immediate breaking change on consumers that still rely on `text_chunk`.

That gives us a safer migration path:
1. introduce canonical stream events
2. keep compatibility events temporarily
3. migrate downstream consumers
4. remove legacy stream events later

## Stream contract changes

### New events

- `message_start`
  - indicates the final assistant message has started
  - payload: `{ messageId, role }`

- `part_delta`
  - emits incremental updates for the canonical message content
  - current scope is text parts only
  - payload: `{ messageId, partIndex, part, delta }`

- `message_complete`
  - emits the final canonical multipart message
  - payload: `{ message }`

### Compatibility behavior

- `text_chunk` is still emitted
- existing text-stream clients should continue to work unchanged
- A2A now supports both:
  - legacy `text_chunk`
  - canonical `message_complete` fallback