### PR TITLE
add template category

### DIFF
--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -387,6 +387,8 @@ export interface WorkflowTemplate {
 	title: string;
 	description: string;
 	active: boolean;
+	/** Classification label for grouping templates in the UI (e.g. "식음", "객실"). */
+	category?: string;
 	/** The prompt/instruction template with {{variable}} placeholders */
 	content: string;
 	/** Structured workflow definition. If omitted, legacy content execution is used. */
@@ -410,6 +412,8 @@ export interface UserWorkflow {
 	title: string;
 	description?: string;
 	active: boolean;
+	/** Classification label for grouping workflows in the UI (e.g. "식음", "객실"). Copied from the source template. */
+	category?: string;
 
 	/** Reference to the original WorkflowTemplate (optional) */
 	templateId?: string;


### PR DESCRIPTION
## Summary

Adds an optional `category` field to workflow types so the UI can group/classify
workflow templates by category (e.g. `"식음"`, `"객실"`).

## Changes

- Add `category?: string` to the `WorkflowTemplate` interface — classification label for grouping templates in the UI.
- Add `category?: string` to the `UserWorkflow` interface — copied from the source template so user-owned workflows can be filtered the same way.

Both fields live in `src/types/memory.ts`.

## Design notes

- **Free-form string** rather than an enum, so new categories can be added without code changes.
- **No controller/service changes required:**
  - `WorkflowTemplateApiController` passes `req.body` straight through to `createTemplate` / `updateTemplate`, so `category` is persisted automatically.
  - `UserWorkflowService.createWorkflow` spreads `...workflow`, so `category` propagates on creation when the client includes it.
- There is no server-side "create from template" copy step; the client reads a template and POSTs the workflow, so the client is responsible for carrying `category` over.

## Follow-ups (out of scope)

- `listTemplates()` still returns all templates unfiltered — grouping is handled UI-side, or a query-param filter can be added later if needed.
- Persistence depends on each memory-module implementation (e.g. `ain-adk-providers`); implementations that whitelist columns/fields must add `category` to actually store it.
