### PR TITLE
Feat/artifact query reference validation

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -69,6 +69,9 @@ Completed groundwork so far:
 - added JSON/base64 artifact upload endpoint scaffolding
 - added upload request validation for required fields and invalid base64 payloads
 - added tests covering artifact upload service wiring and controller validation behavior
+- added structured query artifact reference validation against the artifact store
+- added ready-state and ownership checks for artifact-backed query input
+- added tests covering query artifact metadata enrichment and not-ready validation failures
 
 Not completed yet:
 
@@ -946,6 +949,9 @@ Completed groundwork in this phase:
 - added `POST /api/artifacts` for JSON/base64 uploads
 - added controller-level validation for upload name, mime type, optional linkage metadata, and base64 payloads
 - added focused tests for artifact upload service wiring and invalid upload request handling
+- added query-time artifact reference validation and metadata enrichment before inference
+- added `ARTIFACT_NOT_READY` handling for artifact references that are not yet usable
+- added focused tests covering resolved query artifact metadata and stream-path validation failures
 
 ## Phase 11. A2A Expansion
 

--- a/src/container/controllers.ts
+++ b/src/container/controllers.ts
@@ -39,6 +39,7 @@ export class ControllerContainer {
 		if (!this._queryController) {
 			this._queryController = new QueryController(
 				this.services.getQueryService(),
+				this.services.getArtifactService(),
 			);
 		}
 		return this._queryController;

--- a/src/controllers/query.controller.ts
+++ b/src/controllers/query.controller.ts
@@ -2,16 +2,53 @@ import { randomUUID } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { getArtifactModule } from "@/config/modules";
 import type { QueryService } from "@/services";
+import type { ArtifactService } from "@/services/artifact.service";
 import { type CanonicalMessageObject, MessageRole } from "@/types/memory";
+import type { QueryMessageInput } from "@/types/message-input";
 import { loggers } from "@/utils/logger";
-import { createTextMessage, extractTextContent } from "@/utils/message";
+import {
+	createModelInputMessageFromQueryInput,
+	createTextMessage,
+	extractTextContent,
+	serializeMessageForModelFallback,
+} from "@/utils/message";
 import { normalizeQueryRequest } from "@/utils/query-input";
 
 export class QueryController {
 	private queryService: QueryService;
+	private artifactService?: ArtifactService;
 
-	constructor(queryService: QueryService) {
+	constructor(queryService: QueryService, artifactService?: ArtifactService) {
 		this.queryService = queryService;
+		this.artifactService = artifactService;
+	}
+
+	private async normalizeAndResolveInput(
+		body: unknown,
+		userId: string,
+	): Promise<{
+		input: QueryMessageInput;
+		query: string;
+		displayQuery?: string;
+	}> {
+		const normalized = normalizeQueryRequest(body, {
+			artifactModuleConfigured: !!getArtifactModule(),
+		});
+
+		const input = this.artifactService
+			? await this.artifactService.resolveQueryInputArtifacts(
+					userId,
+					normalized.input,
+				)
+			: normalized.input;
+
+		return {
+			input,
+			query: serializeMessageForModelFallback(
+				createModelInputMessageFromQueryInput({ input }),
+			),
+			displayQuery: normalized.displayQuery,
+		};
 	}
 
 	public handleQueryRequest = async (
@@ -23,9 +60,8 @@ export class QueryController {
 		const userId = res.locals.userId;
 
 		try {
-			const { input, query, displayQuery } = normalizeQueryRequest(req.body, {
-				artifactModuleConfigured: !!getArtifactModule(),
-			});
+			const { input, query, displayQuery } =
+				await this.normalizeAndResolveInput(req.body, userId);
 			const stream = this.queryService.handleQuery(
 				{ type, userId, threadId, workflowId, title },
 				{ input, query, displayQuery },
@@ -60,13 +96,23 @@ export class QueryController {
 	public handleQueryStreamRequest = async (
 		req: Request,
 		res: Response,
-		_next: NextFunction,
+		next: NextFunction,
 	) => {
 		const { type, threadId, workflowId, title } = req.body;
 		const userId = res.locals.userId;
-		const { input, query, displayQuery } = normalizeQueryRequest(req.body, {
-			artifactModuleConfigured: !!getArtifactModule(),
-		});
+		let input: QueryMessageInput;
+		let query: string;
+		let displayQuery: string | undefined;
+
+		try {
+			({ input, query, displayQuery } = await this.normalizeAndResolveInput(
+				req.body,
+				userId,
+			));
+		} catch (error) {
+			next(error);
+			return;
+		}
 
 		res.writeHead(200, {
 			"Content-Type": "text/event-stream",

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -6,6 +6,10 @@ import type {
 	ArtifactObject,
 	ArtifactPutInput,
 } from "@/types/artifact";
+import type {
+	QueryArtifactInputPart,
+	QueryMessageInput,
+} from "@/types/message-input";
 
 export class ArtifactService {
 	private artifactModule?: ArtifactModule;
@@ -34,6 +38,20 @@ export class ArtifactService {
 				"ARTIFACT_ACCESS_DENIED",
 			);
 		}
+	}
+
+	private assertArtifactReady(artifact: ArtifactObject): void {
+		if (artifact.status !== "ready") {
+			throw new AinHttpError(
+				StatusCodes.CONFLICT,
+				"Artifact is not ready",
+				"ARTIFACT_NOT_READY",
+			);
+		}
+	}
+
+	private buildDownloadUrl(artifactId: string): string {
+		return `/api/artifacts/${artifactId}/download`;
 	}
 
 	public async getArtifact(
@@ -70,5 +88,35 @@ export class ArtifactService {
 			...input,
 			userId,
 		});
+	}
+
+	public async resolveQueryInputArtifacts(
+		userId: string,
+		input: QueryMessageInput,
+	): Promise<QueryMessageInput> {
+		const parts = await Promise.all(
+			input.parts.map(async (part) => {
+				if (part.kind !== "artifact") {
+					return part;
+				}
+
+				const artifact = await this.getArtifact(userId, part.artifactId);
+				this.assertArtifactReady(artifact);
+
+				const resolvedPart: QueryArtifactInputPart = {
+					kind: "artifact",
+					artifactId: artifact.artifactId,
+					name: artifact.name,
+					mimeType: artifact.mimeType,
+					size: artifact.size,
+					downloadUrl: this.buildDownloadUrl(artifact.artifactId),
+					previewText: artifact.previewText,
+				};
+
+				return resolvedPart;
+			}),
+		);
+
+		return { parts };
 	}
 }

--- a/tests/controllers/query.controller.test.ts
+++ b/tests/controllers/query.controller.test.ts
@@ -39,6 +39,8 @@ describe("QueryController", () => {
 
 		const queryController = new QueryController({
 			handleQuery,
+		} as any, {
+			resolveQueryInputArtifacts: jest.fn(async (_userId, input) => input),
 		} as any);
 
 		const req = {
@@ -103,6 +105,8 @@ describe("QueryController", () => {
 	it("passes validation errors to next", async () => {
 		const queryController = new QueryController({
 			handleQuery: jest.fn(),
+		} as any, {
+			resolveQueryInputArtifacts: jest.fn(),
 		} as any);
 
 		const req = {
@@ -125,5 +129,151 @@ describe("QueryController", () => {
 			"Artifact input requires an artifact module to be configured.",
 		);
 		expect(error.code).toBe("ARTIFACT_STORE_NOT_CONFIGURED");
+	});
+
+	it("resolves artifact references before calling QueryService", async () => {
+		jest.mocked(getArtifactModule).mockReturnValue({} as any);
+
+		const finalMessage = {
+			messageId: "msg-1",
+			role: "MODEL" as const,
+			timestamp: 123,
+			schemaVersion: 2 as const,
+			parts: [{ kind: "text" as const, text: "ok" }],
+		};
+
+		const handleQuery = jest.fn(async function* () {
+			return finalMessage;
+		});
+		const resolveQueryInputArtifacts = jest.fn(async (_userId, _input) => ({
+			parts: [
+				{ kind: "text" as const, text: "Review this file" },
+				{
+					kind: "artifact" as const,
+					artifactId: "art-1",
+					name: "report.pdf",
+					mimeType: "application/pdf",
+					size: 1024,
+					downloadUrl: "/api/artifacts/art-1/download",
+					previewText: "Quarterly report preview",
+				},
+			],
+		}));
+
+		const queryController = new QueryController(
+			{
+				handleQuery,
+			} as any,
+			{
+				resolveQueryInputArtifacts,
+			} as any,
+		);
+
+		const req = {
+			body: {
+				type: "CHAT",
+				input: {
+					parts: [
+						{ kind: "text", text: "Review this file" },
+						{ kind: "artifact", artifactId: "art-1" },
+					],
+				},
+			},
+		} as Request;
+
+		const json = jest.fn();
+		const status = jest.fn().mockReturnValue({ json });
+		const res = {
+			locals: { userId: "user-1" },
+			status,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await queryController.handleQueryRequest(req, res, next);
+
+		expect(resolveQueryInputArtifacts).toHaveBeenCalledWith("user-1", {
+			parts: [
+				{ kind: "text", text: "Review this file" },
+				{ kind: "artifact", artifactId: "art-1" },
+			],
+		});
+		expect(handleQuery).toHaveBeenCalledWith(
+			{
+				type: "CHAT",
+				userId: "user-1",
+				threadId: undefined,
+				workflowId: undefined,
+				title: undefined,
+			},
+			{
+				input: {
+					parts: [
+						{ kind: "text", text: "Review this file" },
+						{
+							kind: "artifact",
+							artifactId: "art-1",
+							name: "report.pdf",
+							mimeType: "application/pdf",
+							size: 1024,
+							downloadUrl: "/api/artifacts/art-1/download",
+							previewText: "Quarterly report preview",
+						},
+					],
+				},
+				query: "Review this file\nQuarterly report preview",
+				displayQuery: undefined,
+			},
+		);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("passes artifact validation errors to next for stream requests", async () => {
+		jest.mocked(getArtifactModule).mockReturnValue({} as any);
+
+		const queryController = new QueryController(
+			{
+				handleQuery: jest.fn(),
+			} as any,
+			{
+				resolveQueryInputArtifacts: jest.fn(async () => {
+					throw Object.assign(new Error("Artifact is not ready"), {
+						code: "ARTIFACT_NOT_READY",
+					});
+				}),
+			} as any,
+		);
+
+		const writeHead = jest.fn();
+		const flushHeaders = jest.fn();
+		const write = jest.fn();
+		const end = jest.fn();
+		const req = {
+			body: {
+				type: "CHAT",
+				input: {
+					parts: [{ kind: "artifact", artifactId: "art-1" }],
+				},
+			},
+			on: jest.fn(),
+		} as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			writeHead,
+			flushHeaders,
+			write,
+			end,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await queryController.handleQueryStreamRequest(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		const error = (next as jest.Mock).mock.calls[0][0];
+		expect(error.message).toBe("Artifact is not ready");
+		expect(error.code).toBe("ARTIFACT_NOT_READY");
+		expect(writeHead).not.toHaveBeenCalled();
+		expect(flushHeaders).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
+		expect(end).not.toHaveBeenCalled();
 	});
 });

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -145,4 +145,81 @@ describe("ArtifactService", () => {
 		});
 		expect(openDownload).toHaveBeenCalledWith("art-1");
 	});
+
+	it("resolves query artifact parts with store metadata", async () => {
+		const get = jest.fn(async () => ({
+			artifactId: "art-1",
+			userId: "user-1",
+			status: "ready" as const,
+			name: "report.pdf",
+			mimeType: "application/pdf",
+			size: 1024,
+			storageKey: "artifacts/report.pdf",
+			previewText: "Quarterly report preview",
+			createdAt: 100,
+		}));
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get,
+					put: jest.fn(),
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(
+			service.resolveQueryInputArtifacts("user-1", {
+				parts: [
+					{ kind: "text", text: "Summarize this" },
+					{ kind: "artifact", artifactId: "art-1" },
+				],
+			}),
+		).resolves.toEqual({
+			parts: [
+				{ kind: "text", text: "Summarize this" },
+				{
+					kind: "artifact",
+					artifactId: "art-1",
+					name: "report.pdf",
+					mimeType: "application/pdf",
+					size: 1024,
+					downloadUrl: "/api/artifacts/art-1/download",
+					previewText: "Quarterly report preview",
+				},
+			],
+		});
+		expect(get).toHaveBeenCalledWith("art-1");
+	});
+
+	it("rejects query artifact references that are not ready", async () => {
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: async () => ({
+						artifactId: "art-1",
+						userId: "user-1",
+						status: "processing" as const,
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						storageKey: "artifacts/report.pdf",
+						createdAt: 100,
+					}),
+					put: jest.fn(),
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(
+			service.resolveQueryInputArtifacts("user-1", {
+				parts: [{ kind: "artifact", artifactId: "art-1" }],
+			}),
+		).rejects.toMatchObject({
+			message: "Artifact is not ready",
+			code: "ARTIFACT_NOT_READY",
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Validates artifact references in structured `/query` input before inference and enriches resolved artifact parts with stored metadata.

## Changes

- Add query-time artifact reference resolution in `ArtifactService`.
- Validate referenced artifacts for:
  - existence
  - ownership
  - `ready` status
- Enrich query artifact parts with:
  - `name`
  - `mimeType`
  - `size`
  - `downloadUrl`
  - `previewText`
- Reject non-ready artifacts with `ARTIFACT_NOT_READY`.
- Wire `QueryController` to resolve artifact-backed input before calling `QueryService`.
- Apply the same validation path to `/query/stream` before opening the SSE response.
- Add tests for:
  - resolved artifact metadata in structured query input
  - not-ready artifact rejection
  - stream-path validation failure before headers are written
- Update `MULTIMODAL_ARTIFACT_PLAN.md`.