### PR TITLE
Feat/artifact upload json endpoint

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -66,6 +66,9 @@ Completed groundwork so far:
 - added artifact metadata and download API skeletons
 - added ownership checks for artifact metadata and download access
 - added tests covering artifact service access control and download controller behavior
+- added JSON/base64 artifact upload endpoint scaffolding
+- added upload request validation for required fields and invalid base64 payloads
+- added tests covering artifact upload service wiring and controller validation behavior
 
 Not completed yet:
 
@@ -940,6 +943,9 @@ Completed groundwork in this phase:
 - added `/api/artifacts/:id` and `/api/artifacts/:id/download` route skeletons
 - mounted artifact API routes only when an `ArtifactModule` is configured
 - added focused tests for artifact service access control and artifact download response behavior
+- added `POST /api/artifacts` for JSON/base64 uploads
+- added controller-level validation for upload name, mime type, optional linkage metadata, and base64 payloads
+- added focused tests for artifact upload service wiring and invalid upload request handling
 
 ## Phase 11. A2A Expansion
 

--- a/src/controllers/api/artifact.api.controller.ts
+++ b/src/controllers/api/artifact.api.controller.ts
@@ -1,5 +1,94 @@
 import type { NextFunction, Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
 import type { ArtifactService } from "@/services/artifact.service";
+import { AinHttpError } from "@/types/agent";
+import type { ArtifactPutInput } from "@/types/artifact";
+
+type ArtifactUploadRequestBody = {
+	name?: unknown;
+	mimeType?: unknown;
+	data?: unknown;
+	threadId?: unknown;
+	messageId?: unknown;
+	metadata?: unknown;
+};
+
+const BASE64_PATTERN =
+	/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function validateUploadBody(
+	body: ArtifactUploadRequestBody,
+): Omit<ArtifactPutInput, "userId"> {
+	if (typeof body.name !== "string" || body.name.trim() === "") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload requires a non-empty string 'name' field.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (typeof body.mimeType !== "string" || body.mimeType.trim() === "") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload requires a non-empty string 'mimeType' field.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (typeof body.data !== "string" || body.data.trim() === "") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload requires a base64 string 'data' field.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (!BASE64_PATTERN.test(body.data)) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload 'data' must be a valid base64 string.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (body.threadId !== undefined && typeof body.threadId !== "string") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload 'threadId' must be a string when provided.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (body.messageId !== undefined && typeof body.messageId !== "string") {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload 'messageId' must be a string when provided.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	if (
+		body.metadata !== undefined &&
+		(typeof body.metadata !== "object" ||
+			body.metadata === null ||
+			Array.isArray(body.metadata))
+	) {
+		throw new AinHttpError(
+			StatusCodes.BAD_REQUEST,
+			"Artifact upload 'metadata' must be an object when provided.",
+			"INVALID_ARTIFACT_UPLOAD",
+		);
+	}
+
+	return {
+		name: body.name,
+		mimeType: body.mimeType,
+		data: Buffer.from(body.data, "base64"),
+		threadId: body.threadId,
+		messageId: body.messageId,
+		metadata: body.metadata as Record<string, unknown> | undefined,
+	};
+}
 
 export class ArtifactApiController {
 	private artifactService: ArtifactService;
@@ -21,6 +110,21 @@ export class ArtifactApiController {
 				artifactId,
 			);
 			res.json(artifact);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleUploadArtifact = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const input = validateUploadBody(req.body as ArtifactUploadRequestBody);
+			const artifact = await this.artifactService.uploadArtifact(userId, input);
+			res.status(StatusCodes.CREATED).json(artifact);
 		} catch (error) {
 			next(error);
 		}

--- a/src/routes/api/artifacts.routes.ts
+++ b/src/routes/api/artifacts.routes.ts
@@ -29,6 +29,11 @@ export const createArtifactApiRouter = (): Router => {
 	};
 
 	// APIs (prefix: /api/artifacts)
+	router.post(
+		"/",
+		checkArtifactModule,
+		artifactApiController.handleUploadArtifact,
+	);
 	router.get(
 		"/:id",
 		checkArtifactModule,

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -1,7 +1,11 @@
 import { StatusCodes } from "http-status-codes";
 import type { ArtifactModule } from "@/modules";
 import { AinHttpError } from "@/types/agent";
-import type { ArtifactDownloadResult, ArtifactObject } from "@/types/artifact";
+import type {
+	ArtifactDownloadResult,
+	ArtifactObject,
+	ArtifactPutInput,
+} from "@/types/artifact";
 
 export class ArtifactService {
 	private artifactModule?: ArtifactModule;
@@ -56,5 +60,15 @@ export class ArtifactService {
 	): Promise<ArtifactDownloadResult> {
 		await this.getArtifact(userId, artifactId);
 		return this.getStore().openDownload(artifactId);
+	}
+
+	public async uploadArtifact(
+		userId: string,
+		input: Omit<ArtifactPutInput, "userId">,
+	): Promise<ArtifactObject> {
+		return this.getStore().put({
+			...input,
+			userId,
+		});
 	}
 }

--- a/tests/controllers/api/artifact.api.controller.test.ts
+++ b/tests/controllers/api/artifact.api.controller.test.ts
@@ -2,8 +2,94 @@ import type { NextFunction, Request, Response } from "express";
 import { ArtifactApiController } from "@/controllers/api/artifact.api.controller";
 
 describe("ArtifactApiController", () => {
+	it("uploads artifacts from JSON/base64 input", async () => {
+		const controller = new ArtifactApiController({
+			uploadArtifact: jest.fn(async (_userId, input) => ({
+				artifactId: "art-1",
+				userId: "user-1",
+				status: "uploaded" as const,
+				name: input.name,
+				mimeType: input.mimeType,
+				size: input.data.length,
+				storageKey: "artifacts/report.pdf",
+				threadId: input.threadId,
+				messageId: input.messageId,
+				metadata: input.metadata,
+				createdAt: 100,
+			})),
+			getArtifact: jest.fn(),
+			openDownload: jest.fn(),
+		} as any);
+
+		const json = jest.fn();
+		const status = jest.fn().mockReturnValue({ json });
+		const req = {
+			body: {
+				name: "report.pdf",
+				mimeType: "application/pdf",
+				data: Buffer.from("hello").toString("base64"),
+				threadId: "thread-1",
+				messageId: "msg-1",
+				metadata: { source: "upload" },
+			},
+		} as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			status,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleUploadArtifact(req, res, next);
+
+		expect(status).toHaveBeenCalledWith(201);
+		expect(json).toHaveBeenCalledWith({
+			artifactId: "art-1",
+			userId: "user-1",
+			status: "uploaded",
+			name: "report.pdf",
+			mimeType: "application/pdf",
+			size: 5,
+			storageKey: "artifacts/report.pdf",
+			threadId: "thread-1",
+			messageId: "msg-1",
+			metadata: { source: "upload" },
+			createdAt: 100,
+		});
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("passes upload validation errors to next", async () => {
+		const controller = new ArtifactApiController({
+			uploadArtifact: jest.fn(),
+			getArtifact: jest.fn(),
+			openDownload: jest.fn(),
+		} as any);
+
+		const req = {
+			body: {
+				name: "report.pdf",
+				mimeType: "application/pdf",
+				data: "not base64!!!",
+			},
+		} as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleUploadArtifact(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		const error = (next as jest.Mock).mock.calls[0][0];
+		expect(error.message).toBe(
+			"Artifact upload 'data' must be a valid base64 string.",
+		);
+		expect(error.code).toBe("INVALID_ARTIFACT_UPLOAD");
+	});
+
 	it("returns artifact metadata as JSON", async () => {
 		const controller = new ArtifactApiController({
+			uploadArtifact: jest.fn(),
 			getArtifact: jest.fn(async () => ({
 				artifactId: "art-1",
 				name: "report.pdf",
@@ -30,6 +116,7 @@ describe("ArtifactApiController", () => {
 
 	it("streams artifact downloads with headers", async () => {
 		const controller = new ArtifactApiController({
+			uploadArtifact: jest.fn(),
 			getArtifact: jest.fn(),
 			openDownload: jest.fn(async () => ({
 				body: new Uint8Array([1, 2, 3]),

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -1,6 +1,60 @@
 import { ArtifactService } from "@/services/artifact.service";
 
 describe("ArtifactService", () => {
+	it("uploads artifacts with the authenticated user attached", async () => {
+		const put = jest.fn(async (input) => ({
+			artifactId: "art-1",
+			userId: input.userId,
+			threadId: input.threadId,
+			messageId: input.messageId,
+			status: "uploaded" as const,
+			name: input.name,
+			mimeType: input.mimeType,
+			size: input.data.length,
+			storageKey: "artifacts/report.pdf",
+			metadata: input.metadata,
+			createdAt: 100,
+		}));
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put,
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(
+			service.uploadArtifact("user-1", {
+				name: "report.pdf",
+				mimeType: "application/pdf",
+				data: new Uint8Array([1, 2, 3]),
+				threadId: "thread-1",
+				messageId: "msg-1",
+				metadata: { source: "upload" },
+			}),
+		).resolves.toMatchObject({
+			artifactId: "art-1",
+			userId: "user-1",
+			threadId: "thread-1",
+			messageId: "msg-1",
+			name: "report.pdf",
+			metadata: { source: "upload" },
+		});
+
+		expect(put).toHaveBeenCalledWith({
+			name: "report.pdf",
+			mimeType: "application/pdf",
+			data: new Uint8Array([1, 2, 3]),
+			userId: "user-1",
+			threadId: "thread-1",
+			messageId: "msg-1",
+			metadata: { source: "upload" },
+		});
+	});
+
 	it("returns artifact metadata when the user owns the artifact", async () => {
 		const get = jest.fn(async () => ({
 			artifactId: "art-1",


### PR DESCRIPTION
## Summary

Adds a first artifact upload API using JSON/base64 input so clients can create artifact records before referencing them from structured `/query` input.

## Changes

- Add `POST /api/artifacts`.
- Add `ArtifactService.uploadArtifact(...)`.
- Add controller validation for:
  - `name`
  - `mimeType`
  - base64 `data`
  - optional `threadId`
  - optional `messageId`
  - optional `metadata`
- Attach the authenticated `userId` to uploaded artifact writes.
- Return `INVALID_ARTIFACT_UPLOAD` for malformed upload requests.
- Add focused tests for:
  - upload service wiring
  - successful upload controller behavior
  - invalid base64 upload requests
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.