### PR TITLE
feat: add structured model input bridge

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-15`
+Last updated: `2026-04-16`
 
 Completed groundwork so far:
 
@@ -52,6 +52,10 @@ Completed groundwork so far:
 - updated fulfillment tool execution to emit `tool_start` and `tool_output` stream events
 - kept provider-facing tool result fallback through existing `appendMessages(..., toolResult)` behavior
 - added MCP and A2A tool execution tests covering canonical tool events and compatibility behavior
+- added an optional structured `input` bridge to `BaseModel.generateMessages`
+- added model input message helpers for text and structured query input
+- updated internal model calls to pass both compatibility `query` text and canonical `input` messages
+- added tests covering structured model input propagation without changing provider-facing fallback behavior
 
 Not completed yet:
 
@@ -885,6 +889,17 @@ Completed groundwork in this phase:
 - change `BaseModel` interfaces
 - update provider implementations
 - define degradation strategy for unsupported modalities
+
+Completed groundwork in this phase:
+
+- introduced `ModelGenerateMessagesParams` as the named `BaseModel.generateMessages` parameter contract
+- added optional `input?: CanonicalMessageObject` alongside the existing required `query: string`
+- exported the new generate-message params type from the public module surface
+- added shared helpers for creating canonical model input messages from text and structured query input
+- updated title generation, PII, intent trigger, fulfillment, and aggregation model calls to include canonical `input`
+- preserved the existing `query` fallback field so current provider implementations can keep using string-only input
+- preserved `BaseModel.appendMessages(messages, message: string)` for tool-result fallback pending a later provider migration
+- added focused tests for structured query propagation, fulfillment model input, aggregate model input, and model input helper construction
 
 Why this comes after service refactors:
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -12,5 +12,9 @@ export type {
 	IWorkflowTemplateMemory,
 } from "./memory/base.memory.js";
 export { MemoryModule } from "./memory/memory.module.js";
-export { BaseModel, type ModelFetchOptions } from "./models/base.model.js";
+export {
+	BaseModel,
+	type ModelFetchOptions,
+	type ModelGenerateMessagesParams,
+} from "./models/base.model.js";
 export { ModelModule } from "./models/model.module.js";

--- a/src/modules/models/base.model.ts
+++ b/src/modules/models/base.model.ts
@@ -1,11 +1,20 @@
 import type { ConnectorTool, FetchResponse } from "@/types/connector.js";
-import type { ThreadObject } from "@/types/memory.js";
+import type { CanonicalMessageObject, ThreadObject } from "@/types/memory.js";
 import type { LLMStream } from "@/types/stream.js";
 
 export type ModelFetchOptions = {
 	reasoning?: "none" | "minimal" | "low" | "medium" | "high";
 	verbosity?: "low" | "medium" | "high";
 	toolChoice?: "auto" | "required";
+};
+
+export type ModelGenerateMessagesParams = {
+	/** Text fallback for providers that have not migrated to structured input yet */
+	query: string;
+	/** Canonical multipart input for providers that opt into structured handling */
+	input?: CanonicalMessageObject;
+	thread?: ThreadObject;
+	systemPrompt?: string;
 };
 
 /**
@@ -27,11 +36,7 @@ export abstract class BaseModel<MessageType, FunctionType> {
 	 * @param systemPrompt - Optional system prompt to set context
 	 * @returns Array of messages formatted for the specific model API
 	 */
-	abstract generateMessages(params: {
-		query: string;
-		thread?: ThreadObject;
-		systemPrompt?: string;
-	}): MessageType[];
+	abstract generateMessages(params: ModelGenerateMessagesParams): MessageType[];
 
 	/**
 	 * Appends a new message to the existing message array.

--- a/src/services/intents/aggregate.service.ts
+++ b/src/services/intents/aggregate.service.ts
@@ -6,7 +6,11 @@ import {
 	type ThreadType,
 } from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
-import { createTextMessage, serializeMessageForIntent } from "@/utils/message";
+import {
+	createModelInputMessage,
+	createTextMessage,
+	serializeMessageForIntent,
+} from "@/utils/message";
 import aggregatePrompts from "../prompts/aggregate";
 
 function serializeFulfillmentResult(result: FulfillmentResult): string {
@@ -94,6 +98,7 @@ export class AggregateService {
 
 		const messages = modelInstance.generateMessages({
 			query,
+			input: createModelInputMessage({ text: query }),
 			thread: emptyThread,
 			systemPrompt: await aggregatePrompts(this.memoryModule),
 		});

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -20,6 +20,7 @@ import {
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger";
 import {
+	createModelInputMessage,
 	createTextMessage,
 	createThoughtPart,
 	createToolCallPart,
@@ -107,6 +108,7 @@ export class IntentFulfillService {
 		query: string,
 		thread: ThreadObject,
 		intent?: Intent,
+		input?: CanonicalMessageObject,
 	): AsyncGenerator<StreamEvent, void, undefined> {
 		const prompt = await fulfillPrompt(this.memoryModule, intent);
 
@@ -114,6 +116,7 @@ export class IntentFulfillService {
 		const modelOptions = this.modelModule.getModelOptions();
 		const messages = modelInstance.generateMessages({
 			query,
+			input: input ?? createModelInputMessage({ text: query }),
 			thread,
 			systemPrompt: prompt.trim(),
 		});
@@ -305,6 +308,7 @@ export class IntentFulfillService {
 	private getIntentStream(
 		triggeredIntent: TriggeredIntent,
 		thread: ThreadObject,
+		input?: CanonicalMessageObject,
 	): AsyncGenerator<StreamEvent> | undefined {
 		const { subquery = "", intent } = triggeredIntent;
 
@@ -319,7 +323,7 @@ export class IntentFulfillService {
 			}
 		}
 
-		return this.intentFulfilling(subquery, thread, intent);
+		return this.intentFulfilling(subquery, thread, intent, input);
 	}
 
 	/**
@@ -342,6 +346,7 @@ export class IntentFulfillService {
 		thread: ThreadObject,
 		originalQuery: string,
 		needsAggregation: boolean,
+		input?: CanonicalMessageObject,
 	): AsyncGenerator<
 		StreamEvent,
 		CanonicalMessageObject | undefined,
@@ -411,7 +416,7 @@ export class IntentFulfillService {
 			};
 
 			// Get the stream for this intent
-			const stream = this.getIntentStream(triggeredIntent, thread);
+			const stream = this.getIntentStream(triggeredIntent, thread, input);
 			if (!stream) {
 				return;
 			}

--- a/src/services/intents/multi-trigger.service.ts
+++ b/src/services/intents/multi-trigger.service.ts
@@ -5,7 +5,10 @@ import type {
 	TriggeredIntent,
 } from "@/types/memory";
 import { loggers } from "@/utils/logger";
-import { serializeThreadForIntent } from "@/utils/message";
+import {
+	createModelInputMessage,
+	serializeThreadForIntent,
+} from "@/utils/message";
 import multiTriggerPrompt from "../prompts/multi-trigger";
 
 /**
@@ -76,6 +79,7 @@ Based on the above conversation history, analyze the last user question and iden
 
 		const messages = modelInstance.generateMessages({
 			query: triggerMessage,
+			input: createModelInputMessage({ text: triggerMessage }),
 			systemPrompt,
 		});
 
@@ -95,7 +99,7 @@ Based on the above conversation history, analyze the last user question and iden
 		};
 		try {
 			parsed = JSON.parse(response.content);
-		} catch (error: unknown) {
+		} catch (_error: unknown) {
 			return { intents: [{ subquery: query }], needsAggregation: false };
 		}
 

--- a/src/services/intents/single-trigger.service.ts
+++ b/src/services/intents/single-trigger.service.ts
@@ -5,7 +5,10 @@ import type {
 	TriggeredIntent,
 } from "@/types/memory";
 import { loggers } from "@/utils/logger";
-import { serializeThreadForIntent } from "@/utils/message";
+import {
+	createModelInputMessage,
+	serializeThreadForIntent,
+} from "@/utils/message";
 import singleTriggerPrompt from "../prompts/single-trigger";
 
 /**
@@ -75,6 +78,7 @@ Based on the above conversation history, analyze the user question and identify 
 
 		const messages = modelInstance.generateMessages({
 			query: triggerMessage,
+			input: createModelInputMessage({ text: triggerMessage }),
 			systemPrompt,
 		});
 
@@ -87,7 +91,7 @@ Based on the above conversation history, analyze the user question and identify 
 		let parsed: { intentName?: string; actionPlan?: string };
 		try {
 			parsed = JSON.parse(response.content);
-		} catch (error: unknown) {
+		} catch (_error: unknown) {
 			return { intents: [{ subquery: query }], needsAggregation: false };
 		}
 

--- a/src/services/pii.service.ts
+++ b/src/services/pii.service.ts
@@ -1,5 +1,6 @@
 import type { MemoryModule, ModelModule } from "@/modules/index.js";
 import { loggers } from "@/utils/logger.js";
+import { createModelInputMessage } from "@/utils/message.js";
 import piiDetectPrompt from "./prompts/pii-detect.js";
 import piiFilterPrompt from "./prompts/pii-filter.js";
 
@@ -37,6 +38,7 @@ export class PIIService {
 			const modelOptions = this.modelModule.getModelOptions();
 			const messages = modelInstance.generateMessages({
 				query: text,
+				input: createModelInputMessage({ text }),
 				systemPrompt: await piiDetectPrompt(this.memoryModule),
 			});
 			const response = await modelInstance.fetch(messages, modelOptions);
@@ -55,6 +57,7 @@ export class PIIService {
 			const modelOptions = this.modelModule.getModelOptions();
 			const messages = modelInstance.generateMessages({
 				query: text,
+				input: createModelInputMessage({ text }),
 				systemPrompt: await piiFilterPrompt(this.memoryModule),
 			});
 			const response = await modelInstance.fetch(messages, modelOptions);

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -17,7 +17,11 @@ import {
 import type { QueryMessageInput } from "@/types/message-input";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger.js";
-import { createMessageFromQueryInput } from "@/utils/message";
+import {
+	createMessageFromQueryInput,
+	createModelInputMessage,
+	createModelInputMessageFromQueryInput,
+} from "@/utils/message";
 import type { IntentFulfillService } from "./intents/fulfill.service";
 import type { IntentTriggerService } from "./intents/trigger.service";
 import { PIIFilterMode, type PIIService } from "./pii.service";
@@ -70,6 +74,7 @@ export class QueryService {
 			const modelOptions = this.modelModule.getModelOptions();
 			const messages = modelInstance.generateMessages({
 				query,
+				input: createModelInputMessage({ text: query }),
 				systemPrompt: await generateTitlePrompt(this.memoryModule),
 			});
 			const response = await modelInstance.fetch(
@@ -130,6 +135,7 @@ export class QueryService {
 			options,
 		} = threadMetadata;
 		const { displayQuery, input } = queryData;
+		const originalQuery = queryData.query;
 		let { query } = queryData;
 		const threadMemory = this.memoryModule.getThreadMemory();
 
@@ -214,6 +220,11 @@ export class QueryService {
 			};
 		}
 
+		const modelInput =
+			input && query === originalQuery
+				? createModelInputMessageFromQueryInput({ input })
+				: createModelInputMessage({ text: query });
+
 		// 2. intent triggering
 		const triggerResult = await this.intentTriggerService.intentTriggering(
 			query,
@@ -254,6 +265,7 @@ export class QueryService {
 			thread,
 			query,
 			needsAggregation,
+			modelInput,
 		);
 
 		while (true) {

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type {
 	ArtifactContentPart,
 	CanonicalMessageObject,
@@ -5,13 +6,13 @@ import type {
 	LegacyMessageObject,
 	MessageContentPart,
 	MessageObject,
-	MessageRole,
 	TextContentPart,
 	ThoughtContentPart,
 	ThreadObject,
 	ToolCallContentPart,
 	ToolResultContentPart,
 } from "@/types/memory";
+import { MessageRole } from "@/types/memory";
 import type {
 	QueryArtifactInputPart,
 	QueryDataInputPart,
@@ -179,6 +180,38 @@ export function createTextMessage(params: {
 		schemaVersion: 2,
 		parts: [{ kind: "text", text: params.text }],
 	};
+}
+
+export function createModelInputMessage(params: {
+	text: string;
+	role?: MessageRole;
+	messageId?: string;
+	timestamp?: number;
+	metadata?: Record<string, unknown>;
+}): CanonicalMessageObject {
+	return createTextMessage({
+		messageId: params.messageId ?? randomUUID(),
+		role: params.role ?? MessageRole.USER,
+		timestamp: params.timestamp ?? Date.now(),
+		text: params.text,
+		metadata: params.metadata,
+	});
+}
+
+export function createModelInputMessageFromQueryInput(params: {
+	input: QueryMessageInput;
+	role?: MessageRole;
+	messageId?: string;
+	timestamp?: number;
+	metadata?: Record<string, unknown>;
+}): CanonicalMessageObject {
+	return createMessageFromQueryInput({
+		messageId: params.messageId ?? randomUUID(),
+		role: params.role ?? MessageRole.USER,
+		timestamp: params.timestamp ?? Date.now(),
+		input: params.input,
+		metadata: params.metadata,
+	});
 }
 
 export function createToolCallPart(params: {

--- a/tests/services/intents/aggregate.service.test.ts
+++ b/tests/services/intents/aggregate.service.test.ts
@@ -13,12 +13,14 @@ describe("AggregateService", () => {
 
 	it("serializes canonical fulfillment messages when building aggregate prompts", async () => {
 		let aggregateQuery = "";
+		let aggregateInput;
 
 		const service = new AggregateService(
 			{
 				getModel: () => ({
-					generateMessages: ({ query }: { query: string }) => {
+					generateMessages: ({ input, query }: any) => {
 						aggregateQuery = query;
+						aggregateInput = input;
 						return [];
 					},
 					fetchStreamWithContextMessage: async () => ({
@@ -79,6 +81,11 @@ describe("AggregateService", () => {
 		expect(aggregateQuery).toContain("canonical artifact preview");
 		expect(aggregateQuery).toContain("canonical text result");
 		expect(aggregateQuery).not.toContain("legacy text should not be used");
+		expect(aggregateInput).toMatchObject({
+			role: MessageRole.USER,
+			schemaVersion: 2,
+			parts: [{ kind: "text", text: aggregateQuery }],
+		});
 		expect(events).toEqual([
 			expect.objectContaining({ event: "thinking_process" }),
 			{ event: "text_chunk", data: { delta: "combined reply" } },

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -13,10 +13,11 @@ describe("IntentFulfillService", () => {
 
 	it("emits canonical message stream events alongside compatibility text chunks", async () => {
 		const addMessagesToThread = jest.fn(async () => {});
+		const generateMessages = jest.fn(() => []);
 		const service = new IntentFulfillService(
 			{
 				getModel: () => ({
-					generateMessages: () => [],
+					generateMessages,
 					convertToolsToFunctions: () => [],
 					appendMessages: jest.fn(),
 					fetchStreamWithContextMessage: async () => ({
@@ -83,6 +84,16 @@ describe("IntentFulfillService", () => {
 			parts: [{ kind: "text", text: "streamed reply" }],
 		});
 		expect(completedMessages).toEqual([finalMessage]);
+		expect(generateMessages).toHaveBeenCalledWith(
+			expect.objectContaining({
+				query: "hello there",
+				input: expect.objectContaining({
+					role: MessageRole.USER,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "hello there" }],
+				}),
+			}),
+		);
 		expect(addMessagesToThread).toHaveBeenCalledWith(
 			"user-1",
 			"thread-1",
@@ -92,6 +103,80 @@ describe("IntentFulfillService", () => {
 					role: MessageRole.MODEL,
 				}),
 			],
+		);
+	});
+
+	it("uses provided canonical model input for single-intent fulfillment", async () => {
+		const generateMessages = jest.fn(() => []);
+		const service = new IntentFulfillService(
+			{
+				getModel: () => ({
+					generateMessages,
+					convertToolsToFunctions: () => [],
+					appendMessages: jest.fn(),
+					fetchStreamWithContextMessage: async () => ({
+						async *[Symbol.asyncIterator]() {
+							yield {
+								delta: {
+									content: "structured reply",
+								},
+							};
+						},
+					}),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getAgentMemory: () => ({
+					getAgentPrompt: async () => "",
+				}),
+				getThreadMemory: () => ({
+					addMessagesToThread: jest.fn(async () => {}),
+				}),
+			} as any,
+		);
+
+		const modelInput = {
+			messageId: "input-1",
+			role: MessageRole.USER,
+			timestamp: 100,
+			schemaVersion: 2 as const,
+			parts: [
+				{ kind: "text" as const, text: "Summarize this" },
+				{
+					kind: "artifact" as const,
+					artifactId: "art-1",
+					previewText: "file preview",
+				},
+			],
+		};
+
+		const stream = service.intentFulfill(
+			[{ subquery: "Summarize this\nfile preview" }],
+			{
+				userId: "user-1",
+				threadId: "thread-1",
+				type: ThreadType.CHAT,
+				title: "Thread",
+				messages: [],
+			},
+			"Summarize this\nfile preview",
+			false,
+			modelInput,
+		);
+
+		while (true) {
+			const result = await stream.next();
+			if (result.done) {
+				break;
+			}
+		}
+
+		expect(generateMessages).toHaveBeenCalledWith(
+			expect.objectContaining({
+				query: "Summarize this\nfile preview",
+				input: modelInput,
+			}),
 		);
 	});
 

--- a/tests/services/query.service.test.ts
+++ b/tests/services/query.service.test.ts
@@ -12,6 +12,14 @@ describe("QueryService", () => {
 		}));
 		const addMessagesToThread = jest.fn(async () => {});
 		const getThread = jest.fn(async () => undefined);
+		const intentFulfill = jest.fn(async function* () {
+			return createTextMessage({
+				messageId: "model-msg-1",
+				role: MessageRole.MODEL,
+				timestamp: 456,
+				text: "hi there",
+			});
+		});
 
 		const queryService = new QueryService(
 			{
@@ -35,14 +43,7 @@ describe("QueryService", () => {
 				}),
 			} as any,
 			{
-				intentFulfill: async function* () {
-					return createTextMessage({
-						messageId: "model-msg-1",
-						role: MessageRole.MODEL,
-						timestamp: 456,
-						text: "hi there",
-					});
-				},
+				intentFulfill,
 			} as any,
 		);
 
@@ -103,6 +104,102 @@ describe("QueryService", () => {
 					parts: [{ kind: "text", text: "hello there" }],
 				}),
 			],
+		);
+		expect(intentFulfill).toHaveBeenCalledWith(
+			[{ subquery: "hello there" }],
+			expect.objectContaining({ threadId: createdThreadId }),
+			"hello there",
+			false,
+			expect.objectContaining({
+				role: MessageRole.USER,
+				schemaVersion: 2,
+				parts: [{ kind: "text", text: "hello there" }],
+			}),
+		);
+	});
+
+	it("passes structured query input to fulfillment as canonical model input", async () => {
+		const intentFulfill = jest.fn(async function* () {
+			return createTextMessage({
+				messageId: "model-msg-2",
+				role: MessageRole.MODEL,
+				timestamp: 789,
+				text: "done",
+			});
+		});
+
+		const queryService = new QueryService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					fetch: async () => ({ content: "New Chat" }),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getThreadMemory: () => ({
+					getThread: jest.fn(async () => ({
+						type: ThreadType.CHAT,
+						userId: "user-1",
+						threadId: "thread-1",
+						title: "Thread",
+						messages: [],
+					})),
+					addMessagesToThread: jest.fn(async () => {}),
+				}),
+			} as any,
+			{
+				intentTriggering: async () => ({
+					intents: [{ subquery: "summarize" }],
+					needsAggregation: false,
+				}),
+			} as any,
+			{
+				intentFulfill,
+			} as any,
+		);
+
+		const stream = queryService.handleQuery(
+			{
+				type: ThreadType.CHAT,
+				userId: "user-1",
+				threadId: "thread-1",
+			},
+			{
+				query: "Summarize this\nfile preview",
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this" },
+						{
+							kind: "artifact",
+							artifactId: "art-1",
+							previewText: "file preview",
+						},
+					],
+				},
+			},
+		);
+
+		await expect(stream.next()).resolves.toMatchObject({
+			done: true,
+		});
+		expect(intentFulfill).toHaveBeenCalledWith(
+			[{ subquery: "summarize" }],
+			expect.objectContaining({ threadId: "thread-1" }),
+			"Summarize this\nfile preview",
+			false,
+			expect.objectContaining({
+				role: MessageRole.USER,
+				schemaVersion: 2,
+				parts: [
+					{ kind: "text", text: "Summarize this" },
+					expect.objectContaining({
+						kind: "artifact",
+						artifactId: "art-1",
+						previewText: "file preview",
+					}),
+				],
+			}),
 		);
 	});
 });

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -1,5 +1,7 @@
 import { MessageRole, type MessageObject, ThreadType } from "@/types/memory";
 import {
+	createModelInputMessage,
+	createModelInputMessageFromQueryInput,
 	createMessageFromQueryInput,
 	createTextMessage,
 	createThoughtPart,
@@ -69,6 +71,53 @@ describe("message utilities", () => {
 					size: undefined,
 					downloadUrl: undefined,
 					previewText: "Revenue increased by 20 percent.",
+				},
+			],
+		});
+	});
+
+	it("creates canonical model input messages for provider bridge calls", () => {
+		expect(
+			createModelInputMessage({
+				messageId: "model-input-1",
+				timestamp: 123,
+				text: "hello model",
+			}),
+		).toEqual({
+			messageId: "model-input-1",
+			role: MessageRole.USER,
+			timestamp: 123,
+			schemaVersion: 2,
+			metadata: undefined,
+			parts: [{ kind: "text", text: "hello model" }],
+		});
+
+		expect(
+			createModelInputMessageFromQueryInput({
+				messageId: "model-input-2",
+				timestamp: 456,
+				input: {
+					parts: [
+						{ kind: "text", text: "Summarize this" },
+						{
+							kind: "artifact",
+							artifactId: "art-1",
+							previewText: "file preview",
+						},
+					],
+				},
+			}),
+		).toMatchObject({
+			messageId: "model-input-2",
+			role: MessageRole.USER,
+			timestamp: 456,
+			schemaVersion: 2,
+			parts: [
+				{ kind: "text", text: "Summarize this" },
+				{
+					kind: "artifact",
+					artifactId: "art-1",
+					previewText: "file preview",
 				},
 			],
 		});


### PR DESCRIPTION
## Summary

Adds an optional structured input bridge to `BaseModel.generateMessages` so providers can opt into canonical multipart input without breaking existing string-based implementations.

## Changes

- Add `ModelGenerateMessagesParams`.
- Keep `query: string` as the compatibility fallback.
- Add optional `input?: CanonicalMessageObject`.
- Export the new params type from the module surface.
- Add helpers for creating canonical model input messages.
- Pass canonical `input` through title generation, PII, intent trigger, fulfillment, and aggregation model calls.
- Add tests for structured query propagation and model input helper construction.
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.