### PR TITLE
Fix/tool call protocol compliance

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -10,5 +10,10 @@ export type {
 	IWorkflowTemplateMemory,
 } from "./memory/base.memory.js";
 export { MemoryModule } from "./memory/memory.module.js";
-export { BaseModel, type ModelFetchOptions } from "./models/base.model.js";
+export {
+	type AssistantToolCallTurn,
+	BaseModel,
+	type ModelFetchOptions,
+	type ToolResultMessage,
+} from "./models/base.model.js";
 export { ModelModule } from "./models/model.module.js";

--- a/src/modules/models/base.model.ts
+++ b/src/modules/models/base.model.ts
@@ -1,12 +1,35 @@
 import type { ConnectorTool, FetchResponse } from "@/types/connector.js";
 import type { ThreadObject } from "@/types/memory.js";
-import type { LLMStream } from "@/types/stream.js";
+import type { AssembledToolCall, LLMStream } from "@/types/stream.js";
 
 export type ModelFetchOptions = {
 	reasoning?: "none" | "minimal" | "low" | "medium" | "high";
 	verbosity?: "low" | "medium" | "high";
 	toolChoice?: "auto" | "required";
 };
+
+/**
+ * Arguments for {@link BaseModel.appendAssistantToolCallTurn}.
+ */
+export interface AssistantToolCallTurn {
+	/** Text the assistant streamed in the same turn as the tool calls, or null. */
+	content: string | null;
+	/** Tool calls assembled from the stream. Must preserve provider-issued ids. */
+	toolCalls: AssembledToolCall[];
+}
+
+/**
+ * Arguments for {@link BaseModel.appendToolResult}.
+ */
+export interface ToolResultMessage {
+	/** Matches the `id` of the corresponding {@link AssembledToolCall}. */
+	toolCallId: string;
+	toolName: string;
+	/** Stringified result; providers wrap it in their native shape. */
+	content: string;
+	/** When true, the result represents a failure (skipped/error/invalid args). */
+	isError?: boolean;
+}
 
 /**
  * Abstract base class for AI model implementations.
@@ -34,12 +57,40 @@ export abstract class BaseModel<MessageType, FunctionType> {
 	}): MessageType[];
 
 	/**
-	 * Appends a new message to the existing message array.
+	 * Appends the assistant's tool-call turn to the message history.
 	 *
-	 * @param messages - Existing message array to expand
-	 * @param message - New message content to append
+	 * Called by `ToolCallingService` immediately after the streamed assistant
+	 * response is fully assembled and contains one or more tool calls, and
+	 * before the corresponding tool results are pushed.
+	 *
+	 * Each provider must translate the input into the shape its own protocol
+	 * expects (e.g. OpenAI/Azure: `{role:"assistant", content, tool_calls}`,
+	 * Gemini: `{role:"model", parts:[..., {functionCall}]}`).
+	 *
+	 * @param messages - Existing message array to mutate
+	 * @param turn - Assembled assistant turn (content + tool calls)
 	 */
-	abstract appendMessages(messages: MessageType[], message: string): void;
+	abstract appendAssistantToolCallTurn(
+		messages: MessageType[],
+		turn: AssistantToolCallTurn,
+	): void;
+
+	/**
+	 * Appends a single tool's result to the message history.
+	 *
+	 * Must be called once per `toolCallId` that appeared in the most recent
+	 * {@link appendAssistantToolCallTurn} — including cases where the tool was
+	 * skipped (unknown name, invalid arguments, etc.). Providers that enforce
+	 * matched tool_calls/tool_results pairs (e.g. OpenAI/Azure) will return a
+	 * 400 on the next request if this invariant is violated.
+	 *
+	 * @param messages - Existing message array to mutate
+	 * @param result - Tool execution result keyed by `toolCallId`
+	 */
+	abstract appendToolResult(
+		messages: MessageType[],
+		result: ToolResultMessage,
+	): void;
 
 	/**
 	 * Converts protocol-agnostic tools to model-specific function format.

--- a/src/services/tool-calling.service.ts
+++ b/src/services/tool-calling.service.ts
@@ -2,7 +2,7 @@ import { getManifest } from "@/config/manifest";
 import type { A2AModule, MCPModule, ModelModule } from "@/modules";
 import { CONNECTOR_PROTOCOL_TYPE, type ConnectorTool } from "@/types/connector";
 import type { ThreadObject } from "@/types/memory";
-import type { StreamEvent } from "@/types/stream";
+import type { AssembledToolCall, StreamEvent } from "@/types/stream";
 import { loggers } from "@/utils/logger";
 import {
 	splitAdkToolArgs,
@@ -10,6 +10,14 @@ import {
 } from "@/utils/tool-args";
 
 export type ToolCallingMode = "all" | "mcp";
+
+/**
+ * Hard cap on the tool-calling iteration loop. The loop normally exits when
+ * the model returns a turn with no tool_calls; the cap is a defense-in-depth
+ * guard against runaway interactions caused by protocol drift or persistent
+ * model loops.
+ */
+export const MAX_TOOL_ITERATIONS = 15;
 
 export class ToolCallingService {
 	private modelModule: ModelModule;
@@ -51,8 +59,9 @@ export class ToolCallingService {
 		const tools = [...params.tools];
 		const processList: string[] = [];
 		let isFirstCall = true;
+		let iteration = 0;
 
-		while (true) {
+		for (; iteration < MAX_TOOL_ITERATIONS; iteration++) {
 			const functions = modelInstance.convertToolsToFunctions(tools);
 			const toolChoice =
 				isFirstCall && params.toolChoice === "required" && functions.length > 0
@@ -66,11 +75,8 @@ export class ToolCallingService {
 			);
 			isFirstCall = false;
 
-			const assembledToolCalls: {
-				id: string;
-				type: "function";
-				function: { name: string; arguments: string };
-			}[] = [];
+			const assembledToolCalls: AssembledToolCall[] = [];
+			let assistantText = "";
 
 			for await (const chunk of responseStream) {
 				const delta = chunk.delta;
@@ -89,6 +95,7 @@ export class ToolCallingService {
 						}
 					}
 				} else if (chunk.delta?.content) {
+					assistantText += chunk.delta.content;
 					yield {
 						event: "text_chunk",
 						data: { delta: chunk.delta.content },
@@ -102,13 +109,28 @@ export class ToolCallingService {
 			});
 
 			if (assembledToolCalls.length === 0) {
-				break;
+				return { toolCallsExecuted: processList.length };
 			}
+
+			modelInstance.appendAssistantToolCallTurn(params.messages, {
+				content: assistantText.length > 0 ? assistantText : null,
+				toolCalls: assembledToolCalls,
+			});
 
 			for (const toolCall of assembledToolCalls) {
 				const toolName = toolCall.function.name;
 				const selectedTool = this.selectTool(tools, toolName);
 				if (!selectedTool) {
+					loggers.intent.warn("Tool not found", {
+						toolName,
+						toolCallId: toolCall.id,
+					});
+					modelInstance.appendToolResult(params.messages, {
+						toolCallId: toolCall.id,
+						toolName,
+						content: `Tool "${toolName}" is not available.`,
+						isError: true,
+					});
 					continue;
 				}
 
@@ -121,10 +143,12 @@ export class ToolCallingService {
 						arguments: toolCall.function.arguments,
 						error,
 					});
-					modelInstance.appendMessages(
-						params.messages,
-						`[Bot Called Tool ${toolName}]\nInvalid tool arguments JSON: ${toolCall.function.arguments}`,
-					);
+					modelInstance.appendToolResult(params.messages, {
+						toolCallId: toolCall.id,
+						toolName,
+						content: `Invalid tool arguments JSON: ${toolCall.function.arguments}`,
+						isError: true,
+					});
 					continue;
 				}
 
@@ -147,8 +171,19 @@ export class ToolCallingService {
 
 				loggers.intent.debug("Tool Result", { toolResult });
 				processList.push(toolResult);
-				modelInstance.appendMessages(params.messages, toolResult);
+				modelInstance.appendToolResult(params.messages, {
+					toolCallId: toolCall.id,
+					toolName,
+					content: toolResult,
+				});
 			}
+		}
+
+		if (iteration >= MAX_TOOL_ITERATIONS) {
+			loggers.intent.warn("Tool calling loop reached max iterations cap", {
+				threadId: params.thread.threadId,
+				maxIterations: MAX_TOOL_ITERATIONS,
+			});
 		}
 
 		return { toolCallsExecuted: processList.length };

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -67,6 +67,21 @@ export interface ToolCallDelta {
 }
 
 /**
+ * A fully-assembled tool call reconstructed from a streamed assistant turn.
+ *
+ * The `id` is provider-issued and is the join key between the assistant's
+ * tool call and the corresponding tool result message that follows.
+ */
+export interface AssembledToolCall {
+	id: string;
+	type: "function";
+	function: {
+		name: string;
+		arguments: string;
+	};
+}
+
+/**
  * Normalized stream chunk interface for all LLM providers.
  *
  * This interface provides a consistent structure for stream responses

--- a/tests/services/tool-calling.service.test.ts
+++ b/tests/services/tool-calling.service.test.ts
@@ -1,0 +1,429 @@
+import { setManifest } from "@/config/manifest";
+import type { MCPModule, ModelModule } from "@/modules";
+import type { BaseModel } from "@/modules/models/base.model";
+import {
+	MAX_TOOL_ITERATIONS,
+	ToolCallingService,
+} from "@/services/tool-calling.service";
+import {
+	CONNECTOR_PROTOCOL_TYPE,
+	type ConnectorTool,
+} from "@/types/connector";
+import { ThreadType, type ThreadObject } from "@/types/memory";
+import type {
+	AssembledToolCall,
+	LLMStream,
+	StreamChunk,
+	StreamEvent,
+} from "@/types/stream";
+
+type AnyModel = BaseModel<unknown, unknown>;
+
+function streamOf(chunks: StreamChunk[]): LLMStream {
+	return {
+		[Symbol.asyncIterator]() {
+			let i = 0;
+			return {
+				async next(): Promise<IteratorResult<StreamChunk>> {
+					if (i >= chunks.length) return { done: true, value: undefined };
+					return { done: false, value: chunks[i++] };
+				},
+			};
+		},
+	};
+}
+
+function textChunk(content: string): StreamChunk {
+	return { delta: { content } };
+}
+
+function toolCallChunk(
+	index: number,
+	id: string,
+	name: string,
+	argsJson: string,
+): StreamChunk {
+	return {
+		delta: {
+			tool_calls: [
+				{
+					index,
+					id,
+					type: "function",
+					function: { name, arguments: argsJson },
+				},
+			],
+		},
+	};
+}
+
+function makeModel(streams: LLMStream[]): jest.Mocked<AnyModel> {
+	let call = 0;
+	const model = {
+		generateMessages: jest.fn(() => []),
+		convertToolsToFunctions: jest.fn(() => []),
+		fetchStreamWithContextMessage: jest.fn(async () => {
+			const s = streams[call];
+			call += 1;
+			if (!s) {
+				throw new Error(
+					`fetchStreamWithContextMessage called more times (${call}) than streams provided (${streams.length})`,
+				);
+			}
+			return s;
+		}),
+		appendAssistantToolCallTurn: jest.fn(),
+		appendToolResult: jest.fn(),
+		fetch: jest.fn(),
+		fetchWithContextMessage: jest.fn(),
+	} as unknown as jest.Mocked<AnyModel>;
+	return model;
+}
+
+function makeModelModule(model: AnyModel): ModelModule {
+	return {
+		getModel: () => model,
+		getModelOptions: () => ({}),
+	} as unknown as ModelModule;
+}
+
+function makeThread(): ThreadObject {
+	return {
+		userId: "user-1",
+		threadId: "thread-1",
+		type: ThreadType.CHAT,
+		title: "Test",
+		messages: [],
+	};
+}
+
+function mcpTool(name: string): ConnectorTool {
+	return {
+		toolName: name,
+		connectorName: "mcp-connector",
+		protocol: CONNECTOR_PROTOCOL_TYPE.MCP,
+		description: name,
+		inputSchema: { type: "object" },
+	};
+}
+
+async function drain<TYield, TReturn>(
+	gen: AsyncGenerator<TYield, TReturn, unknown>,
+): Promise<{ events: TYield[]; result: TReturn }> {
+	const events: TYield[] = [];
+	let next = await gen.next();
+	while (!next.done) {
+		events.push(next.value);
+		next = await gen.next();
+	}
+	return { events, result: next.value };
+}
+
+beforeAll(() => {
+	setManifest({
+		name: "TestAgent",
+		description: "test",
+	});
+});
+
+describe("ToolCallingService", () => {
+	it("returns without pushing assistant turn when no tool calls are emitted", async () => {
+		const model = makeModel([streamOf([textChunk("hello "), textChunk("world")])]);
+		const svc = new ToolCallingService(makeModelModule(model));
+		const messages: unknown[] = [];
+
+		const { events, result } = await drain(
+			svc.run({
+				messages,
+				tools: [],
+				query: "hi",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(result.toolCallsExecuted).toBe(0);
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "hello " } },
+			{ event: "text_chunk", data: { delta: "world" } },
+		]);
+		expect(model.appendAssistantToolCallTurn).not.toHaveBeenCalled();
+		expect(model.appendToolResult).not.toHaveBeenCalled();
+	});
+
+	it("pushes a single assistant tool-call turn and a matching tool result", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "call_1", "search", '{"q":"foo"}')]),
+			streamOf([textChunk("final answer")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(async () => "mcp result"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+		const messages: unknown[] = [];
+
+		const { result } = await drain(
+			svc.run({
+				messages,
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(result.toolCallsExecuted).toBe(1);
+		expect(model.appendAssistantToolCallTurn).toHaveBeenCalledTimes(1);
+		expect(model.appendAssistantToolCallTurn).toHaveBeenCalledWith(messages, {
+			content: null,
+			toolCalls: [
+				{
+					id: "call_1",
+					type: "function",
+					function: { name: "search", arguments: '{"q":"foo"}' },
+				},
+			] satisfies AssembledToolCall[],
+		});
+		expect(model.appendToolResult).toHaveBeenCalledTimes(1);
+		expect(model.appendToolResult).toHaveBeenCalledWith(messages, {
+			toolCallId: "call_1",
+			toolName: "search",
+			content: "mcp result",
+		});
+		expect(mcp.useTool).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves streamed text alongside tool calls in the assistant turn", async () => {
+		const model = makeModel([
+			streamOf([
+				textChunk("Let me check. "),
+				toolCallChunk(0, "call_a", "search", '{"q":"x"}'),
+			]),
+			streamOf([textChunk("done")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(async () => "ok"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(model.appendAssistantToolCallTurn).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ content: "Let me check. " }),
+		);
+	});
+
+	it("pushes one tool result per tool call in the same round, matched by id", async () => {
+		const model = makeModel([
+			streamOf([
+				toolCallChunk(0, "id_a", "search", '{"q":"a"}'),
+				toolCallChunk(1, "id_b", "lookup", '{"k":"b"}'),
+			]),
+			streamOf([textChunk("aggregated")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(async (tool: ConnectorTool) => `result:${tool.toolName}`),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		const { result } = await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search"), mcpTool("lookup")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(result.toolCallsExecuted).toBe(2);
+		expect(model.appendAssistantToolCallTurn).toHaveBeenCalledTimes(1);
+		expect(model.appendToolResult).toHaveBeenCalledTimes(2);
+		expect(model.appendToolResult).toHaveBeenNthCalledWith(1, expect.anything(), {
+			toolCallId: "id_a",
+			toolName: "search",
+			content: "result:search",
+		});
+		expect(model.appendToolResult).toHaveBeenNthCalledWith(2, expect.anything(), {
+			toolCallId: "id_b",
+			toolName: "lookup",
+			content: "result:lookup",
+		});
+	});
+
+	it("pushes an isError tool result and skips dispatch when arguments are invalid JSON", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "call_bad", "search", "{not json")]),
+			streamOf([textChunk("fallback")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(mcp.useTool).not.toHaveBeenCalled();
+		expect(model.appendToolResult).toHaveBeenCalledWith(expect.anything(), {
+			toolCallId: "call_bad",
+			toolName: "search",
+			content: expect.stringContaining("Invalid tool arguments JSON"),
+			isError: true,
+		});
+	});
+
+	it("pushes an isError tool result when the model calls an unknown tool", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "call_x", "doesNotExist", "{}")]),
+			streamOf([textChunk("done")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(mcp.useTool).not.toHaveBeenCalled();
+		expect(model.appendToolResult).toHaveBeenCalledWith(expect.anything(), {
+			toolCallId: "call_x",
+			toolName: "doesNotExist",
+			content: expect.stringContaining("not available"),
+			isError: true,
+		});
+	});
+
+	it("stops the loop at MAX_TOOL_ITERATIONS when the model keeps issuing tool calls", async () => {
+		const looping: LLMStream[] = Array.from(
+			{ length: MAX_TOOL_ITERATIONS + 5 },
+			(_, i) =>
+				streamOf([toolCallChunk(0, `call_${i}`, "search", '{"q":"x"}')]),
+		);
+		const model = makeModel(looping);
+		const mcp = {
+			useTool: jest.fn(async () => "x"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		const { result } = await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(model.fetchStreamWithContextMessage).toHaveBeenCalledTimes(
+			MAX_TOOL_ITERATIONS,
+		);
+		expect(model.appendAssistantToolCallTurn).toHaveBeenCalledTimes(
+			MAX_TOOL_ITERATIONS,
+		);
+		expect(result.toolCallsExecuted).toBe(MAX_TOOL_ITERATIONS);
+	});
+
+	it("downgrades toolChoice from 'required' to 'auto' after the first round", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "call_1", "search", "{}")]),
+			streamOf([textChunk("done")]),
+		]);
+		// "required" only takes effect when functions.length > 0
+		(model.convertToolsToFunctions as jest.Mock).mockReturnValue([
+			{ name: "search" },
+		]);
+		const mcp = {
+			useTool: jest.fn(async () => "ok"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+				toolChoice: "required",
+			}),
+		);
+
+		const calls = (model.fetchStreamWithContextMessage as jest.Mock).mock.calls;
+		expect(calls[0][2]).toMatchObject({ toolChoice: "required" });
+		expect(calls[1][2]).toMatchObject({ toolChoice: "auto" });
+	});
+
+	it("invokes appendAssistantToolCallTurn before any appendToolResult call", async () => {
+		const order: string[] = [];
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "id_a", "search", "{}")]),
+			streamOf([textChunk("done")]),
+		]);
+		(model.appendAssistantToolCallTurn as jest.Mock).mockImplementation(() => {
+			order.push("assistant");
+		});
+		(model.appendToolResult as jest.Mock).mockImplementation(() => {
+			order.push("tool");
+		});
+		const mcp = {
+			useTool: jest.fn(async () => "ok"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(order).toEqual(["assistant", "tool"]);
+	});
+
+	it("yields a thinking_process event before each successful tool dispatch", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "id_a", "search", "{}")]),
+			streamOf([textChunk("done")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(async () => "ok"),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		const { events } = await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("search")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		const thinking = events.filter(
+			(e): e is Extract<StreamEvent, { event: "thinking_process" }> =>
+				e.event === "thinking_process",
+		);
+		expect(thinking).toHaveLength(1);
+		expect(thinking[0].data.title).toContain("search");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes an infinite tool-call loop caused by protocol-level violations in how the assistant turn and tool results were threaded back into the LLM message history. Previously, every tool result was pushed as a plain `role:"user"` text message and the assistant's `tool_calls` turn was never echoed back into history — so the model lost the trace that it had already issued tool calls and re-derived the same first-step plan every round.

This is a **breaking change** to `BaseModel`: the old `appendMessages` abstract is removed and replaced with two protocol-aware abstracts. Downstream providers (including Azure/Gemini in `ain-adk-providers`) must migrate. A companion PR updates both first-party providers — that PR must land in lockstep with the next SDK release.

## Root cause

Two protocol violations compounded:

1. **`appendMessages` collapsed tool results into `role:"user"` text** ([src/modules/models/base.model.ts](src/modules/models/base.model.ts)). OpenAI/Azure require `{role:"tool", tool_call_id, content}`; Gemini requires a `functionResponse` part. The generic `(messages, message: string)` signature couldn't express either.
2. **The assistant's `tool_calls` turn was never pushed back into the in-flight message array** ([src/services/tool-calling.service.ts](src/services/tool-calling.service.ts)). `assembledToolCalls` was used only to dispatch tools, then discarded. From the model's POV on iteration N+1, the history showed the original user query + stringified tool outputs labelled `role:"user"`, with no record that the assistant had issued the prior calls.

Result: the model re-derived "I should call list_scopes → reason.query first" every round and looped indefinitely. The previous `while (true)` had no cap, so the loop only terminated when the surrounding request was killed.

## Changes

### `BaseModel` API (breaking)

Removed:
- `abstract appendMessages(messages, message: string): void`

Added:
- `abstract appendAssistantToolCallTurn(messages, { content, toolCalls }): void` — push the assistant turn after a streamed response containing tool_calls, preserving any text content emitted in the same turn.
- `abstract appendToolResult(messages, { toolCallId, toolName, content, isError? }): void` — push one tool result per `toolCallId` from the most recent assistant turn.

New exports: `AssistantToolCallTurn`, `ToolResultMessage`, `AssembledToolCall` (the last from `@ainetwork/adk/types/stream`).

Each provider translates these into its native shape:
- OpenAI / Azure → `{role:"assistant", content, tool_calls}` and `{role:"tool", tool_call_id, content}`
- Gemini → `{role:"model", parts:[{text?}, {functionCall}]}` and `{role:"user", parts:[{functionResponse}]}`
- Anthropic (downstream) → `{role:"assistant", content:[{type:"text"?},{type:"tool_use"}]}` and `{role:"user", content:[{type:"tool_result", tool_use_id, content, is_error?}]}`

### `ToolCallingService`

- Pushes the assembled assistant turn (with any streamed text accumulated as `content`) **before** dispatching tools.
- Pushes a tool result for **every** `toolCallId` in that turn — including unknown-tool and invalid-JSON paths — with `isError:true`. Without this, OpenAI/Azure return 400 on the next request due to unmatched `tool_calls`.
- Adds `MAX_TOOL_ITERATIONS = 15` as defense-in-depth against runaway loops.
- The error path that previously did silent `continue` on invalid JSON now feeds the error back to the model so it can self-correct.