### PR TITLE
feat: align A2A card and protocol handling

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-16`
+Last updated: `2026-04-18`
 
 Completed groundwork so far:
 
@@ -72,6 +72,14 @@ Completed groundwork so far:
 - added structured query artifact reference validation against the artifact store
 - added ready-state and ownership checks for artifact-backed query input
 - added tests covering query artifact metadata enrichment and not-ready validation failures
+- added shared A2A multipart/artifact conversion utilities
+- updated A2A inbound handling to convert multipart/file parts into structured query input
+- updated A2A outbound handling to publish artifact references through A2A `artifact-update` events
+- added `artifact_ready` stream events for A2A-delivered artifact references
+- updated A2A tool consumption to handle direct `message` events as content, not only task bookkeeping
+- aligned outbound A2A sender identity and role metadata with agent-facing protocol usage
+- updated generated A2A agent cards to advertise streaming, structured modes, and a default query skill
+- added focused tests covering A2A artifact reference flow, direct message-event handling, and agent card generation
 
 Not completed yet:
 
@@ -79,7 +87,6 @@ Not completed yet:
 - full query/request/response contract refactor across streaming and provider-facing paths
 - artifact upload/download runtime APIs
 - stream event redesign
-- A2A artifact reference support
 - workflow boundary refactor
 - migration adapters for old message records
 
@@ -87,7 +94,7 @@ Not completed yet:
 
 ## Current State Summary
 
-The current implementation is effectively text-only, even though some types are loosely structured.
+The current implementation is still text-first in important inference paths, but it is no longer purely text-only.
 
 ### Text-only assumptions in the current code
 
@@ -97,8 +104,8 @@ The current implementation is effectively text-only, even though some types are 
 - `QueryService` still processes `query: string` for inference, even though it can now receive structured input for persistence
 - some runtime paths still assume `query: string`, but new message writes now converge on canonical `parts[]` messages
 - thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
-- stream output is centered on `text_chunk`
-- A2A paths read and write only text parts
+- stream output still keeps `text_chunk` as a compatibility-first event, even though canonical message events and `artifact_ready` now exist
+- A2A paths now accept multipart inputs and exchange artifact references, but still avoid raw binary forwarding
 - server middleware only handles JSON and URL-encoded input, not multipart uploads
 
 ### Important impacted files
@@ -626,13 +633,13 @@ Recommended follow-up:
 
 ## A2A Changes
 
-The current A2A path is also text-first.
+The A2A path is now multipart-aware for file references, but it still intentionally avoids raw binary forwarding.
 
-Target direction:
+Current direction:
 
-- agent card should advertise more than text-only capabilities where appropriate
-- inbound A2A messages should parse multipart content
-- outbound A2A responses should allow artifact references
+- agent card now advertises streaming and structured modes, with file mode enabled when artifact storage is configured
+- inbound A2A messages now parse multipart content into structured query input
+- outbound A2A responses now allow artifact references through `artifact-update` and multipart completion payloads
 - prefer artifact reference or downloadable URL exchange over raw binary transport
 
 Important note:
@@ -644,6 +651,13 @@ Additional recommendation:
 
 - define a canonical A2A-safe artifact reference payload shape early
 - avoid depending on provider-local download URLs when cross-agent access control would break portability
+
+Completed groundwork in this area:
+
+- added shared A2A-safe multipart/artifact conversion helpers
+- updated `A2AService` to accept multipart/file input and publish artifact reference updates
+- updated `A2AModule` to consume direct `message` events and `artifact-update` events as streamed content
+- aligned outbound sender role/metadata and generated agent-card capability declarations with the current A2A surface
 
 ---
 
@@ -959,6 +973,16 @@ Completed groundwork in this phase:
 - update agent card capabilities and modes
 - standardize artifact reference handling for A2A interoperability
 - address existing A2A TODO and FIXME items while touching the protocol surface
+
+Completed groundwork in this phase:
+
+- updated A2A inbound message handling to normalize multipart/file parts into structured query input
+- updated A2A outbound task completion to emit multipart content plus artifact references through `artifact-update`
+- added internal `artifact_ready` stream events so A2A-delivered artifact references can flow through the existing fulfillment pipeline
+- updated A2A tool consumption to process direct `message` events as real streamed content
+- aligned outbound A2A sender role and identity metadata with agent-facing protocol expectations
+- updated generated agent cards to advertise streaming, structured modes, JSON-RPC transport, and a default query skill
+- added focused tests covering A2A artifact references, direct message-event handling, outbound identity metadata, and agent card generation
 
 ## Phase 12. Workflow Boundary Review
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { AgentCard } from "@a2a-js/sdk";
+import type { AgentCard, AgentSkill } from "@a2a-js/sdk";
 import cors from "cors";
 import express, { type Response } from "express";
 import helmet from "helmet";
@@ -130,6 +130,10 @@ export class AINAgent {
 
 		// Set global agent reference
 		setAgent(this);
+		this.a2aModule?.configureIdentity({
+			agentId: this.manifest.url || this.manifest.name,
+			agentName: this.manifest.name,
+		});
 
 		this.initializeMiddlewares();
 		this.initializeRoutes();
@@ -159,6 +163,30 @@ export class AINAgent {
 	public generateAgentCard = (): AgentCard => {
 		const _url = new URL(this.manifest.url || "");
 		_url.pathname = "a2a";
+		const defaultModes = ["text", "data"];
+		if (this.artifactModule) {
+			defaultModes.push("file");
+		}
+		const skills: AgentSkill[] = [
+			{
+				id: "query",
+				name: this.manifest.name,
+				description: this.manifest.description,
+				tags: [
+					"chat",
+					"query",
+					"streaming",
+					...(this.artifactModule ? ["artifacts"] : []),
+					...(this.a2aModule ? ["a2a"] : []),
+				],
+				inputModes: [...defaultModes],
+				outputModes: [...defaultModes],
+				examples: [
+					"Summarize a document",
+					"Answer a question with streamed updates",
+				],
+			},
+		];
 
 		return {
 			name: this.manifest.name,
@@ -166,14 +194,21 @@ export class AINAgent {
 			version: version,
 			protocolVersion: "0.3.0",
 			url: _url.toString(),
+			preferredTransport: "JSONRPC",
+			additionalInterfaces: [
+				{
+					url: _url.toString(),
+					transport: "JSONRPC",
+				},
+			],
 			capabilities: {
-				streaming: true, // The new framework supports streaming
-				pushNotifications: false, // Assuming not implemented for this agent yet
-				stateTransitionHistory: true, // Agent uses history
+				streaming: true,
+				pushNotifications: false,
+				stateTransitionHistory: true,
 			},
-			defaultInputModes: ["text"],
-			defaultOutputModes: ["text", "task-status"], // task-status is a common output mode
-			skills: [],
+			defaultInputModes: defaultModes,
+			defaultOutputModes: defaultModes,
+			skills,
 			supportsAuthenticatedExtendedCard: false,
 		};
 	};

--- a/src/modules/a2a/a2a.module.ts
+++ b/src/modules/a2a/a2a.module.ts
@@ -10,6 +10,7 @@ import type {
 	TextPart,
 } from "@a2a-js/sdk";
 import { type Client as A2AClient, ClientFactory } from "@a2a-js/sdk/client";
+import { getManifest } from "@/config/manifest.js";
 import {
 	CONNECTOR_PROTOCOL_TYPE,
 	type ConnectorTool,
@@ -37,7 +38,50 @@ export class A2AModule {
 	private a2aConnectors: Map<string, A2AConnector> = new Map();
 	/** Map of session IDs to their A2A session state */
 	private a2aTasks: Map<string, string> = new Map();
-	private agentId: string = randomUUID(); /* FIXME */
+	private agentId?: string;
+	private agentName?: string;
+
+	public configureIdentity(identity: {
+		agentId?: string;
+		agentName?: string;
+	}): void {
+		if (identity.agentId?.trim()) {
+			this.agentId = identity.agentId;
+		}
+		if (identity.agentName?.trim()) {
+			this.agentName = identity.agentName;
+		}
+	}
+
+	private getAgentId(): string {
+		if (this.agentId) {
+			return this.agentId;
+		}
+
+		try {
+			const manifest = getManifest();
+			this.agentId = manifest.url || manifest.name;
+		} catch {
+			this.agentId = randomUUID();
+		}
+
+		return this.agentId;
+	}
+
+	private getAgentName(): string | undefined {
+		if (this.agentName) {
+			return this.agentName;
+		}
+
+		try {
+			const manifest = getManifest();
+			this.agentName = manifest.name;
+		} catch {
+			this.agentName = undefined;
+		}
+
+		return this.agentName;
+	}
 
 	/**
 	 * Registers a new A2A peer server URL for connection.
@@ -127,9 +171,10 @@ export class A2AModule {
 		const messagePayload: Message = {
 			messageId: randomUUID(),
 			kind: "message",
-			role: "user", // FIXME: it could be 'agent'
+			role: "agent",
 			metadata: {
-				agentId: this.agentId,
+				agentId: this.getAgentId(),
+				agentName: this.getAgentName(),
 				type: ThreadType.CHAT,
 			},
 			parts: [
@@ -146,6 +191,33 @@ export class A2AModule {
 		}
 
 		return messagePayload;
+	}
+
+	private *emitMessageContent(
+		message: Pick<Message, "parts">,
+		seenArtifactIds: Set<string>,
+		appendFinalText: (value: string) => void,
+	): Generator<StreamEvent> {
+		const fallbackText = serializeA2AMessageForFallback(message);
+		if (fallbackText) {
+			appendFinalText(fallbackText);
+			yield {
+				event: "text_chunk",
+				data: { delta: fallbackText },
+			};
+		}
+
+		const artifactParts = extractArtifactPartsFromA2AMessage(message);
+		for (const artifactPart of artifactParts) {
+			if (seenArtifactIds.has(artifactPart.artifactId)) {
+				continue;
+			}
+			seenArtifactIds.add(artifactPart.artifactId);
+			yield {
+				event: "artifact_ready",
+				data: artifactPart,
+			};
+		}
 	}
 
 	/**
@@ -215,30 +287,11 @@ export class A2AModule {
 						}
 					} else if (typedEvent.status.state === "completed") {
 						if (typedEvent.status.message?.parts.length) {
-							const fallbackText = serializeA2AMessageForFallback(
+							yield* this.emitMessageContent(
 								typedEvent.status.message,
+								seenArtifactIds,
+								appendFinalText,
 							);
-							if (fallbackText) {
-								appendFinalText(fallbackText);
-								yield {
-									event: "text_chunk",
-									data: { delta: fallbackText },
-								};
-							}
-
-							const artifactParts = extractArtifactPartsFromA2AMessage(
-								typedEvent.status.message,
-							);
-							for (const artifactPart of artifactParts) {
-								if (seenArtifactIds.has(artifactPart.artifactId)) {
-									continue;
-								}
-								seenArtifactIds.add(artifactPart.artifactId);
-								yield {
-									event: "artifact_ready",
-									data: artifactPart,
-								};
-							}
 						}
 					} else {
 						// ignore other status updates
@@ -259,11 +312,17 @@ export class A2AModule {
 						appendFinalText(artifactText);
 					}
 				} else if (event.kind === "message") {
-					// FIXME: handling text in 'message'?
 					const msg = event as Message;
 					const taskId = this.a2aTasks.get(threadId);
 					if (msg.taskId && msg.taskId !== taskId) {
 						this.a2aTasks.set(threadId, msg.taskId);
+					}
+					if (msg.parts.length > 0) {
+						yield* this.emitMessageContent(
+							msg,
+							seenArtifactIds,
+							appendFinalText,
+						);
 					}
 				} else if (event.kind === "task") {
 					// establishing the Task ID

--- a/src/services/a2a.service.ts
+++ b/src/services/a2a.service.ts
@@ -12,7 +12,7 @@ import type {
 	ExecutionEventBus,
 	RequestContext,
 } from "@a2a-js/sdk/server";
-import type { ThreadType } from "@/types/memory.js";
+import { ThreadType } from "@/types/memory.js";
 import {
 	createA2AArtifactsFromMessage,
 	createA2AMessagePartsFromMessage,
@@ -99,6 +99,30 @@ export class A2AService implements AgentExecutor {
 		};
 	}
 
+	private getRequestMetadata(requestContext: RequestContext): {
+		agentId: string;
+		type: ThreadType;
+	} {
+		const metadata =
+			typeof requestContext.userMessage.metadata === "object" &&
+			requestContext.userMessage.metadata !== null
+				? requestContext.userMessage.metadata
+				: {};
+
+		const agentId =
+			typeof (metadata as { agentId?: unknown }).agentId === "string"
+				? (metadata as { agentId: string }).agentId
+				: requestContext.userMessage.taskId ||
+					requestContext.userMessage.contextId ||
+					"anonymous-a2a-agent";
+
+		const rawType = (metadata as { type?: unknown }).type;
+		const type =
+			rawType === ThreadType.WORKFLOW ? ThreadType.WORKFLOW : ThreadType.CHAT;
+
+		return { agentId, type };
+	}
+
 	async execute(
 		requestContext: RequestContext,
 		eventBus: ExecutionEventBus,
@@ -108,10 +132,7 @@ export class A2AService implements AgentExecutor {
 		const threadId =
 			userMessage.contextId || requestContext.task?.contextId || randomUUID();
 
-		const { agentId, type } = userMessage.metadata as {
-			agentId: string;
-			type: ThreadType;
-		};
+		const { agentId, type } = this.getRequestMetadata(requestContext);
 		const existingTask = requestContext.task;
 
 		const taskId = existingTask?.id || randomUUID();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { AINAgent } from "@/index";
 import { getArtifactModule } from "@/config/modules";
+import { A2AModule } from "@/modules/a2a/a2a.module";
 import { ArtifactModule } from "@/modules/artifacts/artifact.module";
 import type { IArtifactStore } from "@/modules/artifacts/base.artifact";
 import { AuthModule } from "@/modules/auth/auth.module";
@@ -159,5 +160,63 @@ describe("AINAgent artifact module wiring", () => {
 		expect(agent.artifactModule).toBe(artifactModule);
 		expect(getArtifactModule()).toBe(artifactModule);
 		expect(getArtifactModule()?.getStore()).toBe(artifactStore);
+	});
+
+	it("publishes an A2A agent card with streaming and artifact-aware modes", () => {
+		const modelModule = new ModelModule();
+		modelModule.addModel("test-model", new TestModel(), {}, true);
+
+		const artifactStore: IArtifactStore = {
+			put: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			openDownload: jest.fn(),
+		};
+		const artifactModule = new ArtifactModule(artifactStore);
+		const a2aModule = new A2AModule();
+
+		const agent = new AINAgent(
+			{
+				name: "Test Agent",
+				description: "Test agent for A2A card generation",
+				url: "https://example.com/agent",
+			},
+			{
+				authModule: new TestAuthModule(),
+				modelModule,
+				memoryModule: new MemoryModule(new TestMemory()),
+				artifactModule,
+				a2aModule,
+			},
+		);
+
+		const card = agent.generateAgentCard();
+		expect(card).toMatchObject({
+			name: "Test Agent",
+			description: "Test agent for A2A card generation",
+			url: "https://example.com/a2a",
+			preferredTransport: "JSONRPC",
+			defaultInputModes: ["text", "data", "file"],
+			defaultOutputModes: ["text", "data", "file"],
+			capabilities: {
+				streaming: true,
+				pushNotifications: false,
+				stateTransitionHistory: true,
+			},
+			additionalInterfaces: [
+				{
+					url: "https://example.com/a2a",
+					transport: "JSONRPC",
+				},
+			],
+			skills: [
+				{
+					id: "query",
+					name: "Test Agent",
+					inputModes: ["text", "data", "file"],
+					outputModes: ["text", "data", "file"],
+				},
+			],
+		});
 	});
 });

--- a/tests/modules/a2a.module.test.ts
+++ b/tests/modules/a2a.module.test.ts
@@ -3,6 +3,28 @@ import { A2AModule } from "@/modules/a2a/a2a.module";
 import { CONNECTOR_PROTOCOL_TYPE } from "@/types/connector";
 
 describe("A2AModule", () => {
+	it("builds outbound A2A payloads with agent identity metadata", () => {
+		const a2aModule = new A2AModule();
+		a2aModule.configureIdentity({
+			agentId: "agent://local",
+			agentName: "Local Agent",
+		});
+
+		const message = a2aModule.getMessagePayload("hello", "thread-1");
+
+		expect(message).toMatchObject({
+			kind: "message",
+			role: "agent",
+			contextId: "thread-1",
+			metadata: {
+				agentId: "agent://local",
+				agentName: "Local Agent",
+				type: "CHAT",
+			},
+			parts: [{ kind: "text", text: "hello" }],
+		});
+	});
+
 	it("emits artifact_ready when a remote peer returns artifact references", async () => {
 		const a2aModule = new A2AModule();
 		const connector = new A2AConnector("peer", "https://peer.example");
@@ -162,6 +184,83 @@ describe("A2AModule", () => {
 		]);
 		expect(result.value).toBe(
 			"[Bot Called A2A Tool peer-tool]\nArtifact preview\nHere is the summary\nArtifact preview",
+		);
+	});
+
+	it("consumes direct message events as streamed content", async () => {
+		const a2aModule = new A2AModule();
+		const connector = new A2AConnector("peer", "https://peer.example");
+
+		connector.client = {
+			sendMessageStream: async function* () {
+				yield {
+					kind: "message",
+					messageId: "msg-1",
+					role: "agent",
+					contextId: "thread-1",
+					taskId: "task-1",
+					parts: [
+						{ kind: "text", text: "Direct response" },
+						{
+							kind: "file",
+							file: {
+								uri: "https://peer.example/result.csv",
+								name: "result.csv",
+								mimeType: "text/csv",
+							},
+							metadata: {
+								artifactId: "art-direct",
+								size: 128,
+								previewText: "name,value\nfoo,1",
+								downloadUrl: "https://peer.example/result.csv",
+							},
+						},
+					],
+				};
+			},
+		} as any;
+
+		(a2aModule as any).a2aConnectors.set("peer", connector);
+
+		const stream = a2aModule.useTool(
+			{
+				toolName: "peer-tool",
+				connectorName: "peer",
+				protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+			},
+			"hello",
+			"thread-1",
+		);
+
+		const events = [];
+		let result = await stream.next();
+		while (!result.done) {
+			events.push(result.value);
+			result = await stream.next();
+		}
+
+		expect(events).toEqual([
+			{
+				event: "text_chunk",
+				data: {
+					delta: "Direct response\nname,value\nfoo,1",
+				},
+			},
+			{
+				event: "artifact_ready",
+				data: {
+					kind: "artifact",
+					artifactId: "art-direct",
+					name: "result.csv",
+					mimeType: "text/csv",
+					size: 128,
+					downloadUrl: "https://peer.example/result.csv",
+					previewText: "name,value\nfoo,1",
+				},
+			},
+		]);
+		expect(result.value).toBe(
+			"[Bot Called A2A Tool peer-tool]\nDirect response\nname,value\nfoo,1",
 		);
 	});
 });


### PR DESCRIPTION
## Summary

This PR tightens the remaining A2A protocol alignment after adding artifact reference support.

### What changed

- configured stable A2A sender identity from the agent manifest
- updated outbound A2A messages to use `role: "agent"` with explicit agent metadata
- improved A2A tool-stream handling so direct `message` events are consumed as actual content, not only task bookkeeping
- strengthened inbound A2A metadata parsing with safe defaults for missing `agentId` and `type`
- updated generated agent cards to declare:
  - `preferredTransport: JSONRPC`
  - explicit JSON-RPC interface entries
  - streaming/state-history capabilities
  - artifact-aware input/output modes
  - a default query skill
- added tests for:
  - A2A agent card generation
  - outbound A2A payload identity metadata
  - direct A2A `message` event consumption
