### PR TITLE
feat: add A2A artifact reference support

### DIFF
--- a/src/modules/a2a/a2a.module.ts
+++ b/src/modules/a2a/a2a.module.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type {
+	Artifact as A2AArtifact,
 	AgentCard,
 	Message,
 	MessageSendParams,
 	Task,
+	TaskArtifactUpdateEvent,
 	TaskStatusUpdateEvent,
 	TextPart,
 } from "@a2a-js/sdk";
@@ -14,7 +16,13 @@ import {
 } from "@/types/connector.js";
 import { ThreadType } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
+import {
+	artifactContentPartFromA2AArtifact,
+	extractArtifactPartsFromA2AMessage,
+	serializeA2AMessageForFallback,
+} from "@/utils/a2a.js";
 import { loggers } from "@/utils/logger.js";
+import { serializePartForModelFallback } from "@/utils/message.js";
 import { A2AConnector } from "./a2a.connector.js";
 
 /**
@@ -158,6 +166,12 @@ export class A2AModule {
 		threadId: string,
 	): AsyncGenerator<StreamEvent, string, unknown> {
 		const finalText: string[] = [];
+		const seenArtifactIds = new Set<string>();
+		const appendFinalText = (value: string) => {
+			if (value && !finalText.includes(value)) {
+				finalText.push(value);
+			}
+		};
 		const connector = this.a2aConnectors.get(tool.connectorName);
 		if (!connector) {
 			loggers.a2a.error("Unknown agent:", { tool });
@@ -185,28 +199,64 @@ export class A2AModule {
 
 					if (typedEvent.status.state === "working") {
 						// thinking process event
-						const eventData = JSON.parse(
-							(typedEvent.status.message?.parts[0] as TextPart).text,
-						);
-						yield {
-							event: "thinking_process",
-							data: eventData,
-						};
+						const workingText = (
+							typedEvent.status.message?.parts[0] as TextPart | undefined
+						)?.text;
+						if (workingText) {
+							try {
+								const eventData = JSON.parse(workingText);
+								yield {
+									event: "thinking_process",
+									data: eventData,
+								};
+							} catch {
+								finalText.push(workingText);
+							}
+						}
 					} else if (typedEvent.status.state === "completed") {
-						// TODO: handle 'file', 'data' parts
-						const texts = typedEvent.status.message?.parts
-							.filter((part) => part.kind === "text")
-							.map((part: TextPart) => part.text)
-							.join("\n");
-						if (texts) {
-							finalText.push(texts);
-							yield {
-								event: "text_chunk",
-								data: { delta: texts },
-							};
+						if (typedEvent.status.message?.parts.length) {
+							const fallbackText = serializeA2AMessageForFallback(
+								typedEvent.status.message,
+							);
+							if (fallbackText) {
+								appendFinalText(fallbackText);
+								yield {
+									event: "text_chunk",
+									data: { delta: fallbackText },
+								};
+							}
+
+							const artifactParts = extractArtifactPartsFromA2AMessage(
+								typedEvent.status.message,
+							);
+							for (const artifactPart of artifactParts) {
+								if (seenArtifactIds.has(artifactPart.artifactId)) {
+									continue;
+								}
+								seenArtifactIds.add(artifactPart.artifactId);
+								yield {
+									event: "artifact_ready",
+									data: artifactPart,
+								};
+							}
 						}
 					} else {
 						// ignore other status updates
+					}
+				} else if (event.kind === "artifact-update") {
+					const artifact = artifactContentPartFromA2AArtifact(
+						(event as TaskArtifactUpdateEvent).artifact as A2AArtifact,
+					);
+					if (!seenArtifactIds.has(artifact.artifactId)) {
+						seenArtifactIds.add(artifact.artifactId);
+						yield {
+							event: "artifact_ready",
+							data: artifact,
+						};
+					}
+					const artifactText = serializePartForModelFallback(artifact);
+					if (artifactText) {
+						appendFinalText(artifactText);
 					}
 				} else if (event.kind === "message") {
 					// FIXME: handling text in 'message'?

--- a/src/services/a2a.service.ts
+++ b/src/services/a2a.service.ts
@@ -1,13 +1,28 @@
 import { randomUUID } from "node:crypto";
-import type { Task, TaskStatusUpdateEvent } from "@a2a-js/sdk";
+import type {
+	Artifact as A2AArtifact,
+	Message as A2AMessage,
+	Part as A2APart,
+	Task,
+	TaskArtifactUpdateEvent,
+	TaskStatusUpdateEvent,
+} from "@a2a-js/sdk";
 import type {
 	AgentExecutor,
 	ExecutionEventBus,
 	RequestContext,
 } from "@a2a-js/sdk/server";
 import type { ThreadType } from "@/types/memory.js";
+import {
+	createA2AArtifactsFromMessage,
+	createA2AMessagePartsFromMessage,
+	createQueryInputFromA2AMessage,
+} from "@/utils/a2a.js";
 import { loggers } from "@/utils/logger.js";
-import { extractTextContent } from "@/utils/message.js";
+import {
+	createModelInputMessageFromQueryInput,
+	serializeMessageForModelFallback,
+} from "@/utils/message.js";
 import type { QueryService } from "./query.service.js";
 
 /**
@@ -34,28 +49,55 @@ export class A2AService implements AgentExecutor {
 		contextId: string,
 		state: "working" | "failed" | "canceled" | "completed",
 		message?: string,
+		parts?: A2APart[],
 	): TaskStatusUpdateEvent => {
+		const statusMessage: A2AMessage | undefined =
+			parts && parts.length > 0
+				? {
+						kind: "message",
+						role: "agent",
+						messageId: randomUUID(),
+						parts,
+						taskId,
+						contextId,
+					}
+				: message
+					? {
+							kind: "message",
+							role: "agent",
+							messageId: randomUUID(),
+							parts: [{ kind: "text", text: message }],
+							taskId,
+							contextId,
+						}
+					: undefined;
+
 		return {
 			kind: "status-update",
 			taskId: taskId,
 			contextId: contextId,
 			status: {
 				state: state,
-				message: message
-					? {
-							kind: "message",
-							role: "agent",
-							messageId: randomUUID(),
-							parts: [{ kind: "text", text: message }],
-							taskId: taskId,
-							contextId: contextId,
-						}
-					: undefined,
+				message: statusMessage,
 				timestamp: new Date().toISOString(),
 			},
 			final: state !== "working",
 		};
 	};
+
+	private createTaskArtifactUpdateEvent(
+		taskId: string,
+		contextId: string,
+		artifact: A2AArtifact,
+	): TaskArtifactUpdateEvent {
+		return {
+			kind: "artifact-update",
+			taskId,
+			contextId,
+			artifact,
+			lastChunk: true,
+		};
+	}
 
 	async execute(
 		requestContext: RequestContext,
@@ -63,7 +105,8 @@ export class A2AService implements AgentExecutor {
 	): Promise<void> {
 		const userMessage = requestContext.userMessage;
 		// A2A context ID === AIN ADK thread ID
-		const threadId = userMessage.contextId!; // TODO: no context id case
+		const threadId =
+			userMessage.contextId || requestContext.task?.contextId || randomUUID();
 
 		const { agentId, type } = userMessage.metadata as {
 			agentId: string;
@@ -89,31 +132,33 @@ export class A2AService implements AgentExecutor {
 			eventBus.publish(initialTask);
 		}
 
-		const message: string = userMessage.parts
-			.filter((part) => part.kind === "text")
-			.map((part) => part.text)
-			.join("\n");
-		if (message.length === 0) {
+		const input = createQueryInputFromA2AMessage(userMessage);
+		if (input.parts.length === 0) {
 			loggers.server.warn(`Empty message received for task ${taskId}.`);
 			const failureUpdate = this.createTaskStatusUpdateEvent(
 				taskId,
 				threadId,
 				"failed",
-				"No message found to process.",
+				"No supported content parts found to process.",
 			);
 			eventBus.publish(failureUpdate);
 			return;
 		}
 
+		const query = serializeMessageForModelFallback(
+			createModelInputMessageFromQueryInput({ input }),
+		);
+
 		const stream = this.queryService.handleQuery(
 			{ userId: agentId, type, threadId },
-			{ query: message },
+			{ query, input },
 			true,
 		);
 
 		try {
 			let finalResponseText = "";
-			let sawCompatibilityTextChunk = false;
+			let finalResponseParts: A2APart[] | undefined;
+			let finalArtifacts: A2AArtifact[] = [];
 			for await (const event of stream) {
 				if (this.canceledTasks.has(taskId)) {
 					loggers.server.info(`Task ${taskId} was canceled.`);
@@ -127,13 +172,15 @@ export class A2AService implements AgentExecutor {
 				}
 
 				if (event.event === "text_chunk") {
-					sawCompatibilityTextChunk = true;
 					finalResponseText += event.data.delta;
-				} else if (
-					event.event === "message_complete" &&
-					!sawCompatibilityTextChunk
-				) {
-					finalResponseText = extractTextContent(event.data.message);
+				} else if (event.event === "message_complete") {
+					finalResponseText = serializeMessageForModelFallback(
+						event.data.message,
+					);
+					finalResponseParts = createA2AMessagePartsFromMessage(
+						event.data.message,
+					);
+					finalArtifacts = createA2AArtifactsFromMessage(event.data.message);
 				} else if (event.event === "thinking_process") {
 					const thinkingProcessUpdate = this.createTaskStatusUpdateEvent(
 						taskId,
@@ -145,11 +192,18 @@ export class A2AService implements AgentExecutor {
 				}
 			}
 
+			for (const artifact of finalArtifacts) {
+				eventBus.publish(
+					this.createTaskArtifactUpdateEvent(taskId, threadId, artifact),
+				);
+			}
+
 			const finalUpdate = this.createTaskStatusUpdateEvent(
 				taskId,
 				threadId,
 				"completed",
 				finalResponseText,
+				finalResponseParts,
 			);
 			eventBus.publish(finalUpdate);
 			loggers.server.info(`Task ${taskId} completed successfully.`);

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -254,7 +254,10 @@ export class IntentFulfillService {
 						// yield intermediate events and get final result
 						let result = await a2aStream.next();
 						while (!result.done) {
-							if (result.value.event === "thinking_process") {
+							if (
+								result.value.event === "thinking_process" ||
+								result.value.event === "artifact_ready"
+							) {
 								yield result.value;
 							}
 							result = await a2aStream.next();

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -1,4 +1,5 @@
 import type {
+	ArtifactContentPart,
 	CanonicalMessageObject,
 	MessageRole,
 	TextContentPart,
@@ -20,6 +21,10 @@ export type StreamEvent =
 				part: Pick<TextContentPart, "kind">;
 				delta: string;
 			};
+	  }
+	| {
+			event: "artifact_ready";
+			data: ArtifactContentPart;
 	  }
 	| {
 			event: "message_complete";

--- a/src/utils/a2a.ts
+++ b/src/utils/a2a.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import type {
+	Artifact as A2AArtifact,
+	DataPart as A2ADataPart,
+	FilePart as A2AFilePart,
+	Message as A2AMessage,
+	Part as A2APart,
+	TextPart as A2ATextPart,
+} from "@a2a-js/sdk";
+import type { ArtifactContentPart, MessageObject } from "@/types/memory.js";
+import type {
+	QueryArtifactInputPart,
+	QueryDataInputPart,
+	QueryMessageInput,
+	QueryTextInputPart,
+} from "@/types/message-input.js";
+import {
+	createModelInputMessageFromQueryInput,
+	normalizeMessageObject,
+	serializeMessageForModelFallback,
+	serializePartForModelFallback,
+} from "@/utils/message.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseArtifactMetadata(metadata: unknown): {
+	artifactId?: string;
+	size?: number;
+	previewText?: string;
+	downloadUrl?: string;
+	mimeType?: string;
+	name?: string;
+} {
+	if (!isRecord(metadata)) {
+		return {};
+	}
+
+	return {
+		artifactId:
+			typeof metadata.artifactId === "string" ? metadata.artifactId : undefined,
+		size: typeof metadata.size === "number" ? metadata.size : undefined,
+		previewText:
+			typeof metadata.previewText === "string"
+				? metadata.previewText
+				: undefined,
+		downloadUrl:
+			typeof metadata.downloadUrl === "string"
+				? metadata.downloadUrl
+				: undefined,
+		mimeType:
+			typeof metadata.mimeType === "string" ? metadata.mimeType : undefined,
+		name: typeof metadata.name === "string" ? metadata.name : undefined,
+	};
+}
+
+function buildArtifactMetadata(
+	part: ArtifactContentPart,
+): Record<string, unknown> {
+	return {
+		artifactId: part.artifactId,
+		downloadUrl: part.downloadUrl,
+		mimeType: part.mimeType,
+		name: part.name,
+		previewText: part.previewText,
+		size: part.size,
+	};
+}
+
+function textPartToQueryInputPart(part: A2ATextPart): QueryTextInputPart {
+	return {
+		kind: "text",
+		text: part.text,
+	};
+}
+
+function dataPartToQueryInputPart(part: A2ADataPart): QueryDataInputPart {
+	const mimeType =
+		isRecord(part.metadata) && typeof part.metadata.mimeType === "string"
+			? part.metadata.mimeType
+			: "application/json";
+
+	return {
+		kind: "data",
+		mimeType,
+		data: part.data,
+	};
+}
+
+function filePartToQueryInputPart(
+	part: A2AFilePart,
+	index: number,
+): QueryArtifactInputPart {
+	const metadata = parseArtifactMetadata(part.metadata);
+	const file = part.file;
+	const fallbackId =
+		"uri" in file
+			? file.uri
+			: (typeof file.name === "string" && file.name.trim()) ||
+				`a2a-file-${index}-${randomUUID()}`;
+
+	return {
+		kind: "artifact",
+		artifactId: metadata.artifactId ?? fallbackId,
+		name: file.name ?? metadata.name,
+		mimeType: file.mimeType ?? metadata.mimeType,
+		size: metadata.size,
+		downloadUrl: metadata.downloadUrl ?? ("uri" in file ? file.uri : undefined),
+		previewText: metadata.previewText,
+	};
+}
+
+export function createQueryInputFromA2AMessage(
+	message: Pick<A2AMessage, "parts">,
+): QueryMessageInput {
+	return {
+		parts: message.parts.map((part, index) => {
+			if (part.kind === "text") {
+				return textPartToQueryInputPart(part);
+			}
+			if (part.kind === "file") {
+				return filePartToQueryInputPart(part, index);
+			}
+			return dataPartToQueryInputPart(part);
+		}),
+	};
+}
+
+export function serializeA2AMessageForFallback(
+	message: Pick<A2AMessage, "parts">,
+): string {
+	return serializeMessageForModelFallback(
+		createModelInputMessageFromQueryInput({
+			input: createQueryInputFromA2AMessage(message),
+		}),
+	);
+}
+
+function createA2AFilePart(part: ArtifactContentPart): A2AFilePart | undefined {
+	if (!part.downloadUrl) {
+		return undefined;
+	}
+
+	return {
+		kind: "file",
+		file: {
+			uri: part.downloadUrl,
+			name: part.name,
+			mimeType: part.mimeType,
+		},
+		metadata: buildArtifactMetadata(part),
+	};
+}
+
+function getA2AFileUri(filePart: A2AFilePart | undefined): string | undefined {
+	if (!filePart) {
+		return undefined;
+	}
+
+	return "uri" in filePart.file ? filePart.file.uri : undefined;
+}
+
+function createA2ADataPart(part: {
+	mimeType: string;
+	data: unknown;
+}): A2ADataPart {
+	return {
+		kind: "data",
+		data: isRecord(part.data)
+			? part.data
+			: {
+					mimeType: part.mimeType,
+					value: part.data,
+				},
+		metadata: {
+			mimeType: part.mimeType,
+		},
+	};
+}
+
+export function createA2AMessagePartsFromMessage(
+	message: MessageObject,
+): A2APart[] {
+	const canonical = normalizeMessageObject(message);
+	const parts: A2APart[] = [];
+
+	for (const part of canonical.parts) {
+		if (part.kind === "text") {
+			parts.push({
+				kind: "text",
+				text: part.text,
+			});
+			continue;
+		}
+
+		if (part.kind === "artifact") {
+			const filePart = createA2AFilePart(part);
+			if (filePart) {
+				parts.push(filePart);
+			} else {
+				parts.push({
+					kind: "text",
+					text: serializePartForModelFallback(part),
+					metadata: buildArtifactMetadata(part),
+				});
+			}
+			continue;
+		}
+
+		if (part.kind === "data") {
+			parts.push(createA2ADataPart(part));
+			continue;
+		}
+
+		parts.push({
+			kind: "text",
+			text: serializePartForModelFallback(part),
+		});
+	}
+
+	return parts;
+}
+
+function createArtifactPreviewPart(part: ArtifactContentPart): A2ATextPart {
+	return {
+		kind: "text",
+		text: part.previewText?.trim() || serializePartForModelFallback(part),
+		metadata: buildArtifactMetadata(part),
+	};
+}
+
+export function createA2AArtifactsFromMessage(
+	message: MessageObject,
+): A2AArtifact[] {
+	const canonical = normalizeMessageObject(message);
+
+	return canonical.parts
+		.filter((part): part is ArtifactContentPart => part.kind === "artifact")
+		.map((part) => {
+			const previewPart = createArtifactPreviewPart(part);
+			const filePart = createA2AFilePart(part);
+
+			return {
+				artifactId: part.artifactId,
+				name: part.name,
+				description: part.previewText,
+				metadata: buildArtifactMetadata(part),
+				parts: filePart ? [previewPart, filePart] : [previewPart],
+			};
+		});
+}
+
+export function artifactContentPartFromA2AArtifact(
+	artifact: A2AArtifact,
+): ArtifactContentPart {
+	const metadata = parseArtifactMetadata(artifact.metadata);
+	const filePart = artifact.parts.find(
+		(part): part is A2AFilePart => part.kind === "file",
+	);
+	const previewPart = artifact.parts.find(
+		(part): part is A2ATextPart => part.kind === "text",
+	);
+
+	return {
+		kind: "artifact",
+		artifactId: artifact.artifactId,
+		name: artifact.name ?? filePart?.file.name ?? metadata.name,
+		mimeType: filePart?.file.mimeType ?? metadata.mimeType,
+		size: metadata.size,
+		downloadUrl: getA2AFileUri(filePart) ?? metadata.downloadUrl,
+		previewText: previewPart?.text ?? metadata.previewText,
+	};
+}
+
+export function extractArtifactPartsFromA2AMessage(
+	message: Pick<A2AMessage, "parts">,
+): ArtifactContentPart[] {
+	return message.parts
+		.filter((part): part is A2AFilePart => part.kind === "file")
+		.map((part, index) => filePartToQueryInputPart(part, index))
+		.map((part) => ({
+			kind: "artifact" as const,
+			artifactId: part.artifactId,
+			name: part.name,
+			mimeType: part.mimeType,
+			size: part.size,
+			downloadUrl: part.downloadUrl,
+			previewText: part.previewText,
+		}));
+}

--- a/tests/modules/a2a.module.test.ts
+++ b/tests/modules/a2a.module.test.ts
@@ -1,0 +1,167 @@
+import { A2AConnector } from "@/modules/a2a/a2a.connector";
+import { A2AModule } from "@/modules/a2a/a2a.module";
+import { CONNECTOR_PROTOCOL_TYPE } from "@/types/connector";
+
+describe("A2AModule", () => {
+	it("emits artifact_ready when a remote peer returns artifact references", async () => {
+		const a2aModule = new A2AModule();
+		const connector = new A2AConnector("peer", "https://peer.example");
+
+		connector.client = {
+			sendMessageStream: async function* () {
+				yield {
+					kind: "task",
+					id: "task-1",
+					contextId: "thread-1",
+					status: {
+						state: "submitted",
+						timestamp: new Date().toISOString(),
+					},
+				};
+				yield {
+					kind: "status-update",
+					taskId: "task-1",
+					contextId: "thread-1",
+					final: false,
+					status: {
+						state: "working",
+						timestamp: new Date().toISOString(),
+						message: {
+							kind: "message",
+							role: "agent",
+							messageId: "msg-working",
+							taskId: "task-1",
+							contextId: "thread-1",
+							parts: [
+								{
+									kind: "text",
+									text: JSON.stringify({
+										title: "Thinking",
+										description: "Collecting data",
+									}),
+								},
+							],
+						},
+					},
+				};
+				yield {
+					kind: "artifact-update",
+					taskId: "task-1",
+					contextId: "thread-1",
+					lastChunk: true,
+					artifact: {
+						artifactId: "art-1",
+						name: "report.pdf",
+						metadata: {
+							artifactId: "art-1",
+							size: 1024,
+							previewText: "Artifact preview",
+							downloadUrl: "https://peer.example/report.pdf",
+						},
+						parts: [
+							{ kind: "text", text: "Artifact preview" },
+							{
+								kind: "file",
+								file: {
+									uri: "https://peer.example/report.pdf",
+									name: "report.pdf",
+									mimeType: "application/pdf",
+								},
+								metadata: {
+									artifactId: "art-1",
+									size: 1024,
+									previewText: "Artifact preview",
+									downloadUrl: "https://peer.example/report.pdf",
+								},
+							},
+						],
+					},
+				};
+				yield {
+					kind: "status-update",
+					taskId: "task-1",
+					contextId: "thread-1",
+					final: true,
+					status: {
+						state: "completed",
+						timestamp: new Date().toISOString(),
+						message: {
+							kind: "message",
+							role: "agent",
+							messageId: "msg-complete",
+							taskId: "task-1",
+							contextId: "thread-1",
+							parts: [
+								{ kind: "text", text: "Here is the summary" },
+								{
+									kind: "file",
+									file: {
+										uri: "https://peer.example/report.pdf",
+										name: "report.pdf",
+										mimeType: "application/pdf",
+									},
+									metadata: {
+										artifactId: "art-1",
+										size: 1024,
+										previewText: "Artifact preview",
+										downloadUrl: "https://peer.example/report.pdf",
+									},
+								},
+							],
+						},
+					},
+				};
+			},
+		} as any;
+
+		(a2aModule as any).a2aConnectors.set("peer", connector);
+
+		const stream = a2aModule.useTool(
+			{
+				toolName: "peer-tool",
+				connectorName: "peer",
+				protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+			},
+			"hello",
+			"thread-1",
+		);
+
+		const events = [];
+		let result = await stream.next();
+		while (!result.done) {
+			events.push(result.value);
+			result = await stream.next();
+		}
+
+		expect(events).toEqual([
+			{
+				event: "thinking_process",
+				data: {
+					title: "Thinking",
+					description: "Collecting data",
+				},
+			},
+			{
+				event: "artifact_ready",
+				data: {
+					kind: "artifact",
+					artifactId: "art-1",
+					name: "report.pdf",
+					mimeType: "application/pdf",
+					size: 1024,
+					downloadUrl: "https://peer.example/report.pdf",
+					previewText: "Artifact preview",
+				},
+			},
+			{
+				event: "text_chunk",
+				data: {
+					delta: "Here is the summary\nArtifact preview",
+				},
+			},
+		]);
+		expect(result.value).toBe(
+			"[Bot Called A2A Tool peer-tool]\nArtifact preview\nHere is the summary\nArtifact preview",
+		);
+	});
+});

--- a/tests/services/a2a.service.test.ts
+++ b/tests/services/a2a.service.test.ts
@@ -65,4 +65,127 @@ describe("A2AService", () => {
 			final: true,
 		});
 	});
+
+	it("maps inbound file parts to structured input and publishes artifact updates", async () => {
+		const finalMessage = {
+			messageId: "msg-2",
+			role: MessageRole.MODEL,
+			timestamp: 456,
+			schemaVersion: 2 as const,
+			parts: [
+				{ kind: "text" as const, text: "summary ready" },
+				{
+					kind: "artifact" as const,
+					artifactId: "art-1",
+					name: "report.pdf",
+					mimeType: "application/pdf",
+					size: 1024,
+					downloadUrl: "https://agent.example/artifacts/art-1/download",
+					previewText: "Quarterly report preview",
+				},
+			],
+		};
+
+		const handleQuery = jest.fn(async function* (_threadMetadata, queryData) {
+			expect(queryData.input).toEqual({
+				parts: [
+					{ kind: "text", text: "Summarize this file" },
+					{
+						kind: "artifact",
+						artifactId: "peer-art-1",
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						downloadUrl: "https://peer.example/report.pdf",
+						previewText: "Quarterly results preview",
+					},
+				],
+			});
+			expect(queryData.query).toContain("Summarize this file");
+			expect(queryData.query).toContain("Quarterly results preview");
+
+			yield {
+				event: "message_complete" as const,
+				data: { message: finalMessage },
+			};
+			return finalMessage;
+		});
+
+		const a2aService = new A2AService({
+			handleQuery,
+		} as any);
+
+		const publish = jest.fn();
+		await a2aService.execute(
+			{
+				userMessage: {
+					metadata: {
+						agentId: "agent-1",
+						type: ThreadType.CHAT,
+					},
+					parts: [
+						{ kind: "text", text: "Summarize this file" },
+						{
+							kind: "file",
+							file: {
+								uri: "https://peer.example/report.pdf",
+								name: "report.pdf",
+								mimeType: "application/pdf",
+							},
+							metadata: {
+								artifactId: "peer-art-1",
+								size: 1024,
+								previewText: "Quarterly results preview",
+							},
+						},
+					],
+				},
+			} as any,
+			{ publish } as any,
+		);
+
+		expect(handleQuery).toHaveBeenCalledTimes(1);
+		expect(publish.mock.calls[0][0]).toMatchObject({
+			kind: "task",
+			status: { state: "submitted" },
+		});
+		expect(publish.mock.calls[1][0]).toMatchObject({
+			kind: "artifact-update",
+			artifact: {
+				artifactId: "art-1",
+				name: "report.pdf",
+				parts: [
+					{ kind: "text", text: "Quarterly report preview" },
+					{
+						kind: "file",
+						file: {
+							uri: "https://agent.example/artifacts/art-1/download",
+							name: "report.pdf",
+							mimeType: "application/pdf",
+						},
+					},
+				],
+			},
+		});
+		expect(publish.mock.calls[2][0]).toMatchObject({
+			kind: "status-update",
+			status: {
+				state: "completed",
+				message: {
+					parts: [
+						{ kind: "text", text: "summary ready" },
+						{
+							kind: "file",
+							file: {
+								uri: "https://agent.example/artifacts/art-1/download",
+								name: "report.pdf",
+								mimeType: "application/pdf",
+							},
+						},
+					],
+				},
+			},
+			final: true,
+		});
+	});
 });


### PR DESCRIPTION
## Summary

This PR expands the A2A path to support multipart/file-based artifact references instead of staying text-only.

### What changed

- added shared A2A <-> ADK multipart conversion utilities
- updated `A2AService` to:
  - convert inbound A2A file parts into structured ADK query input
  - pass structured input into `QueryService`
  - publish artifact references back as A2A `artifact-update` events
  - include multipart/file parts in final A2A completion messages
- updated `A2AModule` to:
  - consume remote A2A `artifact-update` events
  - convert remote file/artifact payloads into ADK `artifact_ready` stream events
  - preserve text fallback behavior for tool-result aggregation
- updated fulfillment flow to forward `artifact_ready` events from A2A tool execution
- added `artifact_ready` to the internal stream event contract
- added tests for:
  - inbound A2A file-to-query-input mapping
  - outbound artifact update publication
  - remote A2A artifact event consumption
