### PR TITLE
feat: add artifact metadata and download route skeletons

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -63,6 +63,9 @@ Completed groundwork so far:
 - added provider-facing model fallback serializers for multipart messages and threads
 - updated structured query normalization to reuse shared model fallback serialization rules
 - added tests covering artifact, data, tool, and thread fallback serialization
+- added artifact metadata and download API skeletons
+- added ownership checks for artifact metadata and download access
+- added tests covering artifact service access control and download controller behavior
 
 Not completed yet:
 
@@ -928,6 +931,15 @@ Why this comes after service refactors:
 - add artifact download endpoint
 - wire uploaded artifact references into query flow
 - add auth and ownership checks for artifact access
+
+Completed groundwork in this phase:
+
+- added `ArtifactService` for artifact metadata lookup and download access
+- added artifact ownership checks based on `artifact.userId`
+- added `ArtifactApiController` handlers for metadata lookup and binary download
+- added `/api/artifacts/:id` and `/api/artifacts/:id/download` route skeletons
+- mounted artifact API routes only when an `ArtifactModule` is configured
+- added focused tests for artifact service access control and artifact download response behavior
 
 ## Phase 11. A2A Expansion
 

--- a/src/container/controllers.ts
+++ b/src/container/controllers.ts
@@ -4,6 +4,7 @@ import {
 	getModelModule,
 } from "@/config/modules";
 import { AgentApiController } from "@/controllers/api/agent.api.controller";
+import { ArtifactApiController } from "@/controllers/api/artifact.api.controller";
 import { IntentApiController } from "@/controllers/api/intent.api.controller";
 import { ModelApiController } from "@/controllers/api/model.api.controller";
 import { ThreadApiController } from "@/controllers/api/threads.api.controller";
@@ -24,6 +25,7 @@ export class ControllerContainer {
 	private _intentController?: IntentController;
 	private _modelApiController?: ModelApiController;
 	private _agentApiController?: AgentApiController;
+	private _artifactApiController?: ArtifactApiController;
 	private _threadApiController?: ThreadApiController;
 	private _intentApiController?: IntentApiController;
 	private _workflowTemplateApiController?: WorkflowTemplateApiController;
@@ -66,6 +68,15 @@ export class ControllerContainer {
 		return this._agentApiController;
 	}
 
+	getArtifactApiController(): ArtifactApiController {
+		if (!this._artifactApiController) {
+			this._artifactApiController = new ArtifactApiController(
+				this.services.getArtifactService(),
+			);
+		}
+		return this._artifactApiController;
+	}
+
 	getThreadApiController(): ThreadApiController {
 		if (!this._threadApiController) {
 			this._threadApiController = new ThreadApiController(getMemoryModule());
@@ -104,6 +115,7 @@ export class ControllerContainer {
 		this._intentController = undefined;
 		this._modelApiController = undefined;
 		this._agentApiController = undefined;
+		this._artifactApiController = undefined;
 		this._threadApiController = undefined;
 		this._intentApiController = undefined;
 		this._workflowTemplateApiController = undefined;

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -64,6 +64,9 @@ class Container {
 	getAgentApiController() {
 		return this._controllers.getAgentApiController();
 	}
+	getArtifactApiController() {
+		return this._controllers.getArtifactApiController();
+	}
 	getThreadApiController() {
 		return this._controllers.getThreadApiController();
 	}

--- a/src/container/services.ts
+++ b/src/container/services.ts
@@ -1,11 +1,13 @@
 import {
 	getA2AModule,
+	getArtifactModule,
 	getMCPModule,
 	getMemoryModule,
 	getModelModule,
 } from "@/config/modules";
 import { getOnIntentFallback } from "@/config/options";
 import { A2AService } from "@/services/a2a.service";
+import { ArtifactService } from "@/services/artifact.service";
 import { IntentFulfillService } from "@/services/intents/fulfill.service";
 import { IntentTriggerService } from "@/services/intents/trigger.service";
 import { PIIService } from "@/services/pii.service";
@@ -28,6 +30,7 @@ export class ServiceContainer {
 	private _queryService?: QueryService;
 	private _a2aService?: A2AService;
 	private _piiService?: PIIService;
+	private _artifactService?: ArtifactService;
 	private _userWorkflowService?: UserWorkflowService;
 	private _userWorkflowCoordinatorService?: UserWorkflowCoordinatorService;
 	private _workflowExecutionService?: WorkflowExecutionService;
@@ -92,6 +95,13 @@ export class ServiceContainer {
 		return this._a2aService;
 	}
 
+	getArtifactService(): ArtifactService {
+		if (!this._artifactService) {
+			this._artifactService = new ArtifactService(getArtifactModule());
+		}
+		return this._artifactService;
+	}
+
 	getUserWorkflowService(): UserWorkflowService {
 		if (!this._userWorkflowService) {
 			this._userWorkflowService = new UserWorkflowService(
@@ -147,6 +157,7 @@ export class ServiceContainer {
 		this._queryService = undefined;
 		this._a2aService = undefined;
 		this._piiService = undefined;
+		this._artifactService = undefined;
 		this._userWorkflowService = undefined;
 		this._userWorkflowCoordinatorService = undefined;
 		this._workflowExecutionService = undefined;

--- a/src/controllers/api/artifact.api.controller.ts
+++ b/src/controllers/api/artifact.api.controller.ts
@@ -1,0 +1,55 @@
+import type { NextFunction, Request, Response } from "express";
+import type { ArtifactService } from "@/services/artifact.service";
+
+export class ArtifactApiController {
+	private artifactService: ArtifactService;
+
+	constructor(artifactService: ArtifactService) {
+		this.artifactService = artifactService;
+	}
+
+	public handleGetArtifact = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const { id: artifactId } = req.params as { id: string };
+			const userId = res.locals.userId || "";
+			const artifact = await this.artifactService.getArtifact(
+				userId,
+				artifactId,
+			);
+			res.json(artifact);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleDownloadArtifact = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const { id: artifactId } = req.params as { id: string };
+			const userId = res.locals.userId || "";
+			const download = await this.artifactService.openDownload(
+				userId,
+				artifactId,
+			);
+
+			res.setHeader("Content-Type", download.mimeType);
+			if (typeof download.contentLength === "number") {
+				res.setHeader("Content-Length", String(download.contentLength));
+			}
+			if (download.fileName) {
+				res.attachment(download.fileName);
+			}
+
+			res.send(Buffer.from(download.body));
+		} catch (error) {
+			next(error);
+		}
+	};
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,6 @@
 export { A2AController } from "./a2a.controller.js";
 export { AgentApiController } from "./api/agent.api.controller.js";
+export { ArtifactApiController } from "./api/artifact.api.controller.js";
 export { ModelApiController } from "./api/model.api.controller.js";
 export { ThreadApiController } from "./api/threads.api.controller.js";
 export { QueryController } from "./query.controller.js";

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
-import { getMemoryModule } from "@/config/modules";
+import { getArtifactModule, getMemoryModule } from "@/config/modules";
 import { createAgentApiRouter } from "./api/agent.routes.js";
+import { createArtifactApiRouter } from "./api/artifacts.routes.js";
 import { createIntentApiRouter } from "./api/intent.routes.js";
 import { createModelApiRouter } from "./api/model.routes.js";
 import { createThreadApiRouter } from "./api/threads.routes.js";
@@ -12,6 +13,9 @@ export const createApiRouter = (): Router => {
 
 	router.use("/model", createModelApiRouter());
 	router.use("/agent", createAgentApiRouter());
+	if (getArtifactModule()) {
+		router.use("/artifacts", createArtifactApiRouter());
+	}
 
 	const memoryModule = getMemoryModule();
 	if (memoryModule) {

--- a/src/routes/api/artifacts.routes.ts
+++ b/src/routes/api/artifacts.routes.ts
@@ -1,0 +1,44 @@
+import {
+	type NextFunction,
+	type Request,
+	type Response,
+	Router,
+} from "express";
+import { StatusCodes } from "http-status-codes";
+import { getArtifactModule } from "@/config/modules";
+import { container } from "@/container";
+import { AinHttpError } from "@/types/agent";
+
+export const createArtifactApiRouter = (): Router => {
+	const router = Router();
+	const artifactApiController = container.getArtifactApiController();
+
+	const checkArtifactModule = (
+		_req: Request,
+		_res: Response,
+		next: NextFunction,
+	) => {
+		if (!getArtifactModule()) {
+			throw new AinHttpError(
+				StatusCodes.SERVICE_UNAVAILABLE,
+				"Artifact module is not initialized",
+				"ARTIFACT_STORE_NOT_CONFIGURED",
+			);
+		}
+		next();
+	};
+
+	// APIs (prefix: /api/artifacts)
+	router.get(
+		"/:id",
+		checkArtifactModule,
+		artifactApiController.handleGetArtifact,
+	);
+	router.get(
+		"/:id/download",
+		checkArtifactModule,
+		artifactApiController.handleDownloadArtifact,
+	);
+
+	return router;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 export { createA2ARouter } from "./a2a.routes.js";
 export { createAgentApiRouter } from "./api/agent.routes.js";
+export { createArtifactApiRouter } from "./api/artifacts.routes.js";
 export { createModelApiRouter } from "./api/model.routes.js";
 export { createThreadApiRouter } from "./api/threads.routes.js";
 export { createApiRouter } from "./api.routes.js";

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -1,0 +1,60 @@
+import { StatusCodes } from "http-status-codes";
+import type { ArtifactModule } from "@/modules";
+import { AinHttpError } from "@/types/agent";
+import type { ArtifactDownloadResult, ArtifactObject } from "@/types/artifact";
+
+export class ArtifactService {
+	private artifactModule?: ArtifactModule;
+
+	constructor(artifactModule?: ArtifactModule) {
+		this.artifactModule = artifactModule;
+	}
+
+	private getStore() {
+		const store = this.artifactModule?.getStore();
+		if (!store) {
+			throw new AinHttpError(
+				StatusCodes.SERVICE_UNAVAILABLE,
+				"Artifact module is not initialized",
+				"ARTIFACT_STORE_NOT_CONFIGURED",
+			);
+		}
+		return store;
+	}
+
+	private assertArtifactAccess(userId: string, artifact: ArtifactObject): void {
+		if (artifact.userId && artifact.userId !== userId) {
+			throw new AinHttpError(
+				StatusCodes.FORBIDDEN,
+				"Artifact access denied",
+				"ARTIFACT_ACCESS_DENIED",
+			);
+		}
+	}
+
+	public async getArtifact(
+		userId: string,
+		artifactId: string,
+	): Promise<ArtifactObject> {
+		const store = this.getStore();
+		const artifact = await store.get(artifactId);
+		if (!artifact) {
+			throw new AinHttpError(
+				StatusCodes.NOT_FOUND,
+				"Artifact not found",
+				"ARTIFACT_NOT_FOUND",
+			);
+		}
+
+		this.assertArtifactAccess(userId, artifact);
+		return artifact;
+	}
+
+	public async openDownload(
+		userId: string,
+		artifactId: string,
+	): Promise<ArtifactDownloadResult> {
+		await this.getArtifact(userId, artifactId);
+		return this.getStore().openDownload(artifactId);
+	}
+}

--- a/tests/controllers/api/artifact.api.controller.test.ts
+++ b/tests/controllers/api/artifact.api.controller.test.ts
@@ -1,0 +1,62 @@
+import type { NextFunction, Request, Response } from "express";
+import { ArtifactApiController } from "@/controllers/api/artifact.api.controller";
+
+describe("ArtifactApiController", () => {
+	it("returns artifact metadata as JSON", async () => {
+		const controller = new ArtifactApiController({
+			getArtifact: jest.fn(async () => ({
+				artifactId: "art-1",
+				name: "report.pdf",
+			})),
+			openDownload: jest.fn(),
+		} as any);
+
+		const json = jest.fn();
+		const req = { params: { id: "art-1" } } as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			json,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleGetArtifact(req, res, next);
+
+		expect(json).toHaveBeenCalledWith({
+			artifactId: "art-1",
+			name: "report.pdf",
+		});
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("streams artifact downloads with headers", async () => {
+		const controller = new ArtifactApiController({
+			getArtifact: jest.fn(),
+			openDownload: jest.fn(async () => ({
+				body: new Uint8Array([1, 2, 3]),
+				mimeType: "application/pdf",
+				fileName: "report.pdf",
+				contentLength: 3,
+			})),
+		} as any);
+
+		const setHeader = jest.fn();
+		const attachment = jest.fn();
+		const send = jest.fn();
+		const req = { params: { id: "art-1" } } as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			setHeader,
+			attachment,
+			send,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleDownloadArtifact(req, res, next);
+
+		expect(setHeader).toHaveBeenCalledWith("Content-Type", "application/pdf");
+		expect(setHeader).toHaveBeenCalledWith("Content-Length", "3");
+		expect(attachment).toHaveBeenCalledWith("report.pdf");
+		expect(send).toHaveBeenCalledWith(Buffer.from(new Uint8Array([1, 2, 3])));
+		expect(next).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -1,0 +1,94 @@
+import { ArtifactService } from "@/services/artifact.service";
+
+describe("ArtifactService", () => {
+	it("returns artifact metadata when the user owns the artifact", async () => {
+		const get = jest.fn(async () => ({
+			artifactId: "art-1",
+			userId: "user-1",
+			status: "ready" as const,
+			name: "report.pdf",
+			mimeType: "application/pdf",
+			size: 1024,
+			storageKey: "artifacts/report.pdf",
+			createdAt: 100,
+		}));
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get,
+					put: jest.fn(),
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(service.getArtifact("user-1", "art-1")).resolves.toMatchObject({
+			artifactId: "art-1",
+			name: "report.pdf",
+		});
+		expect(get).toHaveBeenCalledWith("art-1");
+	});
+
+	it("rejects metadata access when the artifact belongs to another user", async () => {
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: async () => ({
+						artifactId: "art-1",
+						userId: "other-user",
+						status: "ready" as const,
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						storageKey: "artifacts/report.pdf",
+						createdAt: 100,
+					}),
+					put: jest.fn(),
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(service.getArtifact("user-1", "art-1")).rejects.toMatchObject({
+			message: "Artifact access denied",
+			code: "ARTIFACT_ACCESS_DENIED",
+		});
+	});
+
+	it("opens downloads after access checks", async () => {
+		const openDownload = jest.fn(async () => ({
+			body: new Uint8Array([1, 2, 3]),
+			mimeType: "application/pdf",
+			fileName: "report.pdf",
+			contentLength: 3,
+		}));
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: async () => ({
+						artifactId: "art-1",
+						userId: "user-1",
+						status: "ready" as const,
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						storageKey: "artifacts/report.pdf",
+						createdAt: 100,
+					}),
+					put: jest.fn(),
+					delete: jest.fn(),
+					openDownload,
+				}) as any,
+		} as any);
+
+		await expect(service.openDownload("user-1", "art-1")).resolves.toEqual({
+			body: new Uint8Array([1, 2, 3]),
+			mimeType: "application/pdf",
+			fileName: "report.pdf",
+			contentLength: 3,
+		});
+		expect(openDownload).toHaveBeenCalledWith("art-1");
+	});
+});


### PR DESCRIPTION
## Summary

Adds the first artifact API skeletons for metadata lookup and binary download.

## Changes

- Add `ArtifactService` for:
  - artifact metadata lookup
  - download access
  - ownership checks
- Add `ArtifactApiController`.
- Add routes:
  - `GET /api/artifacts/:id`
  - `GET /api/artifacts/:id/download`
- Mount artifact API routes only when an `ArtifactModule` is configured.
- Add tests for:
  - artifact ownership/access control
  - artifact download response behavior
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.