### PR TITLE
refactor: normalize legacy thread message boundaries

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -84,6 +84,9 @@ Completed groundwork so far:
 - kept workflow execution text-first while reserving optional structured `input` for future expansion
 - updated workflow execution and query service boundaries to pass execution input objects instead of ad-hoc string pairs
 - added focused tests covering workflow execution input resolution and future-friendly workflow query boundary shape
+- added thread-level legacy message read adapters that expose canonical `schemaVersion: 2` message views
+- normalized thread read and write boundaries in thread, query, and thread API services
+- added focused tests covering legacy thread message reads, canonicalized writes, and query intent processing compatibility
 
 Not completed yet:
 
@@ -91,7 +94,6 @@ Not completed yet:
 - full query/request/response contract refactor across streaming and provider-facing paths
 - artifact upload/download runtime APIs
 - stream event redesign
-- migration adapters for old message records
 
 ---
 
@@ -107,6 +109,7 @@ The current implementation is still text-first in important inference paths, but
 - `QueryService` still processes `query: string` for inference, even though it can now receive structured input for persistence
 - some runtime paths still assume `query: string`, but new message writes now converge on canonical `parts[]` messages
 - thread history is still flattened into strings for intent triggering, but now through a shared multipart-aware serializer
+- legacy thread records can still be read from memory providers, but SDK/API read boundaries now normalize messages to canonical `schemaVersion: 2`
 - stream output still keeps `text_chunk` as a compatibility-first event, even though canonical message events and `artifact_ready` now exist
 - A2A paths now accept multipart inputs and exchange artifact references, but still avoid raw binary forwarding
 - workflow authoring and APIs remain text-only, but execution boundaries now use explicit input types that can absorb future structured input
@@ -115,6 +118,8 @@ The current implementation is still text-first in important inference paths, but
 ### Important impacted files
 
 - [src/controllers/query.controller.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/controllers/query.controller.ts)
+- [src/controllers/api/threads.api.controller.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/controllers/api/threads.api.controller.ts)
+- [src/services/thread.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/thread.service.ts)
 - [src/services/query.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/query.service.ts)
 - [src/types/memory.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/types/memory.ts)
 - [src/types/stream.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/types/stream.ts)
@@ -1011,6 +1016,15 @@ Completed groundwork in this phase:
 - provide adapters for old text-only API usage
 - support old message reading where necessary
 - publish upgrade notes for provider and memory implementers
+
+Completed groundwork in this phase:
+
+- added `CanonicalThreadObject`, `normalizeThreadMessages(...)`, and `normalizeThreadObject(...)` as explicit thread-level migration adapters
+- updated `ThreadService.getThread(...)` to return canonical message views when memory providers return legacy message records
+- updated `ThreadService.addMessagesToThread(...)` to normalize incoming messages before writing to memory providers
+- updated `QueryService` thread loading so intent triggering and fulfillment receive canonicalized stored thread history
+- updated the thread API controller to return canonicalized thread messages without requiring a storage migration
+- added focused tests covering legacy thread message normalization at utility, service, query, and API-controller boundaries
 
 ## Phase 14. Tests and Documentation Sweep
 

--- a/src/controllers/api/threads.api.controller.ts
+++ b/src/controllers/api/threads.api.controller.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
 import type { ThreadFilter } from "@/types/memory.js";
+import { normalizeThreadObject } from "@/utils/message.js";
 
 export class ThreadApiController {
 	private memoryModule: MemoryModule;
@@ -22,7 +23,7 @@ export class ThreadApiController {
 			const userId = res.locals.userId || "";
 			const threadMemory = this.memoryModule.getThreadMemory();
 			const thread = await threadMemory?.getThread(userId, threadId);
-			res.json(thread);
+			res.json(thread ? normalizeThreadObject(thread) : thread);
 		} catch (error) {
 			next(error);
 		}

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -21,6 +21,7 @@ import {
 	createMessageFromQueryInput,
 	createModelInputMessage,
 	createModelInputMessageFromQueryInput,
+	normalizeThreadObject,
 } from "@/utils/message";
 import type { IntentFulfillService } from "./intents/fulfill.service";
 import type { IntentTriggerService } from "./intents/trigger.service";
@@ -189,7 +190,8 @@ export class QueryService {
 		let threadId = threadMetadata.threadId;
 		let thread: ThreadObject | undefined;
 		if (threadId) {
-			thread = await threadMemory?.getThread(userId, threadId);
+			const storedThread = await threadMemory?.getThread(userId, threadId);
+			thread = storedThread ? normalizeThreadObject(storedThread) : undefined;
 			if (!thread && !isA2A) {
 				throw new AinHttpError(StatusCodes.NOT_FOUND, "Thread not found");
 			}

--- a/src/services/thread.service.ts
+++ b/src/services/thread.service.ts
@@ -5,6 +5,7 @@ import type {
 	ThreadObject,
 	ThreadType,
 } from "@/types/memory";
+import { normalizeMessageObject, normalizeThreadObject } from "@/utils/message";
 
 export class ThreadService {
 	private memoryModule: MemoryModule;
@@ -22,7 +23,8 @@ export class ThreadService {
 			return;
 		}
 
-		return await threadMemory.getThread(userId, threadId);
+		const thread = await threadMemory.getThread(userId, threadId);
+		return thread ? normalizeThreadObject(thread) : undefined;
 	}
 
 	public async createThread(
@@ -61,6 +63,10 @@ export class ThreadService {
 			return;
 		}
 
-		await threadMemory.addMessagesToThread(userId, threadId, messages);
+		await threadMemory.addMessagesToThread(
+			userId,
+			threadId,
+			messages.map(normalizeMessageObject),
+		);
 	}
 }

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -163,6 +163,10 @@ export type ThreadObject = {
 	messages: Array<MessageObject>;
 };
 
+export type CanonicalThreadObject = Omit<ThreadObject, "messages"> & {
+	messages: Array<CanonicalMessageObject>;
+};
+
 export type IntentToolChoice = "auto" | "required";
 
 export interface Intent {

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
 	ArtifactContentPart,
 	CanonicalMessageObject,
+	CanonicalThreadObject,
 	DataContentPart,
 	LegacyMessageObject,
 	MessageContentPart,
@@ -162,6 +163,21 @@ export function normalizeMessageObject(
 		metadata: message.metadata,
 		schemaVersion: 2,
 		parts: normalizeMessageParts(message),
+	};
+}
+
+export function normalizeThreadMessages(
+	messages: Array<MessageObject>,
+): Array<CanonicalMessageObject> {
+	return messages.map(normalizeMessageObject);
+}
+
+export function normalizeThreadObject(
+	thread: ThreadObject,
+): CanonicalThreadObject {
+	return {
+		...thread,
+		messages: normalizeThreadMessages(thread.messages),
 	};
 }
 

--- a/tests/controllers/api/threads.api.controller.test.ts
+++ b/tests/controllers/api/threads.api.controller.test.ts
@@ -1,0 +1,57 @@
+import type { NextFunction, Request, Response } from "express";
+import { ThreadApiController } from "@/controllers/api/threads.api.controller";
+import { MessageRole, ThreadType } from "@/types/memory";
+
+describe("ThreadApiController", () => {
+	it("returns canonical thread messages from legacy stored records", async () => {
+		const controller = new ThreadApiController({
+			getThreadMemory: () => ({
+				getThread: jest.fn(async () => ({
+					userId: "user-1",
+					threadId: "thread-1",
+					type: ThreadType.CHAT,
+					title: "Thread",
+					messages: [
+						{
+							messageId: "legacy-msg-1",
+							role: MessageRole.USER,
+							timestamp: 100,
+							content: {
+								type: "text",
+								parts: ["legacy hello"],
+							},
+						},
+					],
+				})),
+			}),
+		} as any);
+
+		const json = jest.fn();
+		const req = { params: { id: "thread-1" } } as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			json,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleGetThread(req, res, next);
+
+		expect(json).toHaveBeenCalledWith({
+			userId: "user-1",
+			threadId: "thread-1",
+			type: ThreadType.CHAT,
+			title: "Thread",
+			messages: [
+				{
+					messageId: "legacy-msg-1",
+					role: MessageRole.USER,
+					timestamp: 100,
+					metadata: undefined,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "legacy hello" }],
+				},
+			],
+		});
+		expect(next).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/query.service.test.ts
+++ b/tests/services/query.service.test.ts
@@ -200,6 +200,105 @@ describe("QueryService", () => {
 					}),
 				],
 			}),
+			);
+		});
+
+	it("normalizes legacy stored thread messages before intent processing", async () => {
+		const intentTriggering = jest.fn(async () => ({
+			intents: [{ subquery: "next question" }],
+			needsAggregation: false,
+		}));
+		const intentFulfill = jest.fn(async function* () {
+			return createTextMessage({
+				messageId: "model-msg-3",
+				role: MessageRole.MODEL,
+				timestamp: 900,
+				text: "done",
+			});
+		});
+
+		const queryService = new QueryService(
+			{
+				getModel: () => ({
+					generateMessages: () => [],
+					fetch: async () => ({ content: "New Chat" }),
+				}),
+				getModelOptions: () => undefined,
+			} as any,
+			{
+				getThreadMemory: () => ({
+					getThread: jest.fn(async () => ({
+						type: ThreadType.CHAT,
+						userId: "user-1",
+						threadId: "thread-1",
+						title: "Thread",
+						messages: [
+							{
+								messageId: "legacy-msg-1",
+								role: MessageRole.USER,
+								timestamp: 100,
+								content: {
+									type: "text",
+									parts: ["legacy hello"],
+								},
+							},
+						],
+					})),
+					addMessagesToThread: jest.fn(async () => {}),
+				}),
+			} as any,
+			{
+				intentTriggering,
+			} as any,
+			{
+				intentFulfill,
+			} as any,
+		);
+
+		const stream = queryService.handleQuery(
+			{
+				type: ThreadType.CHAT,
+				userId: "user-1",
+				threadId: "thread-1",
+			},
+			{
+				query: "next question",
+			},
+		);
+
+		await expect(stream.next()).resolves.toMatchObject({
+			done: true,
+		});
+		expect(intentTriggering).toHaveBeenCalledWith(
+			"next question",
+			expect.objectContaining({
+				messages: [
+					{
+						messageId: "legacy-msg-1",
+						role: MessageRole.USER,
+						timestamp: 100,
+						metadata: undefined,
+						schemaVersion: 2,
+						parts: [{ kind: "text", text: "legacy hello" }],
+					},
+				],
+			}),
+		);
+		expect(intentFulfill).toHaveBeenCalledWith(
+			[{ subquery: "next question" }],
+			expect.objectContaining({
+				messages: [
+					expect.objectContaining({
+						schemaVersion: 2,
+						parts: [{ kind: "text", text: "legacy hello" }],
+					}),
+				],
+			}),
+			"next question",
+			false,
+			expect.objectContaining({
+				schemaVersion: 2,
+			}),
 		);
 	});
 });

--- a/tests/services/thread.service.test.ts
+++ b/tests/services/thread.service.test.ts
@@ -1,0 +1,68 @@
+import { ThreadService } from "@/services/thread.service";
+import { MessageRole, ThreadType, type MessageObject } from "@/types/memory";
+
+describe("ThreadService", () => {
+	const legacyMessage: MessageObject = {
+		messageId: "legacy-msg-1",
+		role: MessageRole.USER,
+		timestamp: 100,
+		content: {
+			type: "text",
+			parts: ["legacy hello"],
+		},
+	};
+
+	it("returns canonical message views when reading threads", async () => {
+		const getThread = jest.fn(async () => ({
+			userId: "user-1",
+			threadId: "thread-1",
+			type: ThreadType.CHAT,
+			title: "Thread",
+			messages: [legacyMessage],
+		}));
+		const service = new ThreadService({
+			getThreadMemory: () => ({
+				getThread,
+			}),
+		} as any);
+
+		await expect(service.getThread("user-1", "thread-1")).resolves.toEqual({
+			userId: "user-1",
+			threadId: "thread-1",
+			type: ThreadType.CHAT,
+			title: "Thread",
+			messages: [
+				{
+					messageId: "legacy-msg-1",
+					role: MessageRole.USER,
+					timestamp: 100,
+					metadata: undefined,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "legacy hello" }],
+				},
+			],
+		});
+	});
+
+	it("normalizes messages before writing to thread memory", async () => {
+		const addMessagesToThread = jest.fn(async () => {});
+		const service = new ThreadService({
+			getThreadMemory: () => ({
+				addMessagesToThread,
+			}),
+		} as any);
+
+		await service.addMessagesToThread("user-1", "thread-1", [legacyMessage]);
+
+		expect(addMessagesToThread).toHaveBeenCalledWith("user-1", "thread-1", [
+			{
+				messageId: "legacy-msg-1",
+				role: MessageRole.USER,
+				timestamp: 100,
+				metadata: undefined,
+				schemaVersion: 2,
+				parts: [{ kind: "text", text: "legacy hello" }],
+			},
+		]);
+	});
+});

--- a/tests/utils/message.test.ts
+++ b/tests/utils/message.test.ts
@@ -9,6 +9,8 @@ import {
 	createToolMessage,
 	createToolResultPart,
 	normalizeMessageObject,
+	normalizeThreadMessages,
+	normalizeThreadObject,
 	serializeMessageForModelFallback,
 	serializeMessageForIntent,
 	serializeThreadForModelFallback,
@@ -36,6 +38,49 @@ describe("message utilities", () => {
 			parts: [
 				{ kind: "text", text: "hello" },
 				{ kind: "text", text: "world" },
+			],
+			});
+		});
+
+	it("normalizes legacy thread messages into canonical thread views", () => {
+		const legacyMessage: MessageObject = {
+			messageId: "msg-thread-1",
+			role: MessageRole.USER,
+			timestamp: 100,
+			content: {
+				type: "text",
+				parts: ["hello from storage"],
+			},
+		};
+		const thread = {
+			userId: "user-1",
+			threadId: "thread-1",
+			type: ThreadType.CHAT,
+			title: "Thread",
+			messages: [legacyMessage],
+		};
+
+		expect(normalizeThreadMessages(thread.messages)).toEqual([
+			{
+				messageId: "msg-thread-1",
+				role: MessageRole.USER,
+				timestamp: 100,
+				schemaVersion: 2,
+				metadata: undefined,
+				parts: [{ kind: "text", text: "hello from storage" }],
+			},
+		]);
+		expect(normalizeThreadObject(thread)).toEqual({
+			...thread,
+			messages: [
+				{
+					messageId: "msg-thread-1",
+					role: MessageRole.USER,
+					timestamp: 100,
+					schemaVersion: 2,
+					metadata: undefined,
+					parts: [{ kind: "text", text: "hello from storage" }],
+				},
 			],
 		});
 	});


### PR DESCRIPTION
## Summary

This PR adds explicit thread-level migration adapters so legacy stored message records are normalized into canonical multipart message views at SDK/API read boundaries.

## What changed

- added `CanonicalThreadObject`
- added thread-level normalization helpers:
  - `normalizeThreadMessages(...)`
  - `normalizeThreadObject(...)`
- updated `ThreadService.getThread(...)` to return canonicalized thread messages when memory providers return legacy records
- updated `ThreadService.addMessagesToThread(...)` to normalize messages before writing to memory providers
- updated `QueryService` thread loading so intent triggering and fulfillment receive canonicalized stored history
- updated the thread API controller to return canonical `schemaVersion: 2` messages without requiring a storage migration
- updated the multimodal/artifact plan to mark Phase 13 migration adapter groundwork as complete
- added tests for:
  - utility-level thread message normalization
  - `ThreadService` read/write normalization
  - `QueryService` legacy stored thread compatibility
  - thread API canonicalized response shape