### PR TITLE
refactor: fulfillment results to canonical message parts

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-14`
+Last updated: `2026-04-15`
 
 Completed groundwork so far:
 
@@ -44,6 +44,10 @@ Completed groundwork so far:
 - kept `text_chunk` during the transition as a compatibility stream event for existing consumers
 - updated A2A consumption to fall back to canonical `message_complete` when compatibility text chunks are absent
 - added tests covering canonical stream event emission and A2A compatibility fallback
+- extended fulfillment results with canonical `responseMessage` payloads while preserving compatibility text
+- updated aggregation prompt construction to use shared canonical message serialization
+- updated multi-intent intermediate fulfillment context to reuse canonical model messages
+- added tests covering canonical fulfillment results, aggregation serialization, and stream compatibility
 
 Not completed yet:
 
@@ -856,6 +860,16 @@ Completed groundwork in this phase:
 - update trigger services to use serializer
 - update fulfill flow to produce message parts
 - update aggregate flow to aggregate structured outputs or summarized representations
+
+Completed groundwork in this phase:
+
+- extended `FulfillmentResult` with an optional canonical `responseMessage`
+- kept `FulfillmentResult.response` as deprecated compatibility text during the migration
+- added fulfillment result construction helpers that derive compatibility text from canonical messages
+- updated multi-intent no-aggregation intermediate context to push canonical model messages with thinking metadata
+- updated aggregation to serialize fulfillment `responseMessage` values through shared message serializers
+- preserved legacy aggregation fallback behavior for callers that still provide only `response`
+- added focused tests for canonical fulfillment stream completion, intermediate context, and aggregation serialization
 
 ## Phase 9. Model Abstraction Migration
 

--- a/src/services/intents/aggregate.service.ts
+++ b/src/services/intents/aggregate.service.ts
@@ -1,8 +1,26 @@
 import { getManifest } from "@/config/manifest";
 import type { MemoryModule, ModelModule } from "@/modules";
-import type { FulfillmentResult, ThreadType } from "@/types/memory";
+import {
+	type FulfillmentResult,
+	MessageRole,
+	type ThreadType,
+} from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
+import { createTextMessage, serializeMessageForIntent } from "@/utils/message";
 import aggregatePrompts from "../prompts/aggregate";
+
+function serializeFulfillmentResult(result: FulfillmentResult): string {
+	const responseMessage =
+		result.responseMessage ??
+		createTextMessage({
+			messageId: `legacy-${result.subquery}`,
+			role: MessageRole.MODEL,
+			timestamp: 0,
+			text: result.response,
+		});
+
+	return serializeMessageForIntent(responseMessage);
+}
 
 /**
  * Service for determining whether multiple fulfillment results need to be
@@ -31,7 +49,7 @@ export class AggregateService {
 	): AsyncGenerator<StreamEvent> {
 		// Single result doesn't need aggregation
 		if (results.length <= 1) {
-			const response = results[0]?.response ?? "";
+			const response = results[0] ? serializeFulfillmentResult(results[0]) : "";
 			if (response) {
 				yield {
 					event: "text_chunk",
@@ -105,8 +123,8 @@ export class AggregateService {
 	): string {
 		const resultsText = results
 			.map(
-				(r, i) =>
-					`[Task ${i + 1}] ${r.subquery}\n[Response ${i + 1}] ${r.response}`,
+				(result, i) =>
+					`[Task ${i + 1}] ${result.subquery}\n[Response ${i + 1}] ${serializeFulfillmentResult(result)}`,
 			)
 			.join("\n\n---\n\n");
 

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -18,11 +18,41 @@ import {
 } from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger";
-import { createTextMessage } from "@/utils/message";
+import { createTextMessage, extractTextContent } from "@/utils/message";
 import { PIIFilterMode, type PIIService } from "../pii.service";
 import fulfillPrompt from "../prompts/fulfill";
 import toolSelectPrompt from "../prompts/tool-select";
 import { AggregateService } from "./aggregate.service";
+
+function createFulfillmentResult(params: {
+	subquery: string;
+	intent?: Intent;
+	actionPlan?: string;
+	responseMessage: CanonicalMessageObject;
+}): FulfillmentResult {
+	return {
+		subquery: params.subquery,
+		intent: params.intent,
+		actionPlan: params.actionPlan,
+		responseMessage: params.responseMessage,
+		response: extractTextContent(params.responseMessage),
+	};
+}
+
+function createEphemeralModelContextMessage(
+	message: CanonicalMessageObject,
+): CanonicalMessageObject {
+	return {
+		...message,
+		messageId: randomUUID(),
+		timestamp: Date.now(),
+		metadata: {
+			...message.metadata,
+			isThinking: true,
+		},
+		parts: message.parts.map((part) => ({ ...part })),
+	};
+}
 
 export class IntentFulfillService {
 	private modelModule: ModelModule;
@@ -393,14 +423,14 @@ export class IntentFulfillService {
 						}
 					}
 					// Add intermediate result to thread context for next intent
+					const responseMessage = createTextMessage({
+						messageId: randomUUID(),
+						role: MessageRole.MODEL,
+						timestamp: Date.now(),
+						text: responseText,
+					});
 					thread.messages.push(
-						createTextMessage({
-							messageId: randomUUID(),
-							role: MessageRole.MODEL,
-							timestamp: Date.now(),
-							text: responseText,
-							metadata: { isThinking: true },
-						}),
+						createEphemeralModelContextMessage(responseMessage),
 					);
 				}
 			}
@@ -417,14 +447,16 @@ export class IntentFulfillService {
 				// Add previous result to thread context for inference (not stored in memory)
 				if (fulfillmentResults.length > 0) {
 					const lastResult = fulfillmentResults[fulfillmentResults.length - 1];
-					thread.messages.push(
+					const lastResponseMessage =
+						lastResult.responseMessage ??
 						createTextMessage({
 							messageId: randomUUID(),
 							role: MessageRole.MODEL,
 							timestamp: Date.now(),
 							text: lastResult.response,
-							metadata: { isThinking: true },
-						}),
+						});
+					thread.messages.push(
+						createEphemeralModelContextMessage(lastResponseMessage),
 					);
 				}
 
@@ -456,12 +488,21 @@ export class IntentFulfillService {
 					}
 				}
 
-				fulfillmentResults.push({
-					subquery,
-					intent,
-					actionPlan,
-					response: responseText,
+				const responseMessage = createTextMessage({
+					messageId: randomUUID(),
+					role: MessageRole.MODEL,
+					timestamp: Date.now(),
+					text: responseText,
 				});
+
+				fulfillmentResults.push(
+					createFulfillmentResult({
+						subquery,
+						intent,
+						actionPlan,
+						responseMessage,
+					}),
+				);
 			}
 
 			// Aggregate step: generate unified response

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -201,7 +201,12 @@ export type FulfillmentResult = {
 	intent?: Intent;
 	/** Action plan description */
 	actionPlan?: string;
-	/** Response text generated for this intent */
+	/** Canonical model message generated for this intent */
+	responseMessage?: CanonicalMessageObject;
+	/** Response text generated for this intent.
+	 *
+	 * @deprecated Use responseMessage with the shared message serializers instead.
+	 */
 	response: string;
 };
 

--- a/tests/services/intents/aggregate.service.test.ts
+++ b/tests/services/intents/aggregate.service.test.ts
@@ -1,0 +1,127 @@
+import { setManifest } from "@/config/manifest";
+import { AggregateService } from "@/services/intents/aggregate.service";
+import { MessageRole } from "@/types/memory";
+import { createTextMessage } from "@/utils/message";
+
+describe("AggregateService", () => {
+	beforeEach(() => {
+		setManifest({
+			name: "Test Agent",
+			description: "Test agent",
+		});
+	});
+
+	it("serializes canonical fulfillment messages when building aggregate prompts", async () => {
+		let aggregateQuery = "";
+
+		const service = new AggregateService(
+			{
+				getModel: () => ({
+					generateMessages: ({ query }: { query: string }) => {
+						aggregateQuery = query;
+						return [];
+					},
+					fetchStreamWithContextMessage: async () => ({
+						async *[Symbol.asyncIterator]() {
+							yield {
+								delta: {
+									content: "combined reply",
+								},
+							};
+						},
+					}),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAggregatePrompt: async () => "aggregate prompt",
+				}),
+			} as any,
+		);
+
+		const stream = service.aggregate("summarize everything", [
+			{
+				subquery: "summarize file",
+				response: "legacy text should not be used",
+				responseMessage: {
+					messageId: "message-1",
+					role: MessageRole.MODEL,
+					timestamp: 100,
+					schemaVersion: 2,
+					parts: [
+						{
+							kind: "artifact",
+							artifactId: "artifact-1",
+							name: "summary.csv",
+							previewText: "canonical artifact preview",
+						},
+					],
+				},
+			},
+			{
+				subquery: "summarize text",
+				response: "legacy text should not be used either",
+				responseMessage: createTextMessage({
+					messageId: "message-2",
+					role: MessageRole.MODEL,
+					timestamp: 200,
+					text: "canonical text result",
+				}),
+			},
+		]);
+
+		const events = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(aggregateQuery).toContain("canonical artifact preview");
+		expect(aggregateQuery).toContain("canonical text result");
+		expect(aggregateQuery).not.toContain("legacy text should not be used");
+		expect(events).toEqual([
+			expect.objectContaining({ event: "thinking_process" }),
+			{ event: "text_chunk", data: { delta: "combined reply" } },
+		]);
+	});
+
+	it("keeps legacy fulfillment result text as a fallback", async () => {
+		const service = new AggregateService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					fetchStreamWithContextMessage: async () => ({
+						async *[Symbol.asyncIterator]() {
+							yield {
+								delta: {
+									content: "unused",
+								},
+							};
+						},
+					}),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{} as any,
+		);
+
+		const stream = service.aggregate("summarize", [
+			{
+				subquery: "legacy",
+				response: "legacy fallback text",
+			},
+		]);
+
+		await expect(stream.next()).resolves.toEqual({
+			done: false,
+			value: {
+				event: "text_chunk",
+				data: { delta: "legacy fallback text" },
+			},
+		});
+		await expect(stream.next()).resolves.toEqual({
+			done: true,
+			value: undefined,
+		});
+	});
+});

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -54,6 +54,7 @@ describe("IntentFulfillService", () => {
 		);
 
 		const events: string[] = [];
+		const completedMessages: unknown[] = [];
 		let finalMessage;
 
 		while (true) {
@@ -63,6 +64,9 @@ describe("IntentFulfillService", () => {
 				break;
 			}
 			events.push(result.value.event);
+			if (result.value.event === "message_complete") {
+				completedMessages.push(result.value.data.message);
+			}
 		}
 
 		expect(events).toEqual([
@@ -77,6 +81,7 @@ describe("IntentFulfillService", () => {
 			schemaVersion: 2,
 			parts: [{ kind: "text", text: "streamed reply" }],
 		});
+		expect(completedMessages).toEqual([finalMessage]);
 		expect(addMessagesToThread).toHaveBeenCalledWith(
 			"user-1",
 			"thread-1",
@@ -87,5 +92,92 @@ describe("IntentFulfillService", () => {
 				}),
 			],
 		);
+	});
+
+	it("adds multi-intent intermediate results to context as canonical messages", async () => {
+		let streamCallCount = 0;
+		const generatedMessageInputs: Array<unknown[]> = [];
+		const addMessagesToThread = jest.fn(async () => {});
+
+		const service = new IntentFulfillService(
+			{
+				getModel: () => ({
+					generateMessages: ({ thread }: any) => {
+						generatedMessageInputs.push(
+							thread.messages.map((message: any) => ({
+								role: message.role,
+								schemaVersion: message.schemaVersion,
+								parts: message.parts,
+								metadata: message.metadata,
+							})),
+						);
+						return [];
+					},
+					convertToolsToFunctions: () => [],
+					appendMessages: jest.fn(),
+					fetchStreamWithContextMessage: async () => {
+						const response =
+							streamCallCount === 0 ? "first reply" : "second reply";
+						streamCallCount += 1;
+
+						return {
+							async *[Symbol.asyncIterator]() {
+								yield {
+									delta: {
+										content: response,
+									},
+								};
+							},
+						};
+					},
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAgentPrompt: async () => "",
+				}),
+				getThreadMemory: () => ({
+					addMessagesToThread,
+				}),
+			} as any,
+		);
+
+		const stream = service.intentFulfill(
+			[{ subquery: "first" }, { subquery: "second" }],
+			{
+				userId: "user-1",
+				threadId: "thread-1",
+				type: ThreadType.CHAT,
+				title: "Thread",
+				messages: [],
+			},
+			"original query",
+			false,
+		);
+
+		let finalMessage;
+		while (true) {
+			const result = await stream.next();
+			if (result.done) {
+				finalMessage = result.value;
+				break;
+			}
+		}
+
+		expect(generatedMessageInputs).toHaveLength(2);
+		expect(generatedMessageInputs[1]).toEqual([
+			expect.objectContaining({
+				role: MessageRole.MODEL,
+				schemaVersion: 2,
+				parts: [{ kind: "text", text: "first reply" }],
+				metadata: { isThinking: true },
+			}),
+		]);
+		expect(finalMessage).toMatchObject({
+			role: MessageRole.MODEL,
+			schemaVersion: 2,
+			parts: [{ kind: "text", text: "second reply" }],
+		});
 	});
 });

--- a/tests/services/query.service.test.ts
+++ b/tests/services/query.service.test.ts
@@ -67,9 +67,11 @@ describe("QueryService", () => {
 			},
 		});
 
-		const createdThreadId = first.value.event === "thread_id"
-			? first.value.data.threadId
-			: undefined;
+		if (first.done || first.value.event !== "thread_id") {
+			throw new Error("Expected initial thread_id event");
+		}
+
+		const createdThreadId = first.value.data.threadId;
 		expect(createdThreadId).toBeTruthy();
 		expect(createThread).toHaveBeenCalledWith(
 			ThreadType.CHAT,


### PR DESCRIPTION
## Summary

Refactors fulfillment and aggregation result handling so runtime response data converges on canonical multipart messages instead of plain string-only results.

This PR keeps the current public compatibility behavior intact while reducing the remaining text-first assumptions inside the fulfillment pipeline.

## Background

The query/controller layer already accepts structured input and returns a canonical `message` payload alongside the compatibility `content` field. Streaming also emits canonical lifecycle events such as `message_start`, `part_delta`, and `message_complete`.

However, fulfillment and aggregation still collect intermediate and final responses mainly through string fields such as `finalResponseText`, `responseText`, and `FulfillmentResult.response`. That makes the next steps, especially tool result parts, artifact-bearing messages, and provider-facing multipart migration, harder than necessary.

This PR moves the internal fulfillment result boundary toward canonical `MessageObject.parts[]`.

## Changes

- Extends fulfillment result handling to carry canonical model messages.
- Updates single-intent, multi-intent, and aggregation paths to work from canonical message results.
- Preserves existing text compatibility behavior:
  - streaming still emits `text_chunk`
  - final `/query` compatibility `content` can still be derived from text parts
  - `message_complete.data.message` remains canonical
- Routes aggregation prompt construction through shared message serialization instead of reading plain response strings directly.
- Keeps final response persistence aligned with canonical `MODEL` messages.
- Keeps PII mask behavior scoped to final text output and reflects the masked text in the canonical message.
- Adds focused test coverage for canonical fulfillment result handling and compatibility stream behavior.