### PR TITLE
Refactor/workflow execution boundary

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -80,6 +80,10 @@ Completed groundwork so far:
 - aligned outbound A2A sender identity and role metadata with agent-facing protocol usage
 - updated generated A2A agent cards to advertise streaming, structured modes, and a default query skill
 - added focused tests covering A2A artifact reference flow, direct message-event handling, and agent card generation
+- introduced explicit `QueryExecutionInput` and `WorkflowExecutionInput` boundary types
+- kept workflow execution text-first while reserving optional structured `input` for future expansion
+- updated workflow execution and query service boundaries to pass execution input objects instead of ad-hoc string pairs
+- added focused tests covering workflow execution input resolution and future-friendly workflow query boundary shape
 
 Not completed yet:
 
@@ -87,7 +91,6 @@ Not completed yet:
 - full query/request/response contract refactor across streaming and provider-facing paths
 - artifact upload/download runtime APIs
 - stream event redesign
-- workflow boundary refactor
 - migration adapters for old message records
 
 ---
@@ -106,6 +109,7 @@ The current implementation is still text-first in important inference paths, but
 - thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
 - stream output still keeps `text_chunk` as a compatibility-first event, even though canonical message events and `artifact_ready` now exist
 - A2A paths now accept multipart inputs and exchange artifact references, but still avoid raw binary forwarding
+- workflow authoring and APIs remain text-only, but execution boundaries now use explicit input types that can absorb future structured input
 - server middleware only handles JSON and URL-encoded input, not multipart uploads
 
 ### Important impacted files
@@ -120,6 +124,9 @@ The current implementation is still text-first in important inference paths, but
 - [src/services/intents/fulfill.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/intents/fulfill.service.ts)
 - [src/services/a2a.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/a2a.service.ts)
 - [src/modules/a2a/a2a.module.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/modules/a2a/a2a.module.ts)
+- [src/services/workflow-variable-resolver.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/workflow-variable-resolver.service.ts)
+- [src/services/workflow-execution.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/workflow-execution.service.ts)
+- [src/types/message-input.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/types/message-input.ts)
 - [src/index.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/index.ts)
 
 ---
@@ -989,6 +996,15 @@ Completed groundwork in this phase:
 - keep workflow APIs text-only in the first milestone
 - review workflow service signatures for future structured input support
 - document the future path from string workflows to multipart workflows without implementing it yet
+
+Completed groundwork in this phase:
+
+- introduced explicit `QueryExecutionInput` and `WorkflowExecutionInput` types to make workflow/query execution boundaries more legible
+- updated `WorkflowVariableResolver.resolveForExecution(...)` to return a typed workflow execution input object instead of an ad-hoc string pair
+- updated `WorkflowExecutionService` to pass workflow execution through an explicit execution-input boundary while preserving current text-first behavior
+- updated `QueryService.handleQuery(...)` to accept a shared execution input type so workflow callers no longer need custom inline parameter shapes
+- kept workflow runtime behavior text-only for this milestone while reserving optional structured `input` support for later expansion
+- added focused tests covering text-first workflow execution input resolution and future-friendly workflow query boundary compatibility
 
 ## Phase 13. Migration and Compatibility Layer
 

--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-18`
+Last updated: `2026-04-20`
 
 Completed groundwork so far:
 

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -14,7 +14,7 @@ import {
 	type ThreadObject,
 	ThreadType,
 } from "@/types/memory.js";
-import type { QueryMessageInput } from "@/types/message-input";
+import type { QueryExecutionInput } from "@/types/message-input";
 import type { StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger.js";
 import {
@@ -116,11 +116,7 @@ export class QueryService {
 			title?: string;
 			options?: ModelFetchOptions;
 		},
-		queryData: {
-			query: string;
-			displayQuery?: string;
-			input?: QueryMessageInput;
-		},
+		queryData: QueryExecutionInput,
 		isA2A?: boolean,
 	): AsyncGenerator<
 		StreamEvent,

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -1,4 +1,5 @@
 import { ThreadType } from "@/types/memory.js";
+import type { WorkflowExecutionInput } from "@/types/message-input.js";
 import { loggers } from "@/utils/logger.js";
 import type { QueryService } from "./query.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
@@ -19,6 +20,16 @@ export class WorkflowExecutionService {
 		this.workflowVariableResolver = workflowVariableResolver;
 	}
 
+	private createQueryData(
+		executionInput: WorkflowExecutionInput,
+	): WorkflowExecutionInput {
+		return {
+			query: executionInput.query,
+			displayQuery: executionInput.displayQuery,
+			input: executionInput.input,
+		};
+	}
+
 	async executeWorkflow(
 		workflowId: string,
 		executionVariables?: Record<string, string>,
@@ -28,15 +39,14 @@ export class WorkflowExecutionService {
 			throw new Error(`User workflow not found: ${workflowId}`);
 		}
 
-		const { query, displayQuery } =
-			this.workflowVariableResolver.resolveForExecution(
-				workflow,
-				executionVariables,
-			);
+		const executionInput = this.workflowVariableResolver.resolveForExecution(
+			workflow,
+			executionVariables,
+		);
 
 		loggers.agent.info(`Executing user workflow: ${workflow.title}`, {
 			workflowId,
-			resolvedQuery: query,
+			resolvedQuery: executionInput.query,
 		});
 
 		const stream = this.queryService.handleQuery(
@@ -46,7 +56,7 @@ export class WorkflowExecutionService {
 				workflowId,
 				title: workflow.title,
 			},
-			{ query, displayQuery },
+			this.createQueryData(executionInput),
 		);
 
 		let threadId: string | undefined;

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -1,4 +1,5 @@
 import type { UserWorkflow } from "@/types/memory.js";
+import type { WorkflowExecutionInput } from "@/types/message-input.js";
 import {
 	resolveTemplateRecord,
 	resolveTemplateString,
@@ -35,10 +36,7 @@ export class WorkflowVariableResolver {
 	resolveForExecution(
 		workflow: WorkflowTextFields,
 		executionVariables?: Record<string, string>,
-	): {
-		query: string;
-		displayQuery: string;
-	} {
+	): WorkflowExecutionInput {
 		const { timezone } = workflow;
 		let query = workflow.content;
 		let displayQuery = workflow.title;

--- a/src/types/message-input.ts
+++ b/src/types/message-input.ts
@@ -28,6 +28,24 @@ export type QueryMessageInput = {
 	parts: QueryInputPart[];
 };
 
+export type QueryExecutionInput = {
+	query: string;
+	displayQuery?: string;
+	input?: QueryMessageInput;
+};
+
+/**
+ * Workflow execution remains text-first in the initial milestone.
+ *
+ * The optional `input` field is reserved so workflow execution boundaries can
+ * evolve toward structured query input later without another signature rewrite.
+ */
+export type WorkflowExecutionInput = {
+	query: string;
+	displayQuery: string;
+	input?: QueryMessageInput;
+};
+
 export type QueryRequestInput = {
 	message?: string;
 	displayMessage?: string;

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -1,0 +1,127 @@
+import { WorkflowExecutionService } from "@/services/workflow-execution.service";
+import { ThreadType } from "@/types/memory";
+
+describe("WorkflowExecutionService", () => {
+	it("executes workflows through the text-first query boundary", async () => {
+		const getWorkflow = jest.fn(async () => ({
+			workflowId: "workflow-1",
+			userId: "user-1",
+			title: "Daily report",
+			content: "Summarize performance",
+			active: true,
+		}));
+		const updateWorkflow = jest.fn(async () => {});
+		const resolveForExecution = jest.fn(() => ({
+			query: "Summarize performance",
+			displayQuery: "Daily report",
+		}));
+		const handleQuery = jest.fn(async function* () {
+			yield {
+				event: "thread_id" as const,
+				data: {
+					type: ThreadType.WORKFLOW,
+					userId: "user-1",
+					threadId: "thread-1",
+					title: "Daily report",
+					workflowId: "workflow-1",
+				},
+			};
+			return undefined;
+		});
+
+		const service = new WorkflowExecutionService(
+			{
+				getWorkflow,
+				updateWorkflow,
+			} as any,
+			{
+				handleQuery,
+			} as any,
+			{
+				resolveForExecution,
+			} as any,
+		);
+
+		await expect(service.executeWorkflow("workflow-1")).resolves.toEqual({
+			threadId: "thread-1",
+		});
+
+		expect(resolveForExecution).toHaveBeenCalledWith(
+			expect.objectContaining({
+				workflowId: "workflow-1",
+			}),
+			undefined,
+		);
+		expect(handleQuery).toHaveBeenCalledWith(
+			{
+				type: ThreadType.WORKFLOW,
+				userId: "user-1",
+				workflowId: "workflow-1",
+				title: "Daily report",
+			},
+			{
+				query: "Summarize performance",
+				displayQuery: "Daily report",
+				input: undefined,
+			},
+		);
+		expect(updateWorkflow).toHaveBeenCalledWith("workflow-1", {
+			lastRunAt: expect.any(Number),
+			lastThreadId: "thread-1",
+		});
+	});
+
+	it("preserves the workflow execution input shape for future structured input support", async () => {
+		const handleQuery = jest.fn(async function* () {
+			yield {
+				event: "thread_id" as const,
+				data: {
+					type: ThreadType.WORKFLOW,
+					userId: "user-1",
+					threadId: "thread-2",
+					title: "Daily report",
+					workflowId: "workflow-1",
+				},
+			};
+			return undefined;
+		});
+
+		const service = new WorkflowExecutionService(
+			{
+				getWorkflow: async () => ({
+					workflowId: "workflow-1",
+					userId: "user-1",
+					title: "Daily report",
+					content: "Summarize performance",
+					active: true,
+				}),
+				updateWorkflow: jest.fn(async () => {}),
+			} as any,
+			{
+				handleQuery,
+			} as any,
+			{
+				resolveForExecution: jest.fn(() => ({
+					query: "Summarize performance",
+					displayQuery: "Daily report",
+					input: {
+						parts: [{ kind: "text", text: "future workflow input" }],
+					},
+				})),
+			} as any,
+		);
+
+		await service.executeWorkflow("workflow-1");
+
+		expect(handleQuery).toHaveBeenCalledWith(
+			expect.any(Object),
+			{
+				query: "Summarize performance",
+				displayQuery: "Daily report",
+				input: {
+					parts: [{ kind: "text", text: "future workflow input" }],
+				},
+			},
+		);
+	});
+});

--- a/tests/services/workflow-variable-resolver.service.test.ts
+++ b/tests/services/workflow-variable-resolver.service.test.ts
@@ -1,0 +1,31 @@
+import { WorkflowVariableResolver } from "@/services/workflow-variable-resolver.service";
+
+describe("WorkflowVariableResolver", () => {
+	it("resolves workflow execution input as text-first query data", () => {
+		const resolver = new WorkflowVariableResolver();
+
+		const result = resolver.resolveForExecution(
+			{
+				title: "Daily summary for {{workspace}}",
+				content: "Summarize {{workspace}} performance",
+				timezone: "Asia/Seoul",
+				variables: {
+					workspace: {
+						id: "workspace",
+						label: "Workspace",
+						type: "text",
+						resolveAt: "execution",
+					},
+				},
+				variableValues: {},
+			},
+			{ workspace: "AIN" },
+		);
+
+		expect(result).toEqual({
+			query: "Summarize AIN performance",
+			displayQuery: "Daily summary for AIN",
+		});
+		expect("input" in result).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

This PR cleans up the workflow execution boundary while intentionally keeping workflow APIs text-only for the current milestone.

## What changed

- introduced explicit `QueryExecutionInput` and `WorkflowExecutionInput` types
- updated `WorkflowVariableResolver.resolveForExecution(...)` to return a typed execution input object
- updated `WorkflowExecutionService` to pass workflow execution through an explicit execution-input boundary
- updated `QueryService.handleQuery(...)` to accept a shared execution input type instead of ad-hoc inline query shapes
- preserved current text-first workflow behavior while reserving optional structured `input` for future expansion
- updated the multimodal/artifact plan to reflect Phase 12 progress
- added tests for:
  - text-first workflow execution input resolution
  - workflow execution through the shared query boundary
  - future-friendly structured input compatibility at the workflow boundary