### PR TITLE
feat: add structured append bridge for tool results

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -56,6 +56,10 @@ Completed groundwork so far:
 - added model input message helpers for text and structured query input
 - updated internal model calls to pass both compatibility `query` text and canonical `input` messages
 - added tests covering structured model input propagation without changing provider-facing fallback behavior
+- added an optional structured append bridge to `BaseModel.appendMessages`
+- added a canonical `TOOL` message helper for tool-call/tool-result append payloads
+- updated fulfillment tool result append calls to pass both compatibility text and canonical `TOOL` messages
+- added MCP and A2A tests covering structured append payloads while preserving string fallback behavior
 
 Not completed yet:
 
@@ -898,8 +902,12 @@ Completed groundwork in this phase:
 - added shared helpers for creating canonical model input messages from text and structured query input
 - updated title generation, PII, intent trigger, fulfillment, and aggregation model calls to include canonical `input`
 - preserved the existing `query` fallback field so current provider implementations can keep using string-only input
-- preserved `BaseModel.appendMessages(messages, message: string)` for tool-result fallback pending a later provider migration
 - added focused tests for structured query propagation, fulfillment model input, aggregate model input, and model input helper construction
+- introduced optional structured append input on `BaseModel.appendMessages` while preserving the required string fallback
+- exported the structured append input type from the public module surface
+- added a shared helper for constructing canonical `TOOL` messages from thought, tool-call, and tool-result parts
+- updated MCP and A2A fulfillment tool append calls to pass canonical `TOOL` messages as opt-in provider input
+- added focused tests for MCP and A2A structured append payloads plus canonical tool message helper construction
 
 Why this comes after service refactors:
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -14,6 +14,7 @@ export type {
 export { MemoryModule } from "./memory/memory.module.js";
 export {
 	BaseModel,
+	type ModelAppendMessageInput,
 	type ModelFetchOptions,
 	type ModelGenerateMessagesParams,
 } from "./models/base.model.js";

--- a/src/modules/models/base.model.ts
+++ b/src/modules/models/base.model.ts
@@ -17,6 +17,8 @@ export type ModelGenerateMessagesParams = {
 	systemPrompt?: string;
 };
 
+export type ModelAppendMessageInput = CanonicalMessageObject;
+
 /**
  * Abstract base class for AI model implementations.
  *
@@ -42,9 +44,14 @@ export abstract class BaseModel<MessageType, FunctionType> {
 	 * Appends a new message to the existing message array.
 	 *
 	 * @param messages - Existing message array to expand
-	 * @param message - New message content to append
+	 * @param message - Text fallback for providers that have not migrated to structured append input yet
+	 * @param input - Canonical multipart message for providers that opt into structured append handling
 	 */
-	abstract appendMessages(messages: MessageType[], message: string): void;
+	abstract appendMessages(
+		messages: MessageType[],
+		message: string,
+		input?: ModelAppendMessageInput,
+	): void;
 
 	/**
 	 * Converts protocol-agnostic tools to model-specific function format.

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -24,6 +24,7 @@ import {
 	createTextMessage,
 	createThoughtPart,
 	createToolCallPart,
+	createToolMessage,
 	createToolResultPart,
 	extractTextContent,
 } from "@/utils/message";
@@ -285,7 +286,15 @@ export class IntentFulfillService {
 						},
 					};
 
-					modelInstance.appendMessages(messages, toolResult);
+					modelInstance.appendMessages(
+						messages,
+						toolResult,
+						createToolMessage({
+							thoughtPart,
+							toolCallPart,
+							toolResultPart,
+						}),
+					);
 				}
 			} else {
 				break;

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -251,6 +251,28 @@ export function createThoughtPart(params: {
 	};
 }
 
+export function createToolMessage(params: {
+	toolCallPart: ToolCallContentPart;
+	toolResultPart: ToolResultContentPart;
+	thoughtPart?: ThoughtContentPart;
+	messageId?: string;
+	timestamp?: number;
+	metadata?: Record<string, unknown>;
+}): CanonicalMessageObject {
+	return {
+		messageId: params.messageId ?? randomUUID(),
+		role: MessageRole.TOOL,
+		timestamp: params.timestamp ?? Date.now(),
+		metadata: params.metadata,
+		schemaVersion: 2,
+		parts: [
+			...(params.thoughtPart ? [params.thoughtPart] : []),
+			params.toolCallPart,
+			params.toolResultPart,
+		],
+	};
+}
+
 function queryTextPartToContentPart(part: QueryTextInputPart): TextContentPart {
 	return { kind: "text", text: part.text };
 }

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -401,7 +401,36 @@ describe("IntentFulfillService", () => {
 			expect.objectContaining({ toolName: "search" }),
 			{ query: "hello", thinking_text: "checking sources" },
 		);
-		expect(appendMessages).toHaveBeenCalledWith([], "tool result text");
+		expect(appendMessages).toHaveBeenCalledWith(
+			[],
+			"tool result text",
+			expect.objectContaining({
+				role: MessageRole.TOOL,
+				schemaVersion: 2,
+				parts: [
+					{
+						kind: "thought",
+						title: "[Test Agent] MCP 실행: search",
+						description: "checking sources",
+					},
+					{
+						kind: "tool-call",
+						toolCallId: "tool-call-1",
+						toolName: "search",
+						args: {
+							query: "hello",
+							thinking_text: "checking sources",
+						},
+					},
+					{
+						kind: "tool-result",
+						toolCallId: "tool-call-1",
+						toolName: "search",
+						result: "tool result text",
+					},
+				],
+			}),
+		);
 		expect(finalMessage).toMatchObject({
 			role: MessageRole.MODEL,
 			schemaVersion: 2,
@@ -411,13 +440,14 @@ describe("IntentFulfillService", () => {
 
 	it("emits canonical tool events for A2A tool execution", async () => {
 		let streamCallCount = 0;
+		const appendMessages = jest.fn();
 
 		const service = new IntentFulfillService(
 			{
 				getModel: () => ({
 					generateMessages: () => [],
 					convertToolsToFunctions: () => [],
-					appendMessages: jest.fn(),
+					appendMessages,
 					fetchStreamWithContextMessage: async () => {
 						const isToolRequest = streamCallCount === 0;
 						streamCallCount += 1;
@@ -543,5 +573,34 @@ describe("IntentFulfillService", () => {
 				},
 			},
 		});
+		expect(appendMessages).toHaveBeenCalledWith(
+			[],
+			"remote result text",
+			expect.objectContaining({
+				role: MessageRole.TOOL,
+				schemaVersion: 2,
+				parts: [
+					{
+						kind: "thought",
+						title: "[Test Agent] A2A 실행: remote_agent",
+						description: "asking remote agent",
+					},
+					{
+						kind: "tool-call",
+						toolCallId: "a2a-call-1",
+						toolName: "remote_agent",
+						args: {
+							thinking_text: "asking remote agent",
+						},
+					},
+					{
+						kind: "tool-result",
+						toolCallId: "a2a-call-1",
+						toolName: "remote_agent",
+						result: "remote result text",
+					},
+				],
+			}),
+		);
 	});
 });

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -6,6 +6,7 @@ import {
 	createTextMessage,
 	createThoughtPart,
 	createToolCallPart,
+	createToolMessage,
 	createToolResultPart,
 	normalizeMessageObject,
 	serializeMessageForIntent,
@@ -185,39 +186,71 @@ describe("message utilities", () => {
 	});
 
 	it("creates canonical tool and thought parts", () => {
-		expect(
-			createToolCallPart({
-				toolCallId: "call-1",
-				toolName: "search",
-				args: { query: "hello" },
-			}),
-		).toEqual({
+		const toolCallPart = createToolCallPart({
+			toolCallId: "call-1",
+			toolName: "search",
+			args: { query: "hello" },
+		});
+		const toolResultPart = createToolResultPart({
+			toolCallId: "call-1",
+			toolName: "search",
+			result: "found it",
+		});
+		const thoughtPart = createThoughtPart({
+			title: "Running search",
+			description: "Checking available sources.",
+		});
+
+		expect(toolCallPart).toEqual({
 			kind: "tool-call",
 			toolCallId: "call-1",
 			toolName: "search",
 			args: { query: "hello" },
 		});
-		expect(
-			createToolResultPart({
-				toolCallId: "call-1",
-				toolName: "search",
-				result: "found it",
-			}),
-		).toEqual({
+		expect(toolResultPart).toEqual({
 			kind: "tool-result",
 			toolCallId: "call-1",
 			toolName: "search",
 			result: "found it",
 		});
-		expect(
-			createThoughtPart({
-				title: "Running search",
-				description: "Checking available sources.",
-			}),
-		).toEqual({
+		expect(thoughtPart).toEqual({
 			kind: "thought",
 			title: "Running search",
 			description: "Checking available sources.",
+		});
+	});
+
+	it("creates canonical tool messages for model append bridges", () => {
+		const toolCallPart = createToolCallPart({
+			toolCallId: "call-1",
+			toolName: "search",
+			args: { query: "hello" },
+		});
+		const toolResultPart = createToolResultPart({
+			toolCallId: "call-1",
+			toolName: "search",
+			result: "found it",
+		});
+		const thoughtPart = createThoughtPart({
+			title: "Running search",
+			description: "Checking available sources.",
+		});
+
+		expect(
+			createToolMessage({
+				messageId: "tool-msg-1",
+				timestamp: 123,
+				thoughtPart,
+				toolCallPart,
+				toolResultPart,
+			}),
+		).toEqual({
+			messageId: "tool-msg-1",
+			role: MessageRole.TOOL,
+			timestamp: 123,
+			metadata: undefined,
+			schemaVersion: 2,
+			parts: [thoughtPart, toolCallPart, toolResultPart],
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds an optional structured append bridge for tool results while preserving the existing string fallback behavior.

## Changes

- Add `ModelAppendMessageInput`.
- Extend `BaseModel.appendMessages` with optional `input`.
- Export the new append input type from the module surface.
- Add `createToolMessage` for canonical `TOOL` messages.
- Pass canonical `TOOL` messages to `appendMessages` during MCP/A2A tool execution.
- Keep the existing text `toolResult` fallback unchanged.
- Add tests for MCP/A2A structured append payloads.
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.