### PR TITLE
refactor: add shared model fallback serializers

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -60,6 +60,9 @@ Completed groundwork so far:
 - added a canonical `TOOL` message helper for tool-call/tool-result append payloads
 - updated fulfillment tool result append calls to pass both compatibility text and canonical `TOOL` messages
 - added MCP and A2A tests covering structured append payloads while preserving string fallback behavior
+- added provider-facing model fallback serializers for multipart messages and threads
+- updated structured query normalization to reuse shared model fallback serialization rules
+- added tests covering artifact, data, tool, and thread fallback serialization
 
 Not completed yet:
 
@@ -908,6 +911,10 @@ Completed groundwork in this phase:
 - added a shared helper for constructing canonical `TOOL` messages from thought, tool-call, and tool-result parts
 - updated MCP and A2A fulfillment tool append calls to pass canonical `TOOL` messages as opt-in provider input
 - added focused tests for MCP and A2A structured append payloads plus canonical tool message helper construction
+- added `serializePartForModelFallback`, `serializeMessageForModelFallback`, and `serializeThreadForModelFallback`
+- kept intent serializers aligned by routing them through the same multipart fallback behavior
+- updated structured query normalization to derive compatibility text through shared model fallback serializers
+- added focused tests for artifact-without-preview, data, tool, and thread fallback serialization behavior
 
 Why this comes after service refactors:
 

--- a/src/modules/models/base.model.ts
+++ b/src/modules/models/base.model.ts
@@ -34,6 +34,8 @@ export abstract class BaseModel<MessageType, FunctionType> {
 	 * Generates an array of messages from thread and current query.
 	 *
 	 * @param query - Current user query
+	 * @param input - Optional canonical multipart input. Providers that do not support multipart input
+	 * can degrade it through the shared model fallback serializers in `@/utils/message`.
 	 * @param thread - Previous conversation history
 	 * @param systemPrompt - Optional system prompt to set context
 	 * @returns Array of messages formatted for the specific model API
@@ -45,7 +47,9 @@ export abstract class BaseModel<MessageType, FunctionType> {
 	 *
 	 * @param messages - Existing message array to expand
 	 * @param message - Text fallback for providers that have not migrated to structured append input yet
-	 * @param input - Canonical multipart message for providers that opt into structured append handling
+	 * @param input - Canonical multipart message for providers that opt into structured append handling.
+	 * Providers that do not support multipart append input can degrade it through the shared
+	 * model fallback serializers in `@/utils/message`.
 	 */
 	abstract appendMessages(
 		messages: MessageType[],

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -340,6 +340,27 @@ export function createMessageFromQueryInput(params: {
 	};
 }
 
+export function serializePartForModelFallback(
+	part: MessageContentPart,
+): string {
+	switch (part.kind) {
+		case "text":
+			return part.text;
+		case "artifact":
+			return serializeArtifactPart(part);
+		case "data":
+			return serializeDataPart(part);
+		case "tool-call":
+			return serializeToolCallPart(part);
+		case "tool-result":
+			return serializeToolResultPart(part);
+		case "thought":
+			return part.description
+				? `${part.title}\n${part.description}`
+				: part.title;
+	}
+}
+
 function serializeArtifactPart(part: ArtifactContentPart): string {
 	if (part.previewText?.trim()) {
 		return part.previewText;
@@ -391,30 +412,21 @@ function serializeToolResultPart(part: ToolResultContentPart): string {
 	}
 }
 
+export function serializeMessageForModelFallback(
+	message: MessageObject,
+): string {
+	return normalizeMessageParts(message)
+		.map(serializePartForModelFallback)
+		.filter((value) => value.trim() !== "")
+		.join("\n");
+}
+
 export function serializePartForIntent(part: MessageContentPart): string {
-	switch (part.kind) {
-		case "text":
-			return part.text;
-		case "artifact":
-			return serializeArtifactPart(part);
-		case "data":
-			return serializeDataPart(part);
-		case "tool-call":
-			return serializeToolCallPart(part);
-		case "tool-result":
-			return serializeToolResultPart(part);
-		case "thought":
-			return part.description
-				? `${part.title}\n${part.description}`
-				: part.title;
-	}
+	return serializePartForModelFallback(part);
 }
 
 export function serializeMessageForIntent(message: MessageObject): string {
-	return normalizeMessageParts(message)
-		.map(serializePartForIntent)
-		.filter((value) => value.trim() !== "")
-		.join("\n");
+	return serializeMessageForModelFallback(message);
 }
 
 function roleLabel(role: MessageRole): string {
@@ -433,6 +445,12 @@ function roleLabel(role: MessageRole): string {
 export function serializeThreadForIntent(
 	thread: ThreadObject | undefined,
 ): string {
+	return serializeThreadForModelFallback(thread);
+}
+
+export function serializeThreadForModelFallback(
+	thread: ThreadObject | undefined,
+): string {
 	if (!thread) {
 		return "";
 	}
@@ -441,7 +459,7 @@ export function serializeThreadForIntent(
 		.slice()
 		.sort((a, b) => a.timestamp - b.timestamp)
 		.map((message) => {
-			const content = serializeMessageForIntent(message);
+			const content = serializeMessageForModelFallback(message);
 			return `${roleLabel(message.role)}: """${content}"""`;
 		})
 		.join("\n");

--- a/src/utils/query-input.ts
+++ b/src/utils/query-input.ts
@@ -4,11 +4,14 @@ import type {
 	NormalizedQueryRequest,
 	QueryArtifactInputPart,
 	QueryDataInputPart,
-	QueryInputPart,
 	QueryMessageInput,
 	QueryRequestInput,
 	QueryTextInputPart,
 } from "@/types/message-input";
+import {
+	createModelInputMessageFromQueryInput,
+	serializeMessageForModelFallback,
+} from "./message";
 
 type NormalizeQueryInputOptions = {
 	artifactModuleConfigured: boolean;
@@ -16,47 +19,6 @@ type NormalizeQueryInputOptions = {
 
 function isObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
-}
-
-function serializeArtifactPart(part: QueryArtifactInputPart): string {
-	if (part.previewText?.trim()) {
-		return part.previewText;
-	}
-
-	const artifactLabel = part.name || part.artifactId;
-	const metadata: string[] = [];
-	if (part.mimeType) {
-		metadata.push(part.mimeType);
-	}
-	if (typeof part.size === "number") {
-		metadata.push(`${part.size} bytes`);
-	}
-
-	return metadata.length > 0
-		? `[Artifact: ${artifactLabel} (${metadata.join(", ")})]`
-		: `[Artifact: ${artifactLabel}]`;
-}
-
-function serializeDataPart(part: QueryDataInputPart): string {
-	if (typeof part.data === "string") {
-		return part.data;
-	}
-
-	try {
-		return `${part.mimeType}: ${JSON.stringify(part.data)}`;
-	} catch {
-		return `[Data: ${part.mimeType}]`;
-	}
-}
-
-function serializePart(part: QueryInputPart): string {
-	if (part.kind === "text") {
-		return part.text;
-	}
-	if (part.kind === "artifact") {
-		return serializeArtifactPart(part);
-	}
-	return serializeDataPart(part);
 }
 
 function validateTextPart(part: Record<string, unknown>): QueryTextInputPart {
@@ -230,10 +192,11 @@ export function normalizeQueryRequest(
 	}
 
 	const input = validateStructuredInput(body.input, options);
-	const query = input.parts
-		.map(serializePart)
-		.filter((value) => value.trim() !== "")
-		.join("\n");
+	const query = serializeMessageForModelFallback(
+		createModelInputMessageFromQueryInput({
+			input,
+		}),
+	);
 
 	return {
 		input,

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -9,7 +9,9 @@ import {
 	createToolMessage,
 	createToolResultPart,
 	normalizeMessageObject,
+	serializeMessageForModelFallback,
 	serializeMessageForIntent,
+	serializeThreadForModelFallback,
 	serializeThreadForIntent,
 } from "@/utils/message";
 
@@ -158,6 +160,9 @@ describe("message utilities", () => {
 		expect(serializeThreadForIntent(thread)).toBe(
 			'User: """Analyze this file"""\nAssistant: """month,revenue\nJan,100"""',
 		);
+		expect(serializeThreadForModelFallback(thread)).toBe(
+			'User: """Analyze this file"""\nAssistant: """month,revenue\nJan,100"""',
+		);
 	});
 
 	it("serializes thought and data parts consistently", () => {
@@ -182,6 +187,58 @@ describe("message utilities", () => {
 
 		expect(serializeMessageForIntent(message)).toBe(
 			'Collecting data\nFetching the latest metrics.\napplication/json: {"total":3}',
+		);
+		expect(serializeMessageForModelFallback(message)).toBe(
+			'Collecting data\nFetching the latest metrics.\napplication/json: {"total":3}',
+		);
+	});
+
+	it("serializes artifacts without preview text for model fallback", () => {
+		const message: MessageObject = {
+			messageId: "msg-6",
+			role: MessageRole.USER,
+			timestamp: 400,
+			schemaVersion: 2,
+			parts: [
+				{
+					kind: "artifact",
+					artifactId: "art-3",
+					name: "report.pdf",
+					mimeType: "application/pdf",
+					size: 1024,
+				},
+			],
+		};
+
+		expect(serializeMessageForModelFallback(message)).toBe(
+			"[Artifact: report.pdf (application/pdf, 1024 bytes)]",
+		);
+	});
+
+	it("serializes tool parts consistently for model fallback", () => {
+		const message: MessageObject = {
+			messageId: "msg-7",
+			role: MessageRole.TOOL,
+			timestamp: 500,
+			schemaVersion: 2,
+			parts: [
+				{
+					kind: "tool-call",
+					toolCallId: "call-1",
+					toolName: "search",
+					args: { query: "hello" },
+				},
+				{
+					kind: "tool-result",
+					toolCallId: "call-1",
+					toolName: "search",
+					result: { total: 2 },
+				},
+			],
+		};
+
+		expect(serializeMessageForModelFallback(message)).toBe(
+			'[Tool Call: search] {"query":"hello"}\n[Tool Result: search] {"total":2}',
 		);
 	});
 

--- a/tests/utils/query-input.test.ts
+++ b/tests/utils/query-input.test.ts
@@ -54,6 +54,48 @@ describe("normalizeQueryRequest", () => {
 		);
 	});
 
+	it("serializes structured artifact input without preview using shared fallback formatting", () => {
+		const result = normalizeQueryRequest(
+			{
+				input: {
+					parts: [
+						{
+							kind: "artifact",
+							artifactId: "art_456",
+							name: "report.pdf",
+							mimeType: "application/pdf",
+							size: 2048,
+						},
+					],
+				},
+			},
+			{ artifactModuleConfigured: true },
+		);
+
+		expect(result.query).toBe(
+			"[Artifact: report.pdf (application/pdf, 2048 bytes)]",
+		);
+	});
+
+	it("serializes structured data input using shared fallback formatting", () => {
+		const result = normalizeQueryRequest(
+			{
+				input: {
+					parts: [
+						{
+							kind: "data",
+							mimeType: "application/json",
+							data: { total: 3 },
+						},
+					],
+				},
+			},
+			{ artifactModuleConfigured: false },
+		);
+
+		expect(result.query).toBe('application/json: {"total":3}');
+	});
+
 	it("rejects artifact input when artifact storage is not configured", () => {
 		expect(() =>
 			normalizeQueryRequest(


### PR DESCRIPTION
## Summary

Adds shared model fallback serializers for canonical multipart messages and reuses them across provider-facing and request-normalization paths.

## Changes

- Add:
  - `serializePartForModelFallback`
  - `serializeMessageForModelFallback`
  - `serializeThreadForModelFallback`
- Keep intent serializers aligned by routing them through the same fallback behavior.
- Reuse shared fallback serialization in structured query normalization.
- Cover fallback behavior for:
  - artifacts with and without `previewText`
  - structured data
  - tool-call / tool-result parts
  - thread serialization
- Add provider migration guidance to `BaseModel` JSDoc.
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.