### PR TITLE
add column operation for added total row

### DIFF
--- a/src/services/workflow-response-composer.service.ts
+++ b/src/services/workflow-response-composer.service.ts
@@ -74,7 +74,7 @@ export class WorkflowResponseComposer {
 			block,
 			taskResults,
 			renderedBlocks,
-			"Generate this workflow response text from the task results. Return only the response block content.",
+			"Generate ONLY the new text described in Instructions. Task results and already-rendered blocks are reference context — never restate, echo, or repeat them in your output.",
 		);
 
 		const finalContent = content.endsWith("\n\n") ? content : `${content}\n\n`;
@@ -183,7 +183,7 @@ export class WorkflowResponseComposer {
 		taskResults: Record<string, WorkflowTaskResult>,
 	): WorkflowTaskResult[] {
 		if (!block.sourceTaskIds || block.sourceTaskIds.length === 0) {
-			return Object.values(taskResults);
+			return [];
 		}
 
 		return block.sourceTaskIds
@@ -196,16 +196,26 @@ export class WorkflowResponseComposer {
 		taskResults: WorkflowTaskResult[],
 		renderedBlocks: WorkflowRenderedBlock[],
 	): string {
-		const resultsText = serializeTaskResults(taskResults);
+		const sections: string[] = [];
+
+		if (taskResults.length > 0) {
+			sections.push(
+				`Task results (reference context — do not restate):\n${serializeTaskResults(taskResults)}`,
+			);
+		}
+
 		const blocksText = this.serializeRenderedBlocks(renderedBlocks);
-		return `Task results:
-${resultsText}
+		if (blocksText) {
+			sections.push(
+				`Already-rendered blocks (reference context — do not repeat):\n${blocksText}`,
+			);
+		}
 
-Rendered response blocks:
-${blocksText || "(none)"}
+		sections.push(
+			`Instructions:\n${block.prompt}\n\nOutput only the new text described above. Do not include any reference context.`,
+		);
 
-Instructions:
-${block.prompt}`;
+		return sections.join("\n\n");
 	}
 
 	private getSourceRenderedBlocks(
@@ -213,7 +223,7 @@ ${block.prompt}`;
 		renderedBlocks: WorkflowRenderedBlock[],
 	): WorkflowRenderedBlock[] {
 		if (!block.sourceBlockIds || block.sourceBlockIds.length === 0) {
-			return renderedBlocks;
+			return [];
 		}
 
 		const sourceBlockIds = new Set(block.sourceBlockIds);

--- a/src/services/workflow-table/formula-evaluator.ts
+++ b/src/services/workflow-table/formula-evaluator.ts
@@ -62,13 +62,25 @@ export class WorkflowTableFormulaEvaluator {
 			}
 		}
 
-		return {
-			rows,
-			totalRow: definition.totalFormula
-				? this.buildRecordTotalRow(definition, rows)
-				: undefined,
-			warnings,
-		};
+		let totalRow: RecordTableRow | undefined;
+		if (definition.totalFormula) {
+			totalRow = this.buildRecordTotalRow(definition, rows);
+			const totalIndex = definition.formulas.findIndex(
+				(formula) => formula.type === "total",
+			);
+			const postTotalFormulas = definition.formulas.slice(totalIndex + 1);
+			for (const formula of postTotalFormulas) {
+				if (formula.type === "expression") {
+					this.applyRecordExpressionFormula(formula, [totalRow], warnings);
+					continue;
+				}
+				if (formula.type === "sum") {
+					this.applyRecordSumFormula(formula, [totalRow]);
+				}
+			}
+		}
+
+		return { rows, totalRow, warnings };
 	}
 
 	private validateRecordFormulaDependencies(

--- a/tests/services/workflow-response-composer.service.test.ts
+++ b/tests/services/workflow-response-composer.service.test.ts
@@ -88,7 +88,7 @@ describe("WorkflowResponseComposer", () => {
 		);
 
 		const query = generateMessages.mock.calls[0][0].query;
-		expect(query).toContain("Rendered response blocks:");
+		expect(query).toContain("Already-rendered blocks");
 		expect(query).toContain("[sales-table] table");
 		expect(query).toContain("[sales-graph] graph");
 		expect(query).toContain('"headers": [');


### PR DESCRIPTION
## Summary

레코드 테이블(records layout) 수식 시스템을 두 가지 측면에서 확장하고, `helmet` 의존성 분류를 바로잡았습니다.

### 1. 레코드 수식에 숫자 리터럴 지원 (`definition-builder.ts`, `shared.ts`, `formula-evaluator.ts`)
- `ParsedRecordFormula.operands` 타입을 `string[]` → `RecordExpressionOperand[]`로 일반화했습니다. 각 operand는 `{ kind: "column", name }` 또는 `{ kind: "number", value }`입니다.
- 표현식 파서가 컬럼 매칭에 실패하면 숫자 패턴(`/\d+(?:\.\d+)?/y`)으로 fallback합니다. 컬럼 매칭이 먼저이므로 `"100"`이라는 이름의 컬럼이 있으면 리터럴 `100`보다 우선합니다.
- 평가기는 operand의 `kind`에 따라 row 값을 파싱하거나 리터럴 값을 그대로 사용합니다. dependency validator도 컬럼 operand만 필터링하도록 수정.
- 예: `"Var.(명%) = 2026 고객수 / 2025 고객수 * 100"` 같은 수식이 동작합니다.

### 2. Total row에 대한 후속 컬럼 연산 (`formula-evaluator.ts`)
- `totalFormula` 이후에 정의된 `expression`/`sum` 수식들을 total row에도 적용하도록 변경했습니다. 이전에는 total row가 합계만 계산되고 끝났지만, 이제 합계를 기반으로 한 파생 컬럼(예: 증감률) 값을 total row에서도 계산할 수 있습니다.

### 3. `helmet` 의존성 위치 수정 (`package.json`)
- `@types/helmet` (devDep) 제거, `helmet` (dep) 추가. 런타임에서 사용되므로 dependencies로 이동.