### PR TITLE
refactor: emit canonical tool execution events

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -48,6 +48,10 @@ Completed groundwork so far:
 - updated aggregation prompt construction to use shared canonical message serialization
 - updated multi-intent intermediate fulfillment context to reuse canonical model messages
 - added tests covering canonical fulfillment results, aggregation serialization, and stream compatibility
+- added canonical tool/thought message part creation helpers
+- updated fulfillment tool execution to emit `tool_start` and `tool_output` stream events
+- kept provider-facing tool result fallback through existing `appendMessages(..., toolResult)` behavior
+- added MCP and A2A tool execution tests covering canonical tool events and compatibility behavior
 
 Not completed yet:
 
@@ -870,6 +874,11 @@ Completed groundwork in this phase:
 - updated aggregation to serialize fulfillment `responseMessage` values through shared message serializers
 - preserved legacy aggregation fallback behavior for callers that still provide only `response`
 - added focused tests for canonical fulfillment stream completion, intermediate context, and aggregation serialization
+- added shared helpers for canonical `tool-call`, `tool-result`, and `thought` parts
+- updated MCP and A2A tool execution flows to emit canonical `tool_start` and `tool_output` stream events
+- preserved existing `thinking_process` events as compatibility/UX progress signals
+- preserved provider-facing string fallback by continuing to append tool results through `BaseModel.appendMessages`
+- added focused tests for MCP and A2A tool event emission plus tool part helper construction
 
 ## Phase 9. Model Abstraction Migration
 

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -12,13 +12,20 @@ import {
 	type CanonicalMessageObject,
 	type FulfillmentResult,
 	type Intent,
+	type MessageContentPart,
 	MessageRole,
 	type ThreadObject,
 	type TriggeredIntent,
 } from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger";
-import { createTextMessage, extractTextContent } from "@/utils/message";
+import {
+	createTextMessage,
+	createThoughtPart,
+	createToolCallPart,
+	createToolResultPart,
+	extractTextContent,
+} from "@/utils/message";
 import { PIIFilterMode, type PIIService } from "../pii.service";
 import fulfillPrompt from "../prompts/fulfill";
 import toolSelectPrompt from "../prompts/tool-select";
@@ -122,7 +129,7 @@ export class IntentFulfillService {
 		this.a2aModule &&
 			tools.push(...(await this.a2aModule.getTools(toolPrompt)));
 
-		const processList: string[] = [];
+		const toolTraceParts: MessageContentPart[] = [];
 
 		while (true) {
 			const functions = modelInstance.convertToolsToFunctions(tools);
@@ -187,13 +194,33 @@ export class IntentFulfillService {
 					}
 
 					const toolArgs = JSON.parse(toolCall.function.arguments);
-					const thinkData = {
+					const toolCallId = toolCall.id || randomUUID();
+					const thoughtPart = createThoughtPart({
 						title: `[${getManifest().name}] ${selectedTool.protocol} 실행: ${toolName}`,
 						description: `${toolArgs.thinking_text || ""}`,
-					};
+					});
+					const toolCallPart = createToolCallPart({
+						toolCallId,
+						toolName,
+						args: toolArgs,
+					});
+					toolTraceParts.push(thoughtPart, toolCallPart);
+
 					yield {
 						event: "thinking_process",
-						data: thinkData,
+						data: {
+							title: thoughtPart.title,
+							description: thoughtPart.description ?? "",
+						},
+					};
+					yield {
+						event: "tool_start",
+						data: {
+							toolCallId: toolCallPart.toolCallId,
+							protocol: selectedTool.protocol,
+							toolName: toolCallPart.toolName,
+							toolArgs: toolCallPart.args,
+						},
 					};
 
 					let toolResult = "";
@@ -232,7 +259,22 @@ export class IntentFulfillService {
 
 					loggers.intent.debug("Tool Result", { toolResult });
 
-					processList.push(toolResult);
+					const toolResultPart = createToolResultPart({
+						toolCallId: toolCallPart.toolCallId,
+						toolName: toolCallPart.toolName,
+						result: toolResult,
+					});
+					toolTraceParts.push(toolResultPart);
+					yield {
+						event: "tool_output",
+						data: {
+							toolCallId: toolResultPart.toolCallId,
+							protocol: selectedTool.protocol,
+							toolName: toolResultPart.toolName,
+							result: toolResultPart.result,
+						},
+					};
+
 					modelInstance.appendMessages(messages, toolResult);
 				}
 			} else {
@@ -242,7 +284,9 @@ export class IntentFulfillService {
 
 		loggers.intent.debug("Intent fulfillment completed", {
 			threadId: thread.threadId,
-			toolCallsExecuted: processList.length,
+			toolCallsExecuted: toolTraceParts.filter(
+				(part) => part.kind === "tool-result",
+			).length,
 			intentName: intent?.name,
 		});
 	}

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -181,6 +181,43 @@ export function createTextMessage(params: {
 	};
 }
 
+export function createToolCallPart(params: {
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+}): ToolCallContentPart {
+	return {
+		kind: "tool-call",
+		toolCallId: params.toolCallId,
+		toolName: params.toolName,
+		args: params.args,
+	};
+}
+
+export function createToolResultPart(params: {
+	toolCallId: string;
+	toolName: string;
+	result: unknown;
+}): ToolResultContentPart {
+	return {
+		kind: "tool-result",
+		toolCallId: params.toolCallId,
+		toolName: params.toolName,
+		result: params.result,
+	};
+}
+
+export function createThoughtPart(params: {
+	title: string;
+	description?: string;
+}): ThoughtContentPart {
+	return {
+		kind: "thought",
+		title: params.title,
+		description: params.description,
+	};
+}
+
 function queryTextPartToContentPart(part: QueryTextInputPart): TextContentPart {
 	return { kind: "text", text: part.text };
 }

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -1,5 +1,6 @@
 import { setManifest } from "@/config/manifest";
 import { IntentFulfillService } from "@/services/intents/fulfill.service";
+import { CONNECTOR_PROTOCOL_TYPE } from "@/types/connector";
 import { MessageRole, ThreadType } from "@/types/memory";
 
 describe("IntentFulfillService", () => {
@@ -178,6 +179,284 @@ describe("IntentFulfillService", () => {
 			role: MessageRole.MODEL,
 			schemaVersion: 2,
 			parts: [{ kind: "text", text: "second reply" }],
+		});
+	});
+
+	it("emits canonical tool events for MCP tool execution while preserving provider append fallback", async () => {
+		let streamCallCount = 0;
+		const appendMessages = jest.fn();
+		const useTool = jest.fn(async () => "tool result text");
+
+		const service = new IntentFulfillService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					convertToolsToFunctions: () => [],
+					appendMessages,
+					fetchStreamWithContextMessage: async () => {
+						const isToolRequest = streamCallCount === 0;
+						streamCallCount += 1;
+
+						return {
+							async *[Symbol.asyncIterator]() {
+								if (isToolRequest) {
+									yield {
+										delta: {
+											tool_calls: [
+												{
+													index: 0,
+													id: "tool-call-1",
+													function: {
+														name: "search",
+														arguments:
+															'{"query":"hello","thinking_text":"checking sources"}',
+													},
+												},
+											],
+										},
+									};
+									return;
+								}
+
+								yield {
+									delta: {
+										content: "final answer",
+									},
+								};
+							},
+						};
+					},
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAgentPrompt: async () => "",
+				}),
+				getThreadMemory: () => ({
+					addMessagesToThread: jest.fn(async () => {}),
+				}),
+			} as any,
+			undefined,
+			{
+				getTools: () => [
+					{
+						toolName: "search",
+						connectorName: "test-mcp",
+						protocol: CONNECTOR_PROTOCOL_TYPE.MCP,
+					},
+				],
+				useTool,
+			} as any,
+		);
+
+		const stream = service.intentFulfill(
+			[{ subquery: "find info" }],
+			{
+				userId: "user-1",
+				threadId: "thread-1",
+				type: ThreadType.CHAT,
+				title: "Thread",
+				messages: [],
+			},
+			"find info",
+			false,
+		);
+
+		const events = [];
+		let finalMessage;
+		while (true) {
+			const result = await stream.next();
+			if (result.done) {
+				finalMessage = result.value;
+				break;
+			}
+			events.push(result.value);
+		}
+
+		expect(events.map((event) => event.event)).toEqual([
+			"thinking_process",
+			"thinking_process",
+			"tool_start",
+			"tool_output",
+			"message_start",
+			"part_delta",
+			"text_chunk",
+			"message_complete",
+		]);
+		expect(events[1]).toMatchObject({
+			event: "thinking_process",
+			data: {
+				title: "[Test Agent] MCP 실행: search",
+				description: "checking sources",
+			},
+		});
+		expect(events[2]).toEqual({
+			event: "tool_start",
+			data: {
+				toolCallId: "tool-call-1",
+				protocol: CONNECTOR_PROTOCOL_TYPE.MCP,
+				toolName: "search",
+				toolArgs: {
+					query: "hello",
+					thinking_text: "checking sources",
+				},
+			},
+		});
+		expect(events[3]).toEqual({
+			event: "tool_output",
+			data: {
+				toolCallId: "tool-call-1",
+				protocol: CONNECTOR_PROTOCOL_TYPE.MCP,
+				toolName: "search",
+				result: "tool result text",
+			},
+		});
+		expect(useTool).toHaveBeenCalledWith(
+			expect.objectContaining({ toolName: "search" }),
+			{ query: "hello", thinking_text: "checking sources" },
+		);
+		expect(appendMessages).toHaveBeenCalledWith([], "tool result text");
+		expect(finalMessage).toMatchObject({
+			role: MessageRole.MODEL,
+			schemaVersion: 2,
+			parts: [{ kind: "text", text: "final answer" }],
+		});
+	});
+
+	it("emits canonical tool events for A2A tool execution", async () => {
+		let streamCallCount = 0;
+
+		const service = new IntentFulfillService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					convertToolsToFunctions: () => [],
+					appendMessages: jest.fn(),
+					fetchStreamWithContextMessage: async () => {
+						const isToolRequest = streamCallCount === 0;
+						streamCallCount += 1;
+
+						return {
+							async *[Symbol.asyncIterator]() {
+								if (isToolRequest) {
+									yield {
+										delta: {
+											tool_calls: [
+												{
+													index: 0,
+													id: "a2a-call-1",
+													function: {
+														name: "remote_agent",
+														arguments:
+															'{"thinking_text":"asking remote agent"}',
+													},
+												},
+											],
+										},
+									};
+									return;
+								}
+
+								yield {
+									delta: {
+										content: "answer after remote result",
+									},
+								};
+							},
+						};
+					},
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAgentPrompt: async () => "",
+				}),
+				getThreadMemory: () => ({
+					addMessagesToThread: jest.fn(async () => {}),
+				}),
+			} as any,
+			{
+				getTools: async () => [
+					{
+						toolName: "remote_agent",
+						connectorName: "remote",
+						protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+					},
+				],
+				useTool: () =>
+					(async function* () {
+						yield {
+							event: "thinking_process" as const,
+							data: {
+								title: "Remote agent",
+								description: "working",
+							},
+						};
+						return "remote result text";
+					})(),
+			} as any,
+		);
+
+		const stream = service.intentFulfill(
+			[{ subquery: "ask remote" }],
+			{
+				userId: "user-1",
+				threadId: "thread-1",
+				type: ThreadType.CHAT,
+				title: "Thread",
+				messages: [],
+			},
+			"ask remote",
+			false,
+		);
+
+		const events = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(events).toEqual(
+			expect.arrayContaining([
+				{
+					event: "tool_start",
+					data: {
+						toolCallId: "a2a-call-1",
+						protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+						toolName: "remote_agent",
+						toolArgs: {
+							thinking_text: "asking remote agent",
+						},
+					},
+				},
+				{
+					event: "tool_output",
+					data: {
+						toolCallId: "a2a-call-1",
+						protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+						toolName: "remote_agent",
+						result: "remote result text",
+					},
+				},
+				{
+					event: "thinking_process",
+					data: {
+						title: "Remote agent",
+						description: "working",
+					},
+				},
+			]),
+		);
+		expect(events.at(-1)).toMatchObject({
+			event: "message_complete",
+			data: {
+				message: {
+					role: MessageRole.MODEL,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "answer after remote result" }],
+				},
+			},
 		});
 	});
 });

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -2,6 +2,9 @@ import { MessageRole, type MessageObject, ThreadType } from "@/types/memory";
 import {
 	createMessageFromQueryInput,
 	createTextMessage,
+	createThoughtPart,
+	createToolCallPart,
+	createToolResultPart,
 	normalizeMessageObject,
 	serializeMessageForIntent,
 	serializeThreadForIntent,
@@ -130,5 +133,42 @@ describe("message utilities", () => {
 		expect(serializeMessageForIntent(message)).toBe(
 			'Collecting data\nFetching the latest metrics.\napplication/json: {"total":3}',
 		);
+	});
+
+	it("creates canonical tool and thought parts", () => {
+		expect(
+			createToolCallPart({
+				toolCallId: "call-1",
+				toolName: "search",
+				args: { query: "hello" },
+			}),
+		).toEqual({
+			kind: "tool-call",
+			toolCallId: "call-1",
+			toolName: "search",
+			args: { query: "hello" },
+		});
+		expect(
+			createToolResultPart({
+				toolCallId: "call-1",
+				toolName: "search",
+				result: "found it",
+			}),
+		).toEqual({
+			kind: "tool-result",
+			toolCallId: "call-1",
+			toolName: "search",
+			result: "found it",
+		});
+		expect(
+			createThoughtPart({
+				title: "Running search",
+				description: "Checking available sources.",
+			}),
+		).toEqual({
+			kind: "thought",
+			title: "Running search",
+			description: "Checking available sources.",
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds canonical tool execution stream events to the fulfillment flow while preserving existing provider and UX compatibility behavior.

This is the Phase 8B follow-up to the canonical fulfillment result work. Tool execution still flows through the existing provider-facing string fallback, but ADK runtime consumers can now observe structured `tool_start` and `tool_output` events.

## Changes

- Add canonical message part helpers:
  - `createToolCallPart`
  - `createToolResultPart`
  - `createThoughtPart`
- Emit `tool_start` before MCP/A2A tool execution.
- Emit `tool_output` after MCP/A2A tool execution.
- Keep existing `thinking_process` events for compatibility and progress UI.
- Keep `modelInstance.appendMessages(messages, toolResult)` unchanged so provider integrations are not affected.
- Track tool execution through canonical tool/thought parts internally.
- Add tests for:
  - MCP tool execution events
  - A2A tool execution events
  - provider append fallback behavior
  - canonical tool/thought part helper construction