### PR TITLE
Add document artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A TypeScript library for building AI agents with multi-protocol support includin
 - **Thread Management**: Built-in memory module for conversation history
 - **Intent System**: Single/multi-intent triggering with intelligent response aggregation
 - **Workflow Management**: Built-in workflow storage and execution with display query support
+- **Document System**: First-class, mutable documents with slot-filling, faceted labels, and AI-generated advice
 - **Dual Build System**: Supports both ESM and CJS formats for maximum compatibility
 - **Structured Logging**: Winston-based logging system with service-specific loggers
 - **TypeScript First**: Built with strict TypeScript configuration
@@ -70,6 +71,8 @@ interface AINAgentModules {
 
 Each module can be independently configured and passed to the agent constructor.
 
+The `MemoryModule` exposes an optional `IDocumentMemory` (`getDocumentMemory()`). When the underlying memory implementation provides it, document storage and the `/api/document` endpoints are enabled; older implementations that omit it remain fully backward compatible.
+
 ### Intent System
 
 The library supports flexible intent triggering modes:
@@ -87,6 +90,25 @@ Built-in workflow management capabilities:
 - **Display Query Support**: Separate display query for workflow execution visualization
 - **Structured Execution**: Define workflows with tasks and response blocks
 - **RESTful API**: Complete workflow management through `/api/workflow-template` and `/api/user-workflow` endpoints
+
+### Document System
+
+Documents are first-class, **mutable** entities that hold the canonical result of a workflow or query as markdown. They are *referenced* from threads (via a `document` message part) rather than embedded, so manual edits are always reflected wherever the document is rendered. The system is enabled whenever the memory implementation provides an `IDocumentMemory` (`getDocumentMemory()`); it is optional and fully backward compatible.
+
+- **Document Storage**: CRUD via `IDocumentMemory` — `getDocument`, `createDocument`, `updateDocument`, `deleteDocument`, `listDocuments(userId?, filter?)`. Documents are versioned (`version` increments on every update) and track `editedManually`.
+- **Slots**: A document body may contain `{{slot:slotId}}` tokens backed by `DocumentSlot` entries. Each slot has a lifecycle status (`empty` → `running` → `resolved`/`failed`) and an optional `binding` to a workflow (with `executionVariables`) or a query. Slots are filled on demand and the resolved `DocumentFragment` (markdown + structured render blocks) is substituted at render time.
+- **Rendering**: `renderDocument(document)` (`src/utils/document-render.ts`) produces final markdown by substituting each slot token with its resolved fragment, falling back to a status placeholder for unresolved slots. Tokens with no matching slot are left untouched.
+- **Faceted Labels**: `labels` (e.g. `{ category: "logbook", workplaceId: "123", month: "2026-06" }`) provide schema-free grouping. The nesting/hierarchy order is chosen at query or render time, so any number of grouping levels is supported without schema changes. Listing supports subset-match filtering by `labels`, plus `workflowId`/`threadId`/`source`.
+- **Workflow Promotion**: When document memory is available, a user-workflow execution promotes its result into a first-class document and references it from the thread (instead of embedding the markdown inline).
+- **Rich Messages**: Thread message content supports `type: "rich"` with `MessagePart[]` mixing `TextPart` and `DocumentPart` (a `documentId` reference resolved client-side), alongside the legacy `text` form.
+
+### AI Document Advice
+
+The library can generate a short, operational AI **advice** from a document's rendered content:
+
+- **Streaming generation**: `DocumentAdviceService.generateAdviceStream` runs a single-turn streaming completion over the rendered document and emits `text_chunk` events over SSE.
+- **Caching**: On completion the advice is cached on `document.advice` (`{ content, generatedAt }`). The cache write persists only the advice metadata and does not bump the document version, avoiding lost updates against concurrent edits. Nothing is persisted on error or empty output.
+- **Prompt resolution**: A per-call `advicePrompt` (request body) takes precedence, then the agent-memory hook `getDocumentAdvicePrompt()`, then a built-in Korean default prompt.
 
 ### Dependency Injection
 
@@ -118,6 +140,7 @@ Benefits:
 - Automatic tool discovery and execution
 - Supports multiple concurrent MCP servers
 - Protocol-specific tool wrapping as `IMCPTool`
+- Per-connector `requestTimeoutMs` override (in `MCPConfig`) for long-running tools; overrides the SDK's default 60s per-request timeout and uses `resetTimeoutOnProgress` so tools that stream progress notifications stay alive past the base timeout
 
 #### A2A (Agent-to-Agent)  
 - RESTful API for inter-agent communication
@@ -132,6 +155,7 @@ Benefits:
 - **Streaming Support**: Dual implementation for streaming and non-streaming queries
 - **Intent System**: Single/multi-intent triggering with intelligent response aggregation
 - **Workflow Management**: Built-in workflow storage and execution with display query support
+- **Document System**: Mutable documents with on-demand slot-filling, faceted labels, and cached AI advice
 - **Service Layer**: Clean separation with controllers and services
 - **Type Safety**: Comprehensive TypeScript types with strict mode
 - **Error Handling**: Global error middleware with structured logging
@@ -209,6 +233,7 @@ modelLogger.error('Model API error');
     - `task_output`: Workflow task output chunk
     - `task_result`: Workflow task completion status
     - `thread_id`: Thread metadata
+    - `document_id`: Document/slot reference (`{ documentId, slotId }`) for slot-fill streams
     - `thinking_process`: Thinking/reasoning steps
     - `collection_name`: Collection metadata emitted by integrations
     - `error`: Error message
@@ -235,6 +260,18 @@ modelLogger.error('Model API error');
 - `POST /api/user-workflow/:id/execute/stream` - Execute user workflow with streaming (SSE)
 - `POST /api/user-workflow/update/:id` - Update user workflow
 - `POST /api/user-workflow/delete/:id` - Delete user workflow
+
+### Document Endpoints (when the memory module provides `IDocumentMemory`)
+- `GET /api/document` - List documents (filterable by `workflowId`, `threadId`, `source`, and subset-match `labels[...]`)
+- `GET /api/document/:id` - Get document details
+- `POST /api/document` - Create a document (`source: MANUAL`)
+- `POST /api/document/:id/slots/:slotId/fill` - Fill a slot via its bound workflow/query (non-streaming)
+- `POST /api/document/:id/slots/:slotId/fill/stream` - Fill a slot with streaming (SSE)
+  - Body: `{ workflowId?: string, executionVariables?: Record<string, string> }`
+- `POST /api/document/:id/advice/stream` - Generate AI advice with streaming (SSE)
+  - Body: `{ advicePrompt?: string }` (optional per-call prompt override)
+- `POST /api/document/update/:id` - Update document (`title`/`content`/`slots`/`labels`; marks `editedManually`)
+- `POST /api/document/delete/:id` - Delete document
 
 ### A2A Server Endpoints (when `manifest.url` is configured)
 - `GET /.well-known/agent.json` - Agent discovery endpoint (A2A ~v0.2.0)

--- a/docs/superpowers/plans/2026-06-17-document-ai-advice.md
+++ b/docs/superpowers/plans/2026-06-17-document-ai-advice.md
@@ -1,0 +1,633 @@
+# Document AI Advice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a short AI advice from a log book document's content (streamed, cached on the document) and show it in a code-block-style card at the bottom of the log book detail.
+
+**Architecture:** A dedicated ADK service streams a single-turn model completion (system = advice prompt, user = `renderDocument(document)`), emits `text_chunk` SSE events, and caches the result on `document.advice`. A new `POST /api/document/:id/advice/stream` endpoint mirrors the slot-fill streaming endpoint. The WISE log book detail consumes the stream and renders the advice.
+
+**Tech Stack:** ain-adk-v0 (TS, Express, jest, SSE); ain-enterprise-monorepo (@repo/utils types, @repo/ui SSE utils, WISE React).
+
+> **Repos & branches:** Tasks 1–5 in `ain-adk-v0` (create a branch, e.g. `git checkout -b feature/document-ai-advice` if on a shared branch). Tasks 6–8 in `ain-enterprise-monorepo` (branch `feature/seonghwa/wise-logbook` is active there). ain-adk-v0 has jest; the monorepo apps have no test runner (verify with tsc/build/manual).
+
+---
+
+### Task 1: ADK — `DocumentAdvice` type on `Document`
+
+**Files:** Modify `src/types/document.ts`
+
+- [ ] **Step 1: Add the type + field**
+
+In `src/types/document.ts`, add this interface just above `export interface Document {`:
+```ts
+/** AI-generated advice derived from a document's rendered content. */
+export interface DocumentAdvice {
+	/** Generated advice text (plain prose / light markdown). */
+	content: string;
+	/** ISO timestamp when generated. */
+	generatedAt: string;
+}
+```
+Then inside `export interface Document { ... }`, add after the `blocks?` line (around line 95):
+```ts
+	/** Cached AI advice generated from the rendered content. */
+	advice?: DocumentAdvice;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json` (or `yarn build` later). Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/document.ts
+git commit -m "feat(document): add DocumentAdvice type"
+```
+
+---
+
+### Task 2: ADK — advice prompt + agent-memory hook
+
+**Files:**
+- Create: `src/services/prompts/document-advice.ts`
+- Modify: `src/modules/memory/base.memory.ts`
+
+- [ ] **Step 1: Add the agent-memory prompt hook**
+
+In `src/modules/memory/base.memory.ts`, in the `IAgentMemory` interface, add alongside the other `getXxxPrompt?` members (after `getGenerateTitlePrompt?(): Promise<string>;`):
+```ts
+	getDocumentAdvicePrompt?(): Promise<string>;
+```
+
+- [ ] **Step 2: Create the prompt module** (mirrors `generate-title.ts`)
+
+`src/services/prompts/document-advice.ts`:
+```ts
+import type { MemoryModule } from "@/modules";
+
+async function documentAdvicePrompt(memoryModule: MemoryModule) {
+	const prompt =
+		(await memoryModule?.getAgentMemory()?.getDocumentAdvicePrompt?.()) ||
+		`당신은 매장 운영을 돕는 분석 어시스턴트입니다.
+아래는 한 매장의 로그북(운영 메모와 매출/지표 데이터)입니다.
+이 내용을 바탕으로 운영자에게 도움이 되는 조언을 한국어로 작성하세요.
+
+작성 지침:
+- 문단형 산문으로 작성하고, 마크다운 제목/불릿은 사용하지 마세요.
+- 먼저 오늘 운영에 대한 간단한 인정/격려로 시작하세요.
+- 다음 영업일 전망과, 데이터에 근거한 수치 기대치를 제시하세요.
+- 입력에 없는 수치나 사실을 지어내지 마세요. 데이터가 없으면 일반적인 조언만 하세요.
+- 실행 가능한 운영 팁을 1~2가지 제시하세요.
+- 마지막은 짧은 응원의 한 문장으로 마무리하세요.
+- 사용자가 입력한 언어로 답하세요.`;
+	return prompt;
+}
+
+export default documentAdvicePrompt;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/prompts/document-advice.ts src/modules/memory/base.memory.ts
+git commit -m "feat(document-advice): add advice prompt and agent-memory hook"
+```
+
+---
+
+### Task 3: ADK — `DocumentAdviceService` (+ unit test)
+
+**Files:**
+- Create: `src/services/document-advice.service.ts`
+- Test: `tests/services/document-advice.service.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/document-advice.service.test.ts`:
+```ts
+import { DocumentAdviceService } from "@/services/document-advice.service";
+import type { MemoryModule, ModelModule } from "@/modules";
+
+async function collect(gen: AsyncGenerator<unknown>): Promise<unknown[]> {
+	const out: unknown[] = [];
+	for await (const e of gen) out.push(e);
+	return out;
+}
+
+describe("DocumentAdviceService", () => {
+	const document = {
+		documentId: "doc-1",
+		userId: "u1",
+		title: "Log",
+		format: "MARKDOWN",
+		content: "## 매출\n{{slot:rev}}\n",
+		version: 2,
+		source: "MANUAL",
+		slots: [
+			{
+				slotId: "rev",
+				status: "resolved",
+				fragment: { content: "총매출 100만원", source: { type: "QUERY", query: "" }, resolvedAt: "t" },
+			},
+		],
+		createdAt: "t0",
+		updatedAt: "t0",
+	};
+
+	function makeModules(updateDocument = jest.fn(async () => undefined)) {
+		const model = {
+			generateMessages: jest.fn(() => [{ role: "user", content: "x" }]),
+			fetchStreamWithContextMessage: jest.fn(async () => ({
+				async *[Symbol.asyncIterator]() {
+					yield { delta: { content: "좋은 " } };
+					yield { delta: { content: "하루였습니다." } };
+				},
+			})),
+		};
+		const modelModule = {
+			getModel: () => model,
+			getModelOptions: () => ({}),
+		} as unknown as ModelModule;
+		const memoryModule = {
+			getDocumentMemory: () => ({
+				getDocument: jest.fn(async () => document),
+				updateDocument,
+			}),
+			getAgentMemory: () => ({}),
+		} as unknown as MemoryModule;
+		return { modelModule, memoryModule, model, updateDocument };
+	}
+
+	it("streams advice text and caches it on the document", async () => {
+		const { modelModule, memoryModule, updateDocument } = makeModules();
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+
+		const events = await collect(service.generateAdviceStream("doc-1"));
+
+		const text = events
+			.filter((e: any) => e.event === "text_chunk")
+			.map((e: any) => e.data.delta)
+			.join("");
+		expect(text).toBe("좋은 하루였습니다.");
+
+		// Persisted advice on completion.
+		const lastCall = updateDocument.mock.calls.at(-1);
+		expect(lastCall?.[0]).toBe("doc-1");
+		expect((lastCall?.[1] as any).advice.content).toBe("좋은 하루였습니다.");
+		expect(typeof (lastCall?.[1] as any).advice.generatedAt).toBe("string");
+	});
+
+	it("does not persist when the model produces no content", async () => {
+		const { modelModule, memoryModule, model, updateDocument } = makeModules();
+		(model.fetchStreamWithContextMessage as jest.Mock).mockResolvedValue({
+			async *[Symbol.asyncIterator]() {
+				/* no chunks */
+			},
+		});
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+		await collect(service.generateAdviceStream("doc-1"));
+		expect(updateDocument).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest tests/services/document-advice.service.test.ts`
+Expected: FAIL (module `document-advice.service` not found).
+
+- [ ] **Step 3: Implement the service**
+
+`src/services/document-advice.service.ts`:
+```ts
+import type { MemoryModule, ModelModule } from "@/modules";
+import type { StreamEvent } from "@/types/stream.js";
+import { loggers } from "@/utils/logger.js";
+import { renderDocument } from "@/utils/document-render.js";
+import documentAdvicePrompt from "./prompts/document-advice.js";
+
+/**
+ * Generates AI advice for a document by running a single-turn streaming model
+ * completion over the document's rendered content, then caches the result on
+ * `document.advice`. Mirrors the streaming-text pattern used by the workflow
+ * response composer.
+ */
+export class DocumentAdviceService {
+	private modelModule: ModelModule;
+	private memoryModule: MemoryModule;
+
+	constructor(modelModule: ModelModule, memoryModule: MemoryModule) {
+		this.modelModule = modelModule;
+		this.memoryModule = memoryModule;
+	}
+
+	async *generateAdviceStream(
+		documentId: string,
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+		const documentMemory = this.memoryModule.getDocumentMemory();
+		if (!documentMemory) {
+			throw new Error("Document memory is not initialized");
+		}
+		const document = await documentMemory.getDocument(documentId);
+		if (!document) {
+			throw new Error(`Document not found: ${documentId}`);
+		}
+
+		const renderedContent = renderDocument(document);
+		const systemPrompt = await documentAdvicePrompt(this.memoryModule);
+
+		const model = this.modelModule.getModel();
+		const modelOptions = this.modelModule.getModelOptions();
+		const messages = model.generateMessages({
+			query: renderedContent,
+			systemPrompt,
+		});
+
+		let content = "";
+		const stream = await model.fetchStreamWithContextMessage(
+			messages,
+			[],
+			modelOptions,
+		);
+		for await (const chunk of stream) {
+			if (signal?.aborted) {
+				throw new Error("Advice generation aborted by client");
+			}
+			if (chunk.delta?.content) {
+				content += chunk.delta.content;
+				yield { event: "text_chunk", data: { delta: chunk.delta.content } };
+			}
+		}
+
+		if (!content.trim()) {
+			return;
+		}
+
+		try {
+			await documentMemory.updateDocument(documentId, {
+				advice: { content, generatedAt: new Date().toISOString() },
+				version: document.version + 1,
+				updatedAt: new Date().toISOString(),
+			});
+		} catch (saveError) {
+			loggers.agent.error("Failed to cache document advice", {
+				documentId,
+				error: saveError,
+			});
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn jest tests/services/document-advice.service.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/document-advice.service.ts tests/services/document-advice.service.test.ts
+git commit -m "feat(document-advice): add DocumentAdviceService with streaming + cache"
+```
+
+---
+
+### Task 4: ADK — controller method, route, DI wiring
+
+**Files:**
+- Modify: `src/controllers/api/document.api.controller.ts`
+- Modify: `src/routes/api/document.routes.ts`
+- Modify: `src/container/index.ts`
+
+- [ ] **Step 1: Add a container accessor + pass service to the controller**
+
+In `src/container/index.ts`:
+- Add an import near the other service imports: `import { DocumentAdviceService } from "@/services/document-advice.service";`
+- Add a private field near `_workflowExecutionService`: `private _documentAdviceService?: DocumentAdviceService;`
+- Add an accessor method (mirror `getWorkflowExecutionService`), using the existing module getters (`getModelModule()` / `getMemoryModule()` — confirm their names in this file; they are the same getters the other services use):
+```ts
+	getDocumentAdviceService(): DocumentAdviceService {
+		if (!this._documentAdviceService) {
+			this._documentAdviceService = new DocumentAdviceService(
+				getModelModule(),
+				getMemoryModule(),
+			);
+		}
+		return this._documentAdviceService;
+	}
+```
+- In `getDocumentApiController()`, pass the advice service as a third constructor arg:
+```ts
+			this._documentApiController = new DocumentApiController(
+				getMemoryModule(),
+				this.getWorkflowExecutionService(),
+				this.getDocumentAdviceService(),
+			);
+```
+- In the `reset()` method (where `_documentApiController = undefined;` is), add: `this._documentAdviceService = undefined;`
+
+> Note: confirm the exact module-getter names used at the top of this file for model/memory (e.g. `getModelModule`, `getMemoryModule` from `@/config/modules`) and match them.
+
+- [ ] **Step 2: Accept the service in the controller + add the handler**
+
+In `src/controllers/api/document.api.controller.ts`:
+- Add an import: `import type { DocumentAdviceService } from "@/services/document-advice.service.js";`
+- Add a field and constructor param (the controller currently takes `memoryModule` and `workflowExecutionService`):
+```ts
+	private documentAdviceService: DocumentAdviceService;
+
+	constructor(
+		memoryModule: MemoryModule,
+		workflowExecutionService: WorkflowExecutionService,
+		documentAdviceService: DocumentAdviceService,
+	) {
+		this.memoryModule = memoryModule;
+		this.workflowExecutionService = workflowExecutionService;
+		this.documentAdviceService = documentAdviceService;
+	}
+```
+- Add a handler mirroring `handleFillSlotStream` (same `streamEventsToSSE` usage), at the end of the class:
+```ts
+	public handleGenerateAdviceStream = async (req: Request, res: Response) => {
+		const userId = res.locals.userId || "";
+		const { id } = req.params as { id: string };
+
+		await streamEventsToSSE(req, res, {
+			logLabel: "Document advice stream",
+			userId,
+			logContext: { documentId: id },
+			setup: async (signal) => {
+				await this.getAuthorizedDocument(userId, id);
+				return this.documentAdviceService.generateAdviceStream(id, signal);
+			},
+		});
+	};
+```
+
+- [ ] **Step 3: Add the route**
+
+In `src/routes/api/document.routes.ts`, add after the slot fill stream route:
+```ts
+	router.post(
+		"/:id/advice/stream",
+		checkDocumentMemory,
+		controller.handleGenerateAdviceStream,
+	);
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/controllers/api/document.api.controller.ts src/routes/api/document.routes.ts src/container/index.ts
+git commit -m "feat(document-advice): add advice stream endpoint + DI wiring"
+```
+
+---
+
+### Task 5: ADK — build + full test run
+
+- [ ] **Step 1: Build (ESM/CJS + DTS)**
+
+Run: `yarn build`. Expected: `Done`, no type errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `yarn test`. Expected: all suites pass (including the new advice test).
+
+- [ ] **Step 3 (deploy refresh): refresh local-agents install** so the running agent has the new endpoint:
+
+```bash
+cd /Users/shyun/comcom/ain-enterprise/local-agents && rm -rf node_modules && pnpm install
+grep -rl "generateAdviceStream" node_modules/@ainetwork/adk/dist >/dev/null && echo "FRESH" || echo "STALE"
+```
+Expected: `FRESH`. (Then the agent process must be restarted — manual.)
+
+---
+
+### Task 6: monorepo — mirror `DocumentAdvice` in @repo/utils
+
+**Files:** Modify `packages/utils/src/types/document.ts`
+
+- [ ] **Step 1: Add the type + field**
+
+Add above `export interface Document {`:
+```ts
+/** AI-generated advice derived from a document's rendered content. */
+export interface DocumentAdvice {
+  content: string;
+  generatedAt: string;
+}
+```
+Inside `Document`, after the `blocks?` line:
+```ts
+  /** Cached AI advice generated from the rendered content. */
+  advice?: DocumentAdvice;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run from `ain-enterprise-monorepo`: `npx tsc --noEmit -p packages/utils/tsconfig.json` (or the repo's typecheck). Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/utils/src/types/document.ts
+git commit -m "feat(utils): mirror DocumentAdvice on Document type"
+```
+
+---
+
+### Task 7: WISE — `useDocumentAdvice` streaming hook
+
+**Files:** Create `apps/wise/src/hooks/use-document-advice.ts`
+
+- [ ] **Step 1: Implement the hook**
+
+`apps/wise/src/hooks/use-document-advice.ts`:
+```ts
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useAuthStreamFetch } from '@repo/auth';
+import { parseSSEBuffer } from '@repo/ui';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+interface UseDocumentAdviceState {
+  /** Live/streamed advice text (set during generation). */
+  streamed: string;
+  isGenerating: boolean;
+  error: string | null;
+  /** Starts (or restarts) advice generation, streaming text in. */
+  generate: () => Promise<void>;
+}
+
+/** Streams AI advice for a document from the ADK advice endpoint. */
+export function useDocumentAdvice(documentId: string): UseDocumentAdviceState {
+  const authStreamFetch = useAuthStreamFetch();
+  const [streamed, setStreamed] = useState('');
+  const [isGenerating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generate = useCallback(async () => {
+    if (!API_URL) return;
+    setGenerating(true);
+    setError(null);
+    setStreamed('');
+    try {
+      const { reader } = await authStreamFetch(
+        `${API_URL}/api/document/${encodeURIComponent(documentId)}/advice/stream`,
+        {},
+      );
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let text = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { events, remaining } = parseSSEBuffer(buffer);
+        buffer = remaining;
+        for (const e of events) {
+          if (e.event === 'text_chunk' && e.data?.delta) {
+            text += e.data.delta;
+            setStreamed(text);
+          } else if (e.event === 'error') {
+            throw new Error(e.data?.message || 'advice stream error');
+          }
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '조언을 생성하지 못했습니다.');
+    } finally {
+      setGenerating(false);
+    }
+  }, [authStreamFetch, documentId]);
+
+  return { streamed, isGenerating, error, generate };
+}
+```
+Notes: `useAuthStreamFetch()` (from `@repo/auth`) returns a function `(url, body, signal?) => Promise<{ reader }>` that attaches the auth header (used by the chat stream). `parseSSEBuffer` (from `@repo/ui`) returns `{ events, remaining }` where each event is `{ event, data }`. If the `e.data` shape differs (string vs object), adapt the access and report — check `packages/ui/src/lib/sse-parser.ts`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd apps/wise && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "use-document-advice|error TS" | head`. Expected: empty.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/wise/src/hooks/use-document-advice.ts
+git commit -m "feat(wise): add useDocumentAdvice streaming hook"
+```
+
+---
+
+### Task 8: WISE — AI advice card in `log-book-detail.tsx`
+
+**Files:** Modify `apps/wise/src/components/log-book-detail.tsx`
+
+- [ ] **Step 1: Wire the hook + auto-generate, render the card**
+
+Add imports at the top (with the existing imports):
+```tsx
+import { useEffect } from 'react';
+import { useDocumentAdvice } from '../hooks/use-document-advice';
+```
+(If `useState` is already imported from 'react', add `useEffect` to that import instead of a duplicate line.)
+
+Inside the `LogBookDetail` component, after the existing `useDocument(...)` call, add:
+```tsx
+  const advice = useDocumentAdvice(documentId);
+  // 슬롯이 모두 resolved(또는 슬롯 없음)이고 캐시된 advice가 없으면 자동 생성.
+  const slotsReady =
+    (document?.slots ?? []).every((s) => s.status === 'resolved');
+  const hasCachedAdvice = Boolean(document?.advice?.content);
+  useEffect(() => {
+    if (
+      document &&
+      !hasCachedAdvice &&
+      slotsReady &&
+      !advice.isGenerating &&
+      !advice.streamed &&
+      !advice.error
+    ) {
+      advice.generate();
+    }
+  }, [document, hasCachedAdvice, slotsReady, advice]);
+```
+
+Then, inside the returned JSX, after the `<DocumentBody ... />` block (still inside the same content container), add the advice card:
+```tsx
+          {/* AI advice */}
+          {(hasCachedAdvice || slotsReady) && (
+            <div className="mt-2 w-full rounded-2xl border border-gray-200 bg-gray-50 p-5">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-sm font-semibold text-gray-900">AI advice</span>
+                {!advice.isGenerating && (
+                  <button
+                    type="button"
+                    onClick={() => advice.generate()}
+                    className="cursor-pointer rounded-md px-2 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+                  >
+                    다시 생성
+                  </button>
+                )}
+              </div>
+              {advice.error ? (
+                <p className="text-sm text-red-600">{advice.error}</p>
+              ) : advice.streamed ? (
+                <MarkdownRenderer content={advice.streamed} />
+              ) : document?.advice?.content ? (
+                <MarkdownRenderer content={document.advice.content} />
+              ) : (
+                <div className="flex items-center gap-2 text-sm text-gray-500">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  조언을 생성하고 있습니다...
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 슬롯 미조회 안내 */}
+          {!hasCachedAdvice && !slotsReady && (
+            <p className="mt-2 w-full text-sm text-gray-400">
+              데이터를 먼저 불러오면 AI 조언이 생성됩니다.
+            </p>
+          )}
+```
+Notes:
+- `MarkdownRenderer` and `Loader2` must be imported. `Loader2` is already imported from `lucide-react` in this file; add `MarkdownRenderer` to the existing `@repo/ui` import if not present.
+- The card sits inside the same `flex w-full flex-col gap-6` container that holds `<DocumentBody>`.
+- Prefer the live `advice.streamed` while generating/just-generated; otherwise fall back to the cached `document.advice.content`.
+
+- [ ] **Step 2: Typecheck + build**
+
+Run: `cd apps/wise && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "log-book-detail|error TS" | head` (expect empty), then from repo root `pnpm build --filter @repo/wise` (expect success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/wise/src/components/log-book-detail.tsx
+git commit -m "feat(wise): add AI advice card to log book detail"
+```
+
+---
+
+### Task 9: Manual verification
+
+- [ ] **Step 1:** Rebuild/redeploy the ADK backend (Task 5 step 3) and restart the agent so `/api/document/:id/advice/stream` exists.
+- [ ] **Step 2:** Open a log book whose slots are all resolved → the AI advice card auto-streams text in, then (reload) shows the cached `document.advice`.
+- [ ] **Step 3:** Click "다시 생성" → regenerates and overwrites the cache.
+- [ ] **Step 4:** Open a log book with an unresolved slot → shows "데이터를 먼저 불러오면 AI 조언이 생성됩니다." and does not auto-generate.
+- [ ] **Step 5:** Simulate a backend error (e.g., stop the agent) → card shows "조언을 생성하지 못했습니다." with a working "다시 생성" button.

--- a/docs/superpowers/plans/2026-06-17-per-template-advice-prompt.md
+++ b/docs/superpowers/plans/2026-06-17-per-template-advice-prompt.md
@@ -1,0 +1,331 @@
+# Per-Template AI Advice Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let each document template carry its own AI advice prompt (edited in intent-admin), and have WISE pass that prompt to the ADK advice endpoint so advice is generated per-template (global default as fallback).
+
+**Architecture:** Add `advicePrompt?: string` to the document template in both repos (intent-admin writer + WISE reader). WISE's log book detail loads the template and passes `advicePrompt` in the advice request body. The ADK advice service uses the passed prompt as the system prompt, falling back to the existing global default.
+
+**Tech Stack:** intent-admin (Next.js, mongodb driver), WISE (Next.js/mongoose/React), ain-adk-v0 (TS, Express, jest, SSE).
+
+> **Repos & branches:** Tasks 1–3 → `intent-admin` (branch `feature/document-template-editor`). Task 4–5 → `ain-enterprise-monorepo` (branch `feature/seonghwa/wise-logbook`). Tasks 6–7 → `ain-adk-v0` (branch `feature/seonghwa/document-artifact`). Stage only the files each task edits in the monorepo (it has unrelated pending changes). No test runner in the Next.js repos; ain-adk-v0 has jest.
+
+---
+
+### Task 1: intent-admin — `advicePrompt` on type + validation
+
+**Files:** Modify `src/types/document-template.ts`, `src/lib/document-template-validate.ts`
+
+- [ ] **Step 1: Add field to the type**
+
+In `src/types/document-template.ts`, add to `interface DocumentTemplate` (after `name?: string;`):
+```ts
+  /** Per-template system prompt for AI advice. Empty → global default. */
+  advicePrompt?: string;
+```
+
+- [ ] **Step 2: Include it in the validator result**
+
+In `src/lib/document-template-validate.ts`, the success return is:
+```ts
+    return {
+        ok: true,
+        value: { label, name: cleanString(raw.name), args, sections }
+    };
+```
+Change the `value` object to include advicePrompt:
+```ts
+    return {
+        ok: true,
+        value: {
+            label,
+            name: cleanString(raw.name),
+            advicePrompt: cleanString(raw.advicePrompt),
+            args,
+            sections
+        }
+    };
+```
+(`cleanString` already exists in this file.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/document-template.ts src/lib/document-template-validate.ts
+git commit -m "feat(document-templates): add advicePrompt to template type + validation"
+```
+
+---
+
+### Task 2: intent-admin — persist + return `advicePrompt` in the API
+
+**Files:** Modify `src/app/api/document-templates/route.ts`, `src/app/api/document-templates/[label]/route.ts`, `src/app/api/document-templates/[label]/update/route.ts`
+
+- [ ] **Step 1: list/create route — `toDTO` + create insert**
+
+In `src/app/api/document-templates/route.ts`:
+- In `toDTO`, the returned object has `label/name/args/sections/createdAt`. Add after `name`:
+```ts
+        advicePrompt: typeof doc.advicePrompt === 'string' ? doc.advicePrompt : undefined,
+```
+- In `POST` (create), the inserted `doc` is `{ label, name, args, sections, createdAt }`. Add after `name: result.value.name,`:
+```ts
+            advicePrompt: result.value.advicePrompt,
+```
+
+- [ ] **Step 2: single GET route — `toDTO`**
+
+In `src/app/api/document-templates/[label]/route.ts`, its `toDTO` has the same shape; add after `name`:
+```ts
+        advicePrompt: typeof doc.advicePrompt === 'string' ? doc.advicePrompt : undefined,
+```
+
+- [ ] **Step 3: update route — `$set` / `$unset`**
+
+In `src/app/api/document-templates/[label]/update/route.ts`, the update currently `$set`s `args`/`sections` and conditionally `name`. Mirror the `name` handling for `advicePrompt`: after the `name` block, add:
+```ts
+        if (result.value.advicePrompt) {
+            (update.$set as Record<string, unknown>).advicePrompt = result.value.advicePrompt;
+        } else {
+            update.$unset = { ...(update.$unset as object), advicePrompt: '' };
+        }
+```
+(If `update.$unset` is currently set only for `name`, this merges; if `name` used a fresh object, ensure both keys end up under `$unset`. Concretely: where `name` does `update.$unset = { name: '' }`, change such that both can coexist — initialise `const unset: Record<string, string> = {};` and assign `name`/`advicePrompt` into it, then `if (Object.keys(unset).length) update.$unset = unset;`. Implement so clearing either field unsets it.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "src/app/api/document-templates/route.ts" "src/app/api/document-templates/[label]/route.ts" "src/app/api/document-templates/[label]/update/route.ts"
+git commit -m "feat(document-templates): persist + return advicePrompt"
+```
+
+---
+
+### Task 3: intent-admin — advice prompt field in the editor
+
+**Files:** Modify `src/components/document-templates/DocumentTemplateEditor.tsx`
+
+- [ ] **Step 1: Add a Textarea below the Name field**
+
+`Textarea` is already imported. The basics section has a `Name` block ending with its closing `</div>`. After that `Name` `<div className="flex flex-col gap-2"> ... </div>`, add a new block inside the same `<section>`:
+```tsx
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="dt-advice-prompt">AI advice prompt</Label>
+                    <Textarea
+                        id="dt-advice-prompt"
+                        value={value.advicePrompt ?? ''}
+                        placeholder="비우면 기본 프롬프트를 사용합니다."
+                        rows={6}
+                        onChange={(e) => setField('advicePrompt', e.target.value)}
+                    />
+                </div>
+```
+(`setField` and `Label` already exist/are imported; `value.advicePrompt` is now on the type.)
+
+- [ ] **Step 2: Typecheck + build**
+
+Run: `npx tsc --noEmit -p tsconfig.json && pnpm build`. Expected: exit 0, `/document-templates` routes build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/document-templates/DocumentTemplateEditor.tsx
+git commit -m "feat(document-templates): add AI advice prompt field to editor"
+```
+
+---
+
+### Task 4: WISE — `advicePrompt` on the template model + API
+
+**Files (ain-enterprise-monorepo):** Modify `apps/wise/src/lib/models/document-template.ts`, `apps/wise/src/app/api/document-templates/route.ts`. Stage ONLY these two.
+
+- [ ] **Step 1: Model schema + interface**
+
+In `apps/wise/src/lib/models/document-template.ts`:
+- In `DocumentTemplateSchema`, add after the `name` field:
+```ts
+    /** AI advice 시스템 프롬프트 (비우면 기본값) */
+    advicePrompt: { type: String },
+```
+- In the `DocumentTemplate` interface, add after `name?: string;`:
+```ts
+  /** AI advice system prompt. Empty → global default. */
+  advicePrompt?: string;
+```
+
+- [ ] **Step 2: API passthrough**
+
+In `apps/wise/src/app/api/document-templates/route.ts`:
+- In `RawTemplate`, add after `name?: string | null;`:
+```ts
+  advicePrompt?: string | null;
+```
+- In `toDTO`, add after `name: doc.name ?? undefined,`:
+```ts
+    advicePrompt: doc.advicePrompt ?? undefined,
+```
+- In the upsert `$set`, add after `name: body.name ?? undefined,`:
+```ts
+          advicePrompt: body.advicePrompt ?? undefined,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/wise && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "document-template|error TS" | head`. Expected: empty.
+
+- [ ] **Step 4: Commit (only these two files)**
+
+```bash
+cd /Users/shyun/comcom/ain-enterprise/ain-enterprise-monorepo
+git add apps/wise/src/lib/models/document-template.ts apps/wise/src/app/api/document-templates/route.ts
+git commit -m "feat(wise): carry advicePrompt on document template model + API"
+```
+
+---
+
+### Task 5: WISE — pass template advicePrompt into advice generation
+
+**Files (ain-enterprise-monorepo):** Modify `apps/wise/src/hooks/use-document-advice.ts`, `apps/wise/src/components/log-book-detail.tsx`. Stage ONLY these.
+
+- [ ] **Step 1: Hook accepts an advicePrompt and sends it in the body**
+
+In `apps/wise/src/hooks/use-document-advice.ts`, change the hook to accept an optional prompt and include it in the request body. Specifically:
+- Change the signature to `export function useDocumentAdvice(documentId: string, advicePrompt?: string): UseDocumentAdviceState {`.
+- In `generate`, change the `authStreamFetch(... , {})` body argument from `{}` to `{ advicePrompt }` (the hook already builds the URL; just pass the body object). 
+- Add `advicePrompt` to the `useCallback` dependency array.
+
+Resulting `generate` body call:
+```ts
+      const { reader } = await authStreamFetch(
+        `${API_URL}/api/document/${encodeURIComponent(documentId)}/advice/stream`,
+        { advicePrompt },
+      );
+```
+and the deps: `}, [authStreamFetch, documentId, advicePrompt]);`
+
+- [ ] **Step 2: log-book-detail loads the template and passes its advicePrompt**
+
+In `apps/wise/src/components/log-book-detail.tsx`:
+- Add the import: `import { useDocumentTemplate } from '../hooks/use-document-template';`
+- Where `document` is available, derive the template by the document's category label and pass its advice prompt to the advice hook. Replace the existing `const advice = useDocumentAdvice(documentId);` line with:
+```tsx
+  const { data: template } = useDocumentTemplate(document?.labels?.category ?? '');
+  const advice = useDocumentAdvice(documentId, template?.advicePrompt);
+```
+(The `useDocumentTemplate` hook fetches `/api/document-templates?label=`; with an empty label it returns null/none — acceptable, advice then uses the default. The `react-query` call is safe to run unconditionally.)
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd apps/wise && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "use-document-advice|log-book-detail|error TS" | head` (expect empty), then from repo root `pnpm build --filter @repo/wise` (expect success).
+
+- [ ] **Step 4: Commit (only these two files)**
+
+```bash
+cd /Users/shyun/comcom/ain-enterprise/ain-enterprise-monorepo
+git add apps/wise/src/hooks/use-document-advice.ts apps/wise/src/components/log-book-detail.tsx
+git commit -m "feat(wise): pass template advicePrompt into advice generation"
+```
+
+---
+
+### Task 6: ADK — accept advicePrompt override (service + controller + test)
+
+**Files (ain-adk-v0):** Modify `src/services/document-advice.service.ts`, `src/controllers/api/document.api.controller.ts`, `tests/services/document-advice.service.test.ts`
+
+- [ ] **Step 1: Extend the service test (failing)**
+
+In `tests/services/document-advice.service.test.ts`, add a test inside the `describe` block:
+```ts
+	it("uses the provided advicePrompt as the system prompt", async () => {
+		const { modelModule, memoryModule, model } = makeModules();
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+		await collect(
+			service.generateAdviceStream("doc-1", { advicePrompt: "커스텀 프롬프트" }),
+		);
+		expect(model.generateMessages).toHaveBeenCalledWith(
+			expect.objectContaining({ systemPrompt: "커스텀 프롬프트" }),
+		);
+	});
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+Run: `yarn jest tests/services/document-advice.service.test.ts -t "uses the provided advicePrompt"`
+Expected: FAIL (the service ignores options / signature mismatch).
+
+- [ ] **Step 3: Add the `options` param to the service**
+
+In `src/services/document-advice.service.ts`, change the method signature and the system-prompt line. Signature:
+```ts
+	async *generateAdviceStream(
+		documentId: string,
+		options?: { advicePrompt?: string },
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+```
+And replace the `const systemPrompt = await documentAdvicePrompt(this.memoryModule);` line with:
+```ts
+		const systemPrompt =
+			options?.advicePrompt?.trim() ||
+			(await documentAdvicePrompt(this.memoryModule));
+```
+(Everything else unchanged. The previous `generateAdviceStream("doc-1")` and `generateAdviceStream("doc-1")` calls in existing tests still type-check since `options`/`signal` are optional.)
+
+- [ ] **Step 4: Update the controller to read the body + pass options**
+
+In `src/controllers/api/document.api.controller.ts`, in `handleGenerateAdviceStream`, change the `setup` to read `advicePrompt` from the body and pass it:
+```ts
+			setup: async (signal) => {
+				await this.getAuthorizedDocument(userId, id);
+				const { advicePrompt } = req.body as { advicePrompt?: string };
+				return this.documentAdviceService.generateAdviceStream(
+					id,
+					{ advicePrompt },
+					signal,
+				);
+			},
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+Run: `yarn jest tests/services/document-advice.service.test.ts`
+Expected: all advice tests PASS (including the new one).
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `npx tsc --noEmit -p tsconfig.json` (expect no errors), then:
+```bash
+git add src/services/document-advice.service.ts src/controllers/api/document.api.controller.ts tests/services/document-advice.service.test.ts
+git commit -m "feat(document-advice): accept per-call advicePrompt override"
+```
+
+---
+
+### Task 7: ADK — build + refresh local-agents
+
+- [ ] **Step 1: Build + full test**
+
+Run: `yarn build && yarn test`. Expected: build done; all suites pass.
+
+- [ ] **Step 2: Refresh local-agents install**
+
+```bash
+cd /Users/shyun/comcom/ain-enterprise/local-agents && rm -rf node_modules && pnpm install
+```
+Then restart the running agent (manual).
+
+---
+
+### Task 8: Manual verification
+
+- [ ] **Step 1:** In intent-admin (`NEXT_PUBLIC_SIDEBAR_DOCUMENT=true` + `WISE_FRONT_MONGO_URL`), open the `logbook` template, enter an "AI advice prompt", Save, reload → the prompt persists.
+- [ ] **Step 2:** In WISE, open a log book of that template → advice is generated using the template's prompt (verify the tone/instructions match the custom prompt; click "다시 생성" to re-run).
+- [ ] **Step 3:** Clear the template's advice prompt, Save → new advice generations fall back to the global default prompt.

--- a/docs/superpowers/specs/2026-06-17-document-ai-advice-design.md
+++ b/docs/superpowers/specs/2026-06-17-document-ai-advice-design.md
@@ -1,0 +1,121 @@
+# Document AI Advice — Design
+
+**Date:** 2026-06-17
+**Status:** Approved (brainstorming) → ready for implementation plan
+**Repos touched:** `ain-adk-v0` (inference: type, prompt, service, controller, route, DI) and
+`ain-enterprise-monorepo` (@repo/utils type, @repo/ui api, WISE log-book detail UI).
+
+## Goal
+
+Add an **AI advice** area at the bottom of the log book detail that generates a short,
+operational suggestion based on the content already entered/loaded in the document
+(field text + resolved workflow slots), streams it in, caches it on the document, and
+renders it in a distinct code-block-style card.
+
+## Decisions (from brainstorming)
+
+1. **Inference location:** a dedicated ADK advice service + endpoint (not the generic
+   query pipeline, not a workflow/slot). Input is the fully rendered document.
+2. **Trigger + caching:** auto-generate when the document has no cached advice and its
+   slots are all resolved (or it has no slots); cache the result on the document; a
+   "regenerate" button re-runs it.
+3. **Response:** streaming over SSE (same infra as slot fill).
+4. **Prompt:** a default Korean advice prompt, overridable via agent memory.
+5. **Out of scope:** the "오늘 매출에 대해 더 알아보기" button (later); generalizing to
+   non-log-book documents (advice UI shows only on the log book detail for now).
+
+## Data model
+
+Add to `Document` (both `ain-adk-v0/src/types/memory.ts` — where `Document` is defined —
+and the `@repo/utils` mirror `packages/utils/src/types/document.ts`):
+```ts
+export interface DocumentAdvice {
+  /** Generated advice text (markdown/plain prose). */
+  content: string;
+  /** ISO timestamp when generated. */
+  generatedAt: string;
+}
+// on Document:
+advice?: DocumentAdvice;
+```
+> Confirm during implementation which file declares the canonical `Document` in
+> `ain-adk-v0` (it is imported from `@/types/document.js` in services). Add `DocumentAdvice`
+> next to that declaration and mirror it in `@repo/utils`.
+
+## Backend (ain-adk-v0)
+
+### Prompt — `src/services/prompts/document-advice.ts`
+Follows the `generate-title.ts` pattern: an async function that returns
+`(await memoryModule?.getAgentMemory()?.getDocumentAdvicePrompt?.()) || <default>`.
+Default (Korean): instruct the model to read the log book content (operational notes +
+sales data) and produce a concise advice in flowing paragraphs — brief acknowledgement of
+the day, tomorrow's outlook, any numeric expectations grounded in the data, an operational
+tip, and a short closing encouragement. Respond in the user's language; no markdown
+headings; do not invent numbers not present in the input.
+- Add `getDocumentAdvicePrompt?(): Promise<string | undefined>` to the agent memory
+  interface (optional method, same shape as the other `getXxxPrompt` hooks).
+
+### Service — `src/services/document-advice.service.ts`
+`class DocumentAdviceService` constructed with `ModelModule` + `MemoryModule`.
+`async *generateAdviceStream(documentId, signal?): AsyncGenerator<StreamEvent>`:
+1. Load document via `memoryModule.getDocumentMemory().getDocument(documentId)`; throw if
+   missing / no document memory.
+2. `renderDocument(document)` → input text (already substitutes resolved slot fragments).
+3. Build a single-turn request with the model module: system = advice prompt, user =
+   rendered document text. Stream the model output, yielding `text_chunk` events.
+   (Use the same ModelModule streaming path the query service uses for a plain completion —
+   confirm the exact method during implementation.)
+4. Accumulate the streamed text; on completion persist
+   `document.advice = { content, generatedAt: now }` via `updateDocument` (bump version/
+   updatedAt consistent with how slot fill writes).
+5. Never leak a half-written cache: only persist when the stream finishes without error.
+
+### Controller + route
+- `DocumentApiController`: add `handleGenerateAdviceStream` (and a non-stream
+  `handleGenerateAdvice`) mirroring `handleFillSlotStream` (use `streamEventsToSSE`).
+- Routes (`document.routes.ts`): `POST /:id/advice/stream` and `POST /:id/advice`, behind
+  the existing `checkDocumentMemory` guard.
+- DI container: construct `DocumentAdviceService` and pass it to `DocumentApiController`
+  (extend its constructor), following the existing wiring.
+
+## Frontend (ain-enterprise-monorepo)
+
+### @repo/utils
+Mirror `DocumentAdvice` + `advice?` on the `Document` type.
+
+### @repo/ui — `use-app-api.ts`
+Add `generateDocumentAdviceStream(documentId, signal?)` using the existing
+`useAuthStreamFetch` (POST to `${apiUrl}/api/document/:id/advice/stream`), returning the
+reader the same way other stream calls do. (Reuse the existing SSE parsing util the slot
+fill / chat stream uses to read `text_chunk` deltas.)
+
+### WISE — `apps/wise/src/components/log-book-detail.tsx`
+Add an **AI advice** card below `<DocumentBody>`:
+- Distinct code-block-style container (border + subtle background, rounded), with a small
+  "AI advice" label at top; body renders the advice text (markdown via `MarkdownRenderer`
+  or plain text).
+- State machine:
+  - `document.advice` present → render it; show a "다시 생성" (regenerate) button.
+  - absent AND all existing slots `resolved` (or no slots) → auto-start the stream on mount;
+    render streaming text live; on completion the document is refetched (advice now cached).
+  - absent AND some slot not yet resolved → show hint "데이터를 먼저 불러오면 조언이
+    생성됩니다." (no auto-generate).
+- Regenerate triggers the stream again (overwrites the cache on completion).
+- Guard the fetch on `status === 'authenticated'` (consistent with the rest of the file).
+
+## Error handling
+- Backend: missing document / model error → SSE `error` event; nothing persisted.
+- Frontend: stream error → card shows "조언을 생성하지 못했습니다." with the regenerate button.
+
+## Testing / verification
+- ain-adk-v0: `yarn build`; jest unit test for `DocumentAdviceService.generateAdviceStream`
+  with mocked model + memory (asserts it renders the doc, streams text, and persists
+  `advice` on completion; does not persist on error). Mirrors existing service tests.
+- Frontend: `tsc` + WISE build; manual — open a log book with resolved slots, confirm advice
+  auto-streams into the card and persists on reload; regenerate works; unresolved-slots
+  state shows the hint.
+
+## Out of scope
+- The "오늘 매출에 대해 더 알아보기" button.
+- Advice on non-log-book documents.
+- Configurable prompt UI (the prompt is code-default + agent-memory override only).

--- a/docs/superpowers/specs/2026-06-17-per-template-advice-prompt-design.md
+++ b/docs/superpowers/specs/2026-06-17-per-template-advice-prompt-design.md
@@ -1,0 +1,83 @@
+# Per-Template AI Advice Prompt — Design
+
+**Date:** 2026-06-17
+**Status:** Approved (brainstorming) → ready for implementation plan
+**Repos touched:** `intent-admin` (template editor + API), `ain-enterprise-monorepo` (WISE model/API/UI), `ain-adk-v0` (advice endpoint + service).
+
+## Goal
+
+Make the AI advice prompt **per document template** instead of a single global prompt.
+A template author edits an "AI advice prompt" on the template in intent-admin; when the log
+book detail generates advice, WISE passes that template's prompt to the ADK advice endpoint,
+which uses it as the system prompt (falling back to the global default when absent).
+
+## Decisions (from brainstorming)
+
+1. **Granularity:** per document **template** (not per individual document instance).
+2. **Approach A — store on template + pass at generate time:** the prompt lives on the
+   template (WISE front Mongo, edited via intent-admin). WISE reads it and passes it in the
+   advice request body at generation time, so the latest template prompt is always used.
+   No document/payload schema changes, no cross-DB access from ADK.
+3. **Fallback:** if no `advicePrompt` is provided (empty or pre-existing templates), the ADK
+   global default prompt (`src/services/prompts/document-advice.ts`) is used — backward
+   compatible.
+
+## Data model
+
+Add one optional top-level field to the document template (both repos):
+```ts
+// DocumentTemplate
+advicePrompt?: string;
+```
+No change to `Document`, `CreateDocumentPayload`, or the advice cache.
+
+## Components & data flow
+
+### intent-admin
+- `src/types/document-template.ts`: add `advicePrompt?: string` to `DocumentTemplate`.
+- `src/lib/document-template-validate.ts`: include `advicePrompt: cleanString(raw.advicePrompt)`
+  in the validated/normalized result (pass-through; no hard validation).
+- API routes (`route.ts` list/create `toDTO`, `[label]/route.ts` `toDTO`): the create body
+  and update already go through `validateDocumentTemplate`, so persisting `advicePrompt`
+  requires (a) `validateDocumentTemplate` returning it and (b) the create insert / update
+  `$set` and the `toDTO` mappers including it.
+- `DocumentTemplateEditor.tsx`: add an "AI advice 프롬프트" `Textarea` near label/name,
+  bound to `value.advicePrompt`, placeholder "비우면 기본 프롬프트를 사용합니다".
+
+### WISE (ain-enterprise-monorepo)
+- `apps/wise/src/lib/models/document-template.ts`: add `advicePrompt` to
+  `DocumentTemplateSchema` (`{ type: String }`) and `advicePrompt?: string` to
+  `DocumentTemplate` interface.
+- `apps/wise/src/app/api/document-templates/route.ts`: pass `advicePrompt` through
+  `toDTO`, `RawTemplate`, and the upsert `$set`.
+- `apps/wise/src/components/log-book-detail.tsx`: load the document's template via the
+  existing `useDocumentTemplate(document.labels?.category)` hook and pass
+  `template?.advicePrompt` into `useDocumentAdvice`.
+- `apps/wise/src/hooks/use-document-advice.ts`: accept an `advicePrompt?: string` (via hook
+  arg or `generate(advicePrompt?)`), and include it in the advice request body
+  (`{ advicePrompt }`) sent to the ADK endpoint.
+
+### ADK (ain-adk-v0)
+- `DocumentApiController.handleGenerateAdviceStream`: read `advicePrompt?: string` from the
+  request body and pass it to the service.
+- `DocumentAdviceService.generateAdviceStream(documentId, options?, signal?)`: add
+  `options?: { advicePrompt?: string }`; compute
+  `const systemPrompt = options?.advicePrompt?.trim() || (await documentAdvicePrompt(this.memoryModule));`
+  (everything else unchanged). The global default prompt remains the fallback.
+
+## Error handling
+- Empty/missing `advicePrompt` → global default (no error).
+- Template fetch failure on the WISE side → advice still generates with the default
+  (pass `undefined`).
+
+## Testing / verification
+- ADK: extend the advice service test — when `options.advicePrompt` is given, the model is
+  invoked with that system prompt; when absent, the default is used. `yarn build`.
+- intent-admin: tsc + build; manual — edit a template's advice prompt, save, reload → persists.
+- WISE: tsc + build; manual — generate advice on a log book whose template has a custom
+  prompt → advice reflects it; clearing the template prompt → falls back to default.
+
+## Out of scope
+- Per-document-instance prompts.
+- Snapshotting the prompt onto the document (Approach B).
+- A prompt-preview/test UI in the editor.

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -248,6 +248,7 @@ class Container {
 		if (!this._documentApiController) {
 			this._documentApiController = new DocumentApiController(
 				getMemoryModule(),
+				this.getWorkflowExecutionService(),
 			);
 		}
 		return this._documentApiController;

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@/config/modules";
 import { getOnIntentFallback } from "@/config/options";
 import { AgentApiController } from "@/controllers/api/agent.api.controller";
+import { DocumentApiController } from "@/controllers/api/document.api.controller";
 import { IntentApiController } from "@/controllers/api/intent.api.controller";
 import { ModelApiController } from "@/controllers/api/model.api.controller";
 import { ThreadApiController } from "@/controllers/api/threads.api.controller";
@@ -55,6 +56,7 @@ class Container {
 	private _intentApiController?: IntentApiController;
 	private _workflowTemplateApiController?: WorkflowTemplateApiController;
 	private _userWorkflowApiController?: UserWorkflowApiController;
+	private _documentApiController?: DocumentApiController;
 
 	getThreadService(): ThreadService {
 		if (!this._threadService) {
@@ -242,6 +244,15 @@ class Container {
 		return this._userWorkflowApiController;
 	}
 
+	getDocumentApiController(): DocumentApiController {
+		if (!this._documentApiController) {
+			this._documentApiController = new DocumentApiController(
+				getMemoryModule(),
+			);
+		}
+		return this._documentApiController;
+	}
+
 	/**
 	 * Reset all instances (useful for testing)
 	 */
@@ -267,6 +278,7 @@ class Container {
 		this._intentApiController = undefined;
 		this._workflowTemplateApiController = undefined;
 		this._userWorkflowApiController = undefined;
+		this._documentApiController = undefined;
 	}
 }
 

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -15,6 +15,7 @@ import { WorkflowTemplateApiController } from "@/controllers/api/workflow-templa
 import { IntentController } from "@/controllers/intent.controller";
 import { QueryController } from "@/controllers/query.controller";
 import { A2AService } from "@/services/a2a.service";
+import { DocumentAdviceService } from "@/services/document-advice.service";
 import { IntentFulfillService } from "@/services/intents/fulfill.service";
 import { IntentTriggerService } from "@/services/intents/trigger.service";
 import { PIIService } from "@/services/pii.service";
@@ -46,6 +47,7 @@ class Container {
 	private _workflowExecutionService?: WorkflowExecutionService;
 	private _workflowVariableResolver?: WorkflowVariableResolver;
 	private _schedulerService?: SchedulerService;
+	private _documentAdviceService?: DocumentAdviceService;
 
 	// Controllers
 	private _queryController?: QueryController;
@@ -244,11 +246,22 @@ class Container {
 		return this._userWorkflowApiController;
 	}
 
+	getDocumentAdviceService(): DocumentAdviceService {
+		if (!this._documentAdviceService) {
+			this._documentAdviceService = new DocumentAdviceService(
+				getModelModule(),
+				getMemoryModule(),
+			);
+		}
+		return this._documentAdviceService;
+	}
+
 	getDocumentApiController(): DocumentApiController {
 		if (!this._documentApiController) {
 			this._documentApiController = new DocumentApiController(
 				getMemoryModule(),
 				this.getWorkflowExecutionService(),
+				this.getDocumentAdviceService(),
 			);
 		}
 		return this._documentApiController;
@@ -270,6 +283,7 @@ class Container {
 		this._workflowExecutionService = undefined;
 		this._workflowVariableResolver = undefined;
 		this._schedulerService = undefined;
+		this._documentAdviceService = undefined;
 
 		this._queryController = undefined;
 		this._intentController = undefined;

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
+import type { DocumentAdviceService } from "@/services/document-advice.service.js";
 import type { WorkflowExecutionService } from "@/services/workflow-execution.service.js";
 import { AinHttpError } from "@/types/agent.js";
 import {
@@ -16,13 +17,16 @@ import { streamEventsToSSE } from "@/utils/sse-stream.js";
 export class DocumentApiController {
 	private memoryModule: MemoryModule;
 	private workflowExecutionService: WorkflowExecutionService;
+	private documentAdviceService: DocumentAdviceService;
 
 	constructor(
 		memoryModule: MemoryModule,
 		workflowExecutionService: WorkflowExecutionService,
+		documentAdviceService: DocumentAdviceService,
 	) {
 		this.memoryModule = memoryModule;
 		this.workflowExecutionService = workflowExecutionService;
+		this.documentAdviceService = documentAdviceService;
 	}
 
 	private async getAuthorizedDocument(
@@ -216,6 +220,21 @@ export class DocumentApiController {
 					{ workflowId, executionVariables },
 					signal,
 				);
+			},
+		});
+	};
+
+	public handleGenerateAdviceStream = async (req: Request, res: Response) => {
+		const userId = res.locals.userId || "";
+		const { id } = req.params as { id: string };
+
+		await streamEventsToSSE(req, res, {
+			logLabel: "Document advice stream",
+			userId,
+			logContext: { documentId: id },
+			setup: async (signal) => {
+				await this.getAuthorizedDocument(userId, id);
+				return this.documentAdviceService.generateAdviceStream(id, signal);
 			},
 		});
 	};

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -1,0 +1,116 @@
+import type { NextFunction, Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import type { MemoryModule } from "@/modules/index.js";
+import { AinHttpError } from "@/types/agent.js";
+import type {
+	Document,
+	DocumentFilter,
+	DocumentSource,
+} from "@/types/document.js";
+
+export class DocumentApiController {
+	private memoryModule: MemoryModule;
+
+	constructor(memoryModule: MemoryModule) {
+		this.memoryModule = memoryModule;
+	}
+
+	private async getAuthorizedDocument(
+		userId: string,
+		documentId: string,
+	): Promise<Document> {
+		const documentMemory = this.memoryModule.getDocumentMemory();
+		const document = await documentMemory?.getDocument(documentId);
+		if (!document || document.userId !== userId) {
+			throw new AinHttpError(StatusCodes.NOT_FOUND, "Document not found");
+		}
+		return document;
+	}
+
+	public handleGetAllDocuments = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const documentMemory = this.memoryModule.getDocumentMemory();
+			const { workflowId, threadId, source } = req.query as {
+				workflowId?: string;
+				threadId?: string;
+				source?: DocumentSource;
+			};
+			const filter: DocumentFilter = { workflowId, threadId, source };
+			const documents = await documentMemory?.listDocuments(userId, filter);
+			res.json(documents ?? []);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleGetDocument = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const { id } = req.params as { id: string };
+			const document = await this.getAuthorizedDocument(userId, id);
+			res.json(document);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleUpdateDocument = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const { id } = req.params as { id: string };
+			const existing = await this.getAuthorizedDocument(userId, id);
+
+			const { title, content } = req.body as {
+				title?: string;
+				content?: string;
+			};
+
+			const updates: Partial<Document> = {
+				version: existing.version + 1,
+				editedManually: true,
+				updatedAt: new Date().toISOString(),
+			};
+			if (title !== undefined) {
+				updates.title = title;
+			}
+			if (content !== undefined) {
+				updates.content = content;
+			}
+
+			await this.memoryModule.getDocumentMemory()?.updateDocument(id, updates);
+			res.status(StatusCodes.OK).send();
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleDeleteDocument = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const { id } = req.params as { id: string };
+			await this.getAuthorizedDocument(userId, id);
+
+			await this.memoryModule.getDocumentMemory()?.deleteDocument(id);
+			res.status(StatusCodes.OK).send();
+		} catch (error) {
+			next(error);
+		}
+	};
+}

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -234,7 +234,12 @@ export class DocumentApiController {
 			logContext: { documentId: id },
 			setup: async (signal) => {
 				await this.getAuthorizedDocument(userId, id);
-				return this.documentAdviceService.generateAdviceStream(id, signal);
+				const { advicePrompt } = req.body as { advicePrompt?: string };
+				return this.documentAdviceService.generateAdviceStream(
+					id,
+					{ advicePrompt },
+					signal,
+				);
 			},
 		});
 	};

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -1,18 +1,28 @@
+import { randomUUID } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
+import type { WorkflowExecutionService } from "@/services/workflow-execution.service.js";
 import { AinHttpError } from "@/types/agent.js";
-import type {
-	Document,
-	DocumentFilter,
+import {
+	type Document,
+	type DocumentFilter,
+	DocumentFormat,
+	type DocumentSlot,
 	DocumentSource,
 } from "@/types/document.js";
+import { streamEventsToSSE } from "@/utils/sse-stream.js";
 
 export class DocumentApiController {
 	private memoryModule: MemoryModule;
+	private workflowExecutionService: WorkflowExecutionService;
 
-	constructor(memoryModule: MemoryModule) {
+	constructor(
+		memoryModule: MemoryModule,
+		workflowExecutionService: WorkflowExecutionService,
+	) {
 		this.memoryModule = memoryModule;
+		this.workflowExecutionService = workflowExecutionService;
 	}
 
 	private async getAuthorizedDocument(
@@ -35,12 +45,13 @@ export class DocumentApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const documentMemory = this.memoryModule.getDocumentMemory();
-			const { workflowId, threadId, source } = req.query as {
+			const { workflowId, threadId, source, groupId } = req.query as {
 				workflowId?: string;
 				threadId?: string;
 				source?: DocumentSource;
+				groupId?: string;
 			};
-			const filter: DocumentFilter = { workflowId, threadId, source };
+			const filter: DocumentFilter = { workflowId, threadId, source, groupId };
 			const documents = await documentMemory?.listDocuments(userId, filter);
 			res.json(documents ?? []);
 		} catch (error) {
@@ -73,9 +84,10 @@ export class DocumentApiController {
 			const { id } = req.params as { id: string };
 			const existing = await this.getAuthorizedDocument(userId, id);
 
-			const { title, content } = req.body as {
+			const { title, content, slots } = req.body as {
 				title?: string;
 				content?: string;
+				slots?: DocumentSlot[];
 			};
 
 			const updates: Partial<Document> = {
@@ -88,6 +100,9 @@ export class DocumentApiController {
 			}
 			if (content !== undefined) {
 				updates.content = content;
+			}
+			if (slots !== undefined) {
+				updates.slots = slots;
 			}
 
 			await this.memoryModule.getDocumentMemory()?.updateDocument(id, updates);
@@ -112,5 +127,92 @@ export class DocumentApiController {
 		} catch (error) {
 			next(error);
 		}
+	};
+
+	public handleCreateDocument = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const documentMemory = this.memoryModule.getDocumentMemory();
+			const { title, content, slots, groupId, format } = req.body as {
+				title?: string;
+				content?: string;
+				slots?: DocumentSlot[];
+				groupId?: string;
+				format?: DocumentFormat;
+			};
+
+			const now = new Date().toISOString();
+			const document: Document = {
+				documentId: randomUUID(),
+				userId,
+				title: title ?? "Untitled",
+				format: format ?? DocumentFormat.MARKDOWN,
+				content: content ?? "",
+				slots,
+				groupId,
+				source: DocumentSource.MANUAL,
+				version: 1,
+				createdAt: now,
+				updatedAt: now,
+			};
+
+			const created = await documentMemory?.createDocument(document);
+			res.status(StatusCodes.CREATED).json(created ?? document);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleFillSlot = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const userId = res.locals.userId || "";
+			const { id, slotId } = req.params as { id: string; slotId: string };
+			await this.getAuthorizedDocument(userId, id);
+
+			const { workflowId, executionVariables } = req.body as {
+				workflowId?: string;
+				executionVariables?: Record<string, string>;
+			};
+			const result = await this.workflowExecutionService.fillDocumentSlot(
+				id,
+				slotId,
+				{ workflowId, executionVariables },
+			);
+			res.status(StatusCodes.OK).json(result);
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	public handleFillSlotStream = async (req: Request, res: Response) => {
+		const userId = res.locals.userId || "";
+		const { id, slotId } = req.params as { id: string; slotId: string };
+
+		await streamEventsToSSE(req, res, {
+			logLabel: "Document slot fill stream",
+			userId,
+			logContext: { documentId: id, slotId },
+			setup: async (signal) => {
+				await this.getAuthorizedDocument(userId, id);
+				const { workflowId, executionVariables } = req.body as {
+					workflowId?: string;
+					executionVariables?: Record<string, string>;
+				};
+				return this.workflowExecutionService.fillDocumentSlotStream(
+					id,
+					slotId,
+					{ workflowId, executionVariables },
+					signal,
+				);
+			},
+		});
 	};
 }

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -45,13 +45,13 @@ export class DocumentApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const documentMemory = this.memoryModule.getDocumentMemory();
-			const { workflowId, threadId, source, groupId } = req.query as {
+			const { workflowId, threadId, source, labels } = req.query as {
 				workflowId?: string;
 				threadId?: string;
 				source?: DocumentSource;
-				groupId?: string;
+				labels?: Record<string, string>;
 			};
-			const filter: DocumentFilter = { workflowId, threadId, source, groupId };
+			const filter: DocumentFilter = { workflowId, threadId, source, labels };
 			const documents = await documentMemory?.listDocuments(userId, filter);
 			res.json(documents ?? []);
 		} catch (error) {
@@ -84,10 +84,11 @@ export class DocumentApiController {
 			const { id } = req.params as { id: string };
 			const existing = await this.getAuthorizedDocument(userId, id);
 
-			const { title, content, slots } = req.body as {
+			const { title, content, slots, labels } = req.body as {
 				title?: string;
 				content?: string;
 				slots?: DocumentSlot[];
+				labels?: Record<string, string>;
 			};
 
 			const updates: Partial<Document> = {
@@ -103,6 +104,9 @@ export class DocumentApiController {
 			}
 			if (slots !== undefined) {
 				updates.slots = slots;
+			}
+			if (labels !== undefined) {
+				updates.labels = labels;
 			}
 
 			await this.memoryModule.getDocumentMemory()?.updateDocument(id, updates);
@@ -137,11 +141,11 @@ export class DocumentApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const documentMemory = this.memoryModule.getDocumentMemory();
-			const { title, content, slots, groupId, format } = req.body as {
+			const { title, content, slots, labels, format } = req.body as {
 				title?: string;
 				content?: string;
 				slots?: DocumentSlot[];
-				groupId?: string;
+				labels?: Record<string, string>;
 				format?: DocumentFormat;
 			};
 
@@ -153,7 +157,7 @@ export class DocumentApiController {
 				format: format ?? DocumentFormat.MARKDOWN,
 				content: content ?? "",
 				slots,
-				groupId,
+				labels,
 				source: DocumentSource.MANUAL,
 				version: 1,
 				createdAt: now,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,11 @@ export class AINAgent {
 		},
 	) {
 		this.app = express();
+		// Express 5 defaults the query parser to "simple", which does not parse
+		// nested/bracket params (e.g. `?labels[category]=logbook`). Use the
+		// "extended" parser so faceted filters like DocumentFilter.labels are
+		// decoded into nested objects on req.query.
+		this.app.set("query parser", "extended");
 
 		// Set manifest
 		this.manifest = manifest;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ export { AuthModule } from "./auth/auth.module.js";
 export { MCPModule } from "./mcp/mcp.module.js";
 export type {
 	IAgentMemory,
+	IDocumentMemory,
 	IIntentMemory,
 	IMemory,
 	IThreadMemory,

--- a/src/modules/mcp/mcp.module.ts
+++ b/src/modules/mcp/mcp.module.ts
@@ -132,7 +132,8 @@ export class MCPModule {
 		_args?: Record<string, unknown>,
 	): Promise<string> {
 		const { connectorName, toolName } = tool;
-		const client = this.mcpConnectors.get(connectorName)?.client;
+		const connector = this.mcpConnectors.get(connectorName);
+		const client = connector?.client;
 
 		try {
 			if (!client) {
@@ -141,10 +142,20 @@ export class MCPModule {
 
 			// `${name}-${tool.name}` => tool.name
 			const mcpToolName = toolName.slice(connectorName.length + 1);
-			const result = await client.callTool({
-				name: mcpToolName,
-				arguments: _args,
-			});
+			// Per-connector timeout override (defaults to the SDK's 60s when unset).
+			// resetTimeoutOnProgress lets a tool that streams progress notifications
+			// keep the call alive past the base timeout.
+			const requestTimeoutMs = connector?.config.requestTimeoutMs;
+			const result = await client.callTool(
+				{
+					name: mcpToolName,
+					arguments: _args,
+				},
+				undefined,
+				requestTimeoutMs !== undefined
+					? { timeout: requestTimeoutMs, resetTimeoutOnProgress: true }
+					: undefined,
+			);
 			const toolResult =
 				`[Bot Called Tool ${toolName} with args ${JSON.stringify(_args)}]\n` +
 				JSON.stringify(result.content, null, 2);

--- a/src/modules/memory/base.memory.ts
+++ b/src/modules/memory/base.memory.ts
@@ -78,6 +78,7 @@ export interface IAgentMemory {
 	updateAgentPrompt?(prompt: string): Promise<void>;
 	getAggregatePrompt?(): Promise<string>;
 	getGenerateTitlePrompt?(): Promise<string>;
+	getDocumentAdvicePrompt?(): Promise<string>;
 	getSingleTriggerPrompt?(): Promise<string>;
 	getMultiTriggerPrompt?(): Promise<string>;
 	getToolSelectPrompt?(): Promise<string>;

--- a/src/modules/memory/base.memory.ts
+++ b/src/modules/memory/base.memory.ts
@@ -1,3 +1,4 @@
+import type { Document, DocumentFilter } from "@/types/document";
 import type {
 	Intent,
 	MessageObject,
@@ -21,6 +22,11 @@ export interface IMemory {
 	getAgentMemory(): IAgentMemory;
 	getWorkflowTemplateMemory(): IWorkflowTemplateMemory;
 	getUserWorkflowMemory(): IUserWorkflowMemory;
+	/**
+	 * Document storage. Optional for backward compatibility — memory
+	 * implementations that predate documents may omit it.
+	 */
+	getDocumentMemory?(): IDocumentMemory;
 }
 
 /**
@@ -107,4 +113,20 @@ export interface IUserWorkflowMemory {
 	listUserWorkflows(userId?: string): Promise<UserWorkflow[]>;
 	/** List all active scheduled workflows across all users (used by scheduler) */
 	listActiveScheduledWorkflows(): Promise<UserWorkflow[]>;
+}
+
+/**
+ * Document memory interface - handles document persistence.
+ *
+ * Documents are first-class, mutable entities referenced from threads.
+ */
+export interface IDocumentMemory {
+	getDocument(documentId: string): Promise<Document | undefined>;
+	createDocument(document: Document): Promise<Document>;
+	updateDocument(
+		documentId: string,
+		document: Partial<Document>,
+	): Promise<void>;
+	deleteDocument(documentId: string): Promise<void>;
+	listDocuments(userId?: string, filter?: DocumentFilter): Promise<Document[]>;
 }

--- a/src/modules/memory/memory.module.ts
+++ b/src/modules/memory/memory.module.ts
@@ -1,5 +1,6 @@
 import type {
 	IAgentMemory,
+	IDocumentMemory,
 	IIntentMemory,
 	IMemory,
 	IThreadMemory,
@@ -42,5 +43,13 @@ export class MemoryModule {
 
 	public getUserWorkflowMemory(): IUserWorkflowMemory {
 		return this.memory.getUserWorkflowMemory();
+	}
+
+	/**
+	 * Document storage. Returns undefined when the underlying memory
+	 * implementation does not support documents.
+	 */
+	public getDocumentMemory(): IDocumentMemory | undefined {
+		return this.memory.getDocumentMemory?.();
 	}
 }

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { getMemoryModule } from "@/config/modules";
 import { createAgentApiRouter } from "./api/agent.routes.js";
+import { createDocumentApiRouter } from "./api/document.routes.js";
 import { createIntentApiRouter } from "./api/intent.routes.js";
 import { createModelApiRouter } from "./api/model.routes.js";
 import { createThreadApiRouter } from "./api/threads.routes.js";
@@ -19,6 +20,9 @@ export const createApiRouter = (): Router => {
 		router.use("/intent", createIntentApiRouter());
 		router.use("/workflow-template", createWorkflowTemplateApiRouter());
 		router.use("/user-workflow", createUserWorkflowApiRouter());
+		if (memoryModule.getDocumentMemory()) {
+			router.use("/document", createDocumentApiRouter());
+		}
 	}
 
 	return router;

--- a/src/routes/api/document.routes.ts
+++ b/src/routes/api/document.routes.ts
@@ -32,6 +32,17 @@ export const createDocumentApiRouter = (): Router => {
 	// APIs (prefix: /api/document)
 	router.get("/", checkDocumentMemory, controller.handleGetAllDocuments);
 	router.get("/:id", checkDocumentMemory, controller.handleGetDocument);
+	router.post("/", checkDocumentMemory, controller.handleCreateDocument);
+	router.post(
+		"/:id/slots/:slotId/fill",
+		checkDocumentMemory,
+		controller.handleFillSlot,
+	);
+	router.post(
+		"/:id/slots/:slotId/fill/stream",
+		checkDocumentMemory,
+		controller.handleFillSlotStream,
+	);
 	router.post(
 		"/update/:id",
 		checkDocumentMemory,

--- a/src/routes/api/document.routes.ts
+++ b/src/routes/api/document.routes.ts
@@ -44,6 +44,11 @@ export const createDocumentApiRouter = (): Router => {
 		controller.handleFillSlotStream,
 	);
 	router.post(
+		"/:id/advice/stream",
+		checkDocumentMemory,
+		controller.handleGenerateAdviceStream,
+	);
+	router.post(
 		"/update/:id",
 		checkDocumentMemory,
 		controller.handleUpdateDocument,

--- a/src/routes/api/document.routes.ts
+++ b/src/routes/api/document.routes.ts
@@ -1,0 +1,47 @@
+import {
+	type NextFunction,
+	type Request,
+	type Response,
+	Router,
+} from "express";
+import { StatusCodes } from "http-status-codes";
+import { getMemoryModule } from "@/config/modules";
+import { container } from "@/container";
+import { AinHttpError } from "@/types/agent";
+
+export const createDocumentApiRouter = (): Router => {
+	const router = Router();
+	const controller = container.getDocumentApiController();
+
+	const checkDocumentMemory = (
+		_req: Request,
+		_res: Response,
+		next: NextFunction,
+	) => {
+		const memoryModule = getMemoryModule();
+		const documentMemory = memoryModule.getDocumentMemory();
+		if (!documentMemory) {
+			throw new AinHttpError(
+				StatusCodes.SERVICE_UNAVAILABLE,
+				"Document memory is not initialized",
+			);
+		}
+		next();
+	};
+
+	// APIs (prefix: /api/document)
+	router.get("/", checkDocumentMemory, controller.handleGetAllDocuments);
+	router.get("/:id", checkDocumentMemory, controller.handleGetDocument);
+	router.post(
+		"/update/:id",
+		checkDocumentMemory,
+		controller.handleUpdateDocument,
+	);
+	router.post(
+		"/delete/:id",
+		checkDocumentMemory,
+		controller.handleDeleteDocument,
+	);
+
+	return router;
+};

--- a/src/services/document-advice.service.ts
+++ b/src/services/document-advice.service.ts
@@ -1,0 +1,77 @@
+import type { MemoryModule, ModelModule } from "@/modules";
+import type { StreamEvent } from "@/types/stream.js";
+import { renderDocument } from "@/utils/document-render.js";
+import { loggers } from "@/utils/logger.js";
+import documentAdvicePrompt from "./prompts/document-advice.js";
+
+/**
+ * Generates AI advice for a document by running a single-turn streaming model
+ * completion over the document's rendered content, then caches the result on
+ * `document.advice`.
+ */
+export class DocumentAdviceService {
+	private modelModule: ModelModule;
+	private memoryModule: MemoryModule;
+
+	constructor(modelModule: ModelModule, memoryModule: MemoryModule) {
+		this.modelModule = modelModule;
+		this.memoryModule = memoryModule;
+	}
+
+	async *generateAdviceStream(
+		documentId: string,
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+		const documentMemory = this.memoryModule.getDocumentMemory();
+		if (!documentMemory) {
+			throw new Error("Document memory is not initialized");
+		}
+		const document = await documentMemory.getDocument(documentId);
+		if (!document) {
+			throw new Error(`Document not found: ${documentId}`);
+		}
+
+		const renderedContent = renderDocument(document);
+		const systemPrompt = await documentAdvicePrompt(this.memoryModule);
+
+		const model = this.modelModule.getModel();
+		const modelOptions = this.modelModule.getModelOptions();
+		const messages = model.generateMessages({
+			query: renderedContent,
+			systemPrompt,
+		});
+
+		let content = "";
+		const stream = await model.fetchStreamWithContextMessage(
+			messages,
+			[],
+			modelOptions,
+		);
+		for await (const chunk of stream) {
+			if (signal?.aborted) {
+				throw new Error("Advice generation aborted by client");
+			}
+			if (chunk.delta?.content) {
+				content += chunk.delta.content;
+				yield { event: "text_chunk", data: { delta: chunk.delta.content } };
+			}
+		}
+
+		if (!content.trim()) {
+			return;
+		}
+
+		try {
+			await documentMemory.updateDocument(documentId, {
+				advice: { content, generatedAt: new Date().toISOString() },
+				version: document.version + 1,
+				updatedAt: new Date().toISOString(),
+			});
+		} catch (saveError) {
+			loggers.agent.error("Failed to cache document advice", {
+				documentId,
+				error: saveError,
+			});
+		}
+	}
+}

--- a/src/services/document-advice.service.ts
+++ b/src/services/document-advice.service.ts
@@ -20,6 +20,7 @@ export class DocumentAdviceService {
 
 	async *generateAdviceStream(
 		documentId: string,
+		options?: { advicePrompt?: string },
 		signal?: AbortSignal,
 	): AsyncGenerator<StreamEvent> {
 		const documentMemory = this.memoryModule.getDocumentMemory();
@@ -32,7 +33,9 @@ export class DocumentAdviceService {
 		}
 
 		const renderedContent = renderDocument(document);
-		const systemPrompt = await documentAdvicePrompt(this.memoryModule);
+		const systemPrompt =
+			options?.advicePrompt?.trim() ||
+			(await documentAdvicePrompt(this.memoryModule));
 
 		const model = this.modelModule.getModel();
 		const modelOptions = this.modelModule.getModelOptions();

--- a/src/services/document-advice.service.ts
+++ b/src/services/document-advice.service.ts
@@ -65,10 +65,10 @@ export class DocumentAdviceService {
 		}
 
 		try {
+			// Persist only the advice (metadata); do NOT bump version off a
+			// pre-stream read, which could clobber a concurrent edit (lost update).
 			await documentMemory.updateDocument(documentId, {
 				advice: { content, generatedAt: new Date().toISOString() },
-				version: document.version + 1,
-				updatedAt: new Date().toISOString(),
 			});
 		} catch (saveError) {
 			loggers.agent.error("Failed to cache document advice", {

--- a/src/services/prompts/document-advice.ts
+++ b/src/services/prompts/document-advice.ts
@@ -2,7 +2,7 @@ import type { MemoryModule } from "@/modules";
 
 async function documentAdvicePrompt(memoryModule: MemoryModule) {
 	const prompt =
-		(await memoryModule?.getAgentMemory()?.getDocumentAdvicePrompt?.()) ||
+		(await memoryModule.getAgentMemory()?.getDocumentAdvicePrompt?.()) ||
 		`당신은 매장 운영을 돕는 분석 어시스턴트입니다.
 아래는 한 매장의 로그북(운영 메모와 매출/지표 데이터)입니다.
 이 내용을 바탕으로 운영자에게 도움이 되는 조언을 한국어로 작성하세요.

--- a/src/services/prompts/document-advice.ts
+++ b/src/services/prompts/document-advice.ts
@@ -1,0 +1,21 @@
+import type { MemoryModule } from "@/modules";
+
+async function documentAdvicePrompt(memoryModule: MemoryModule) {
+	const prompt =
+		(await memoryModule?.getAgentMemory()?.getDocumentAdvicePrompt?.()) ||
+		`당신은 매장 운영을 돕는 분석 어시스턴트입니다.
+아래는 한 매장의 로그북(운영 메모와 매출/지표 데이터)입니다.
+이 내용을 바탕으로 운영자에게 도움이 되는 조언을 한국어로 작성하세요.
+
+작성 지침:
+- 문단형 산문으로 작성하고, 마크다운 제목/불릿은 사용하지 마세요.
+- 먼저 오늘 운영에 대한 간단한 인정/격려로 시작하세요.
+- 다음 영업일 전망과, 데이터에 근거한 수치 기대치를 제시하세요.
+- 입력에 없는 수치나 사실을 지어내지 마세요. 데이터가 없으면 일반적인 조언만 하세요.
+- 실행 가능한 운영 팁을 1~2가지 제시하세요.
+- 마지막은 짧은 응원의 한 문장으로 마무리하세요.
+- 사용자가 입력한 언어로 답하세요.`;
+	return prompt;
+}
+
+export default documentAdvicePrompt;

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -1,12 +1,19 @@
 import { randomUUID } from "node:crypto";
 import type { A2AModule, MemoryModule, ModelModule } from "@/modules";
-import { DocumentFormat, DocumentSource } from "@/types/document.js";
+import {
+	type Document,
+	DocumentFormat,
+	type DocumentFragment,
+	type DocumentSlot,
+	DocumentSource,
+} from "@/types/document.js";
 import {
 	MessageRole,
 	type ThreadMetadata,
 	type ThreadObject,
 	ThreadType,
 	type UserWorkflow,
+	type WorkflowDefinition,
 	type WorkflowRenderedBlock,
 	type WorkflowTaskResult,
 } from "@/types/memory.js";
@@ -130,6 +137,110 @@ export class WorkflowExecutionService {
 			},
 		};
 
+		const { finalContent, renderedBlocks, executionError } =
+			yield* this.renderStructuredDefinition(
+				definition,
+				thread,
+				workflowId,
+				signal,
+			);
+
+		const responseContent =
+			finalContent || (executionError ? `오류: ${executionError.message}` : "");
+		try {
+			const documentMemory = this.memoryModule.getDocumentMemory();
+			if (documentMemory && !executionError && finalContent) {
+				// Promote the workflow result to a first-class document and
+				// reference it from the thread (body is resolved on demand).
+				const documentId = randomUUID();
+				const now = new Date().toISOString();
+				await documentMemory.createDocument({
+					documentId,
+					userId: workflow.userId,
+					title: thread.title,
+					format: DocumentFormat.MARKDOWN,
+					content: finalContent,
+					blocks: renderedBlocks,
+					source: DocumentSource.WORKFLOW,
+					workflowId,
+					threadId: thread.threadId,
+					version: 1,
+					createdAt: now,
+					updatedAt: now,
+				});
+				await appendRichMessageToThread(
+					this.memoryModule,
+					thread,
+					MessageRole.MODEL,
+					[{ type: "document", documentId, title: thread.title }],
+					{
+						workflowId,
+						workflowRun: true,
+						documentId,
+					},
+				);
+			} else {
+				// No document memory (or execution failed): keep the legacy
+				// inline text message with structured blocks in metadata.
+				await appendTextMessageToThread(
+					this.memoryModule,
+					thread,
+					MessageRole.MODEL,
+					responseContent,
+					{
+						workflowId,
+						workflowRun: true,
+						responseBlocks: renderedBlocks,
+						...(executionError ? { error: executionError.message } : {}),
+					},
+				);
+			}
+		} catch (saveError) {
+			loggers.agent.error("Failed to save workflow response message", {
+				workflowId,
+				threadId: thread.threadId,
+				error: saveError,
+			});
+		}
+
+		try {
+			await this.userWorkflowService.updateWorkflow(workflowId, {
+				userId: workflow.userId,
+				lastRunAt: Date.now(),
+				lastThreadId: thread.threadId,
+			});
+		} catch (updateError) {
+			loggers.agent.error("Failed to update workflow lastRunAt", {
+				workflowId,
+				error: updateError,
+			});
+		}
+
+		if (executionError) {
+			throw executionError;
+		}
+	}
+
+	/**
+	 * Runs a structured workflow definition (tasks → response blocks) against a
+	 * thread context, streaming progress events. Never throws — any failure is
+	 * captured and returned as `executionError` so callers can decide how to
+	 * persist the (partial) result.
+	 */
+	private async *renderStructuredDefinition(
+		definition: WorkflowDefinition,
+		thread: ThreadObject,
+		workflowId: string,
+		signal?: AbortSignal,
+	): AsyncGenerator<
+		StreamEvent,
+		{
+			finalContent: string;
+			renderedBlocks: WorkflowRenderedBlock[];
+			executionError?: Error;
+		},
+		unknown
+	> {
 		const taskResults: Record<string, WorkflowTaskResult> = {};
 		const renderedBlocks: WorkflowRenderedBlock[] = [];
 		let finalContent = "";
@@ -140,7 +251,7 @@ export class WorkflowExecutionService {
 			yield {
 				event: "thinking_process",
 				data: {
-					title: `[워크플로우] ${workflow.title}`,
+					title: "[워크플로우] 실행",
 					description: "워크플로우 실행을 시작합니다.",
 					metadata: {
 						phase: "workflow_start",
@@ -299,101 +410,184 @@ export class WorkflowExecutionService {
 				);
 			}
 
-			loggers.agent.info(
-				`Structured user workflow completed: ${workflow.title}`,
-				{
-					workflowId,
-					threadId: thread.threadId,
-				},
-			);
+			loggers.agent.info("Structured workflow definition completed", {
+				workflowId,
+				threadId: thread.threadId,
+			});
 		} catch (error) {
 			executionError =
 				error instanceof Error ? error : new Error(String(error));
-			loggers.agent.error(
-				`Structured user workflow failed: ${workflow.title}`,
-				{
-					workflowId,
-					threadId: thread.threadId,
-					error: executionError.message,
-				},
+			loggers.agent.error("Structured workflow definition failed", {
+				workflowId,
+				threadId: thread.threadId,
+				error: executionError.message,
+			});
+		}
+
+		return { finalContent, renderedBlocks, executionError };
+	}
+
+	/**
+	 * Non-streaming variant of {@link fillDocumentSlotStream}.
+	 */
+	async fillDocumentSlot(
+		documentId: string,
+		slotId: string,
+		options?: {
+			workflowId?: string;
+			executionVariables?: Record<string, string>;
+		},
+		signal?: AbortSignal,
+	): Promise<{ documentId: string; slotId: string; content: string }> {
+		let content = "";
+		for await (const event of this.fillDocumentSlotStream(
+			documentId,
+			slotId,
+			options,
+			signal,
+		)) {
+			if (event.event === "text_chunk") {
+				content += event.data.delta;
+			}
+		}
+		return { documentId, slotId, content };
+	}
+
+	/**
+	 * Fills a single document slot by running its bound workflow (or an
+	 * explicitly provided one). Unlike {@link executeWorkflowStream}, this does
+	 * NOT create or persist a thread — the document slot is the only artifact.
+	 * Progress is streamed live but not persisted anywhere.
+	 */
+	async *fillDocumentSlotStream(
+		documentId: string,
+		slotId: string,
+		options?: {
+			workflowId?: string;
+			executionVariables?: Record<string, string>;
+		},
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+		const documentMemory = this.memoryModule.getDocumentMemory();
+		if (!documentMemory) {
+			throw new Error("Document memory is not initialized");
+		}
+
+		const document = await documentMemory.getDocument(documentId);
+		if (!document) {
+			throw new Error(`Document not found: ${documentId}`);
+		}
+
+		const slot = document.slots?.find((s) => s.slotId === slotId);
+		if (!slot) {
+			throw new Error(`Document slot not found: ${documentId}/${slotId}`);
+		}
+
+		// Resolve which workflow fills this slot (explicit override > binding).
+		const workflowId =
+			options?.workflowId ??
+			(slot.binding?.type === "WORKFLOW" ? slot.binding.workflowId : undefined);
+		if (!workflowId) {
+			throw new Error(
+				`No workflow bound to slot ${documentId}/${slotId}; provide workflowId`,
 			);
-		} finally {
-			const responseContent =
-				finalContent ||
-				(executionError ? `오류: ${executionError.message}` : "");
-			try {
-				const documentMemory = this.memoryModule.getDocumentMemory();
-				if (documentMemory && !executionError && finalContent) {
-					// Promote the workflow result to a first-class document and
-					// reference it from the thread (body is resolved on demand).
-					const documentId = randomUUID();
-					const now = new Date().toISOString();
-					await documentMemory.createDocument({
-						documentId,
-						userId: workflow.userId,
-						title: thread.title,
-						format: DocumentFormat.MARKDOWN,
-						content: finalContent,
-						blocks: renderedBlocks,
-						source: DocumentSource.WORKFLOW,
-						workflowId,
-						threadId: thread.threadId,
-						version: 1,
-						createdAt: now,
-						updatedAt: now,
-					});
-					await appendRichMessageToThread(
-						this.memoryModule,
-						thread,
-						MessageRole.MODEL,
-						[{ type: "document", documentId, title: thread.title }],
-						{
-							workflowId,
-							workflowRun: true,
-							documentId,
-						},
-					);
-				} else {
-					// No document memory (or execution failed): keep the legacy
-					// inline text message with structured blocks in metadata.
-					await appendTextMessageToThread(
-						this.memoryModule,
-						thread,
-						MessageRole.MODEL,
-						responseContent,
-						{
-							workflowId,
-							workflowRun: true,
-							responseBlocks: renderedBlocks,
-							...(executionError ? { error: executionError.message } : {}),
-						},
-					);
-				}
-			} catch (saveError) {
-				loggers.agent.error("Failed to save workflow response message", {
-					workflowId,
-					threadId: thread.threadId,
-					error: saveError,
-				});
-			}
+		}
+		const executionVariables =
+			options?.executionVariables ??
+			(slot.binding?.type === "WORKFLOW"
+				? slot.binding.executionVariables
+				: undefined);
 
-			try {
-				await this.userWorkflowService.updateWorkflow(workflowId, {
-					userId: workflow.userId,
-					lastRunAt: Date.now(),
-					lastThreadId: thread.threadId,
-				});
-			} catch (updateError) {
-				loggers.agent.error("Failed to update workflow lastRunAt", {
-					workflowId,
-					error: updateError,
-				});
-			}
+		yield {
+			event: "document_id",
+			data: { documentId, slotId },
+		};
+
+		const workflow = await this.userWorkflowService.getWorkflow(workflowId);
+		if (!workflow) {
+			throw new Error(`User workflow not found: ${workflowId}`);
 		}
 
-		if (executionError) {
-			throw executionError;
+		const { definition } = this.workflowVariableResolver.resolveForExecution(
+			workflow,
+			executionVariables,
+		);
+		if (!definition) {
+			throw new Error(
+				`Workflow ${workflowId} has no structured definition; cannot fill slot`,
+			);
 		}
+
+		await this.updateSlot(documentMemory, document, slotId, {
+			status: "running",
+			error: undefined,
+		});
+
+		// Ephemeral, non-persisted thread: carries threadId for A2A correlation
+		// and task context, but is never written to the thread store.
+		const thread: ThreadObject = {
+			type: ThreadType.WORKFLOW,
+			userId: document.userId,
+			threadId: randomUUID(),
+			title: workflow.title,
+			workflowId,
+			messages: [],
+		};
+
+		const { finalContent, renderedBlocks, executionError } =
+			yield* this.renderStructuredDefinition(
+				definition,
+				thread,
+				workflowId,
+				signal,
+			);
+
+		if (executionError || !finalContent) {
+			await this.updateSlot(documentMemory, document, slotId, {
+				status: "failed",
+				error: executionError?.message ?? "No content produced",
+			});
+			if (executionError) {
+				throw executionError;
+			}
+			return;
+		}
+
+		const fragment: DocumentFragment = {
+			content: finalContent,
+			blocks: renderedBlocks,
+			source: { type: "WORKFLOW", workflowId },
+			resolvedAt: new Date().toISOString(),
+		};
+		await this.updateSlot(documentMemory, document, slotId, {
+			status: "resolved",
+			fragment,
+			error: undefined,
+		});
+	}
+
+	/**
+	 * Writes a partial update to a single slot and persists the document with a
+	 * bumped version. Mutates the in-memory `document.slots` so subsequent
+	 * updates in the same run build on the latest state.
+	 */
+	private async updateSlot(
+		documentMemory: NonNullable<ReturnType<MemoryModule["getDocumentMemory"]>>,
+		document: Document,
+		slotId: string,
+		patch: Partial<DocumentSlot>,
+	): Promise<void> {
+		const slots = (document.slots ?? []).map((slot) =>
+			slot.slotId === slotId ? { ...slot, ...patch } : slot,
+		);
+		document.slots = slots;
+		document.version += 1;
+		document.updatedAt = new Date().toISOString();
+		await documentMemory.updateDocument(document.documentId, {
+			slots,
+			version: document.version,
+			updatedAt: document.updatedAt,
+		});
 	}
 
 	private async *executeLegacyWorkflowStream(

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -16,6 +16,7 @@ import {
 	type WorkflowDefinition,
 	type WorkflowRenderedBlock,
 	type WorkflowTaskResult,
+	type WorkflowTemplate,
 } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
 import { loggers } from "@/utils/logger.js";
@@ -503,12 +504,13 @@ export class WorkflowExecutionService {
 			data: { documentId, slotId },
 		};
 
-		const workflow = await this.userWorkflowService.getWorkflow(workflowId);
+		// A slot may bind to either a user workflow or a workflow template.
+		const workflow = await this.getFillableWorkflow(workflowId);
 		if (!workflow) {
-			throw new Error(`User workflow not found: ${workflowId}`);
+			throw new Error(`User workflow or template not found: ${workflowId}`);
 		}
 
-		const { definition } = this.workflowVariableResolver.resolveForExecution(
+		const { definition } = this.workflowVariableResolver.resolveForDocumentFill(
 			workflow,
 			executionVariables,
 		);
@@ -623,6 +625,23 @@ export class WorkflowExecutionService {
 			lastRunAt: Date.now(),
 			lastThreadId: threadId,
 		});
+	}
+
+	/**
+	 * Resolves a slot binding's `workflowId` to a runnable workflow, accepting
+	 * either a user workflow or a workflow template. User workflows take
+	 * precedence; falls back to a template with the same id.
+	 */
+	private async getFillableWorkflow(
+		workflowId: string,
+	): Promise<UserWorkflow | WorkflowTemplate | undefined> {
+		const userWorkflow = await this.userWorkflowService.getWorkflow(workflowId);
+		if (userWorkflow) {
+			return userWorkflow;
+		}
+		return this.memoryModule
+			.getWorkflowTemplateMemory()
+			.getTemplate(workflowId);
 	}
 
 	private async createWorkflowThread(

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { A2AModule, MemoryModule, ModelModule } from "@/modules";
+import { DocumentFormat, DocumentSource } from "@/types/document.js";
 import {
 	MessageRole,
 	type ThreadMetadata,
@@ -11,7 +12,10 @@ import {
 } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
 import { loggers } from "@/utils/logger.js";
-import { appendTextMessageToThread } from "@/utils/thread-messages.js";
+import {
+	appendRichMessageToThread,
+	appendTextMessageToThread,
+} from "@/utils/thread-messages.js";
 import type { QueryService } from "./query.service.js";
 import type { ToolCallingService } from "./tool-calling.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
@@ -318,18 +322,53 @@ export class WorkflowExecutionService {
 				finalContent ||
 				(executionError ? `오류: ${executionError.message}` : "");
 			try {
-				await appendTextMessageToThread(
-					this.memoryModule,
-					thread,
-					MessageRole.MODEL,
-					responseContent,
-					{
+				const documentMemory = this.memoryModule.getDocumentMemory();
+				if (documentMemory && !executionError && finalContent) {
+					// Promote the workflow result to a first-class document and
+					// reference it from the thread (body is resolved on demand).
+					const documentId = randomUUID();
+					const now = new Date().toISOString();
+					await documentMemory.createDocument({
+						documentId,
+						userId: workflow.userId,
+						title: thread.title,
+						format: DocumentFormat.MARKDOWN,
+						content: finalContent,
+						blocks: renderedBlocks,
+						source: DocumentSource.WORKFLOW,
 						workflowId,
-						workflowRun: true,
-						responseBlocks: renderedBlocks,
-						...(executionError ? { error: executionError.message } : {}),
-					},
-				);
+						threadId: thread.threadId,
+						version: 1,
+						createdAt: now,
+						updatedAt: now,
+					});
+					await appendRichMessageToThread(
+						this.memoryModule,
+						thread,
+						MessageRole.MODEL,
+						[{ type: "document", documentId, title: thread.title }],
+						{
+							workflowId,
+							workflowRun: true,
+							documentId,
+						},
+					);
+				} else {
+					// No document memory (or execution failed): keep the legacy
+					// inline text message with structured blocks in metadata.
+					await appendTextMessageToThread(
+						this.memoryModule,
+						thread,
+						MessageRole.MODEL,
+						responseContent,
+						{
+							workflowId,
+							workflowRun: true,
+							responseBlocks: renderedBlocks,
+							...(executionError ? { error: executionError.message } : {}),
+						},
+					);
+				}
 			} catch (saveError) {
 				loggers.agent.error("Failed to save workflow response message", {
 					workflowId,

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -681,49 +681,7 @@ export class WorkflowVariableResolver {
 		displayQuery: string;
 		definition?: WorkflowDefinition;
 	} {
-		const { timezone } = workflow;
-		let query = workflow.content;
-		let displayQuery = workflow.title;
-		let definition = workflow.definition;
-		const normalizedVariables = normalizeWorkflowVariablesRecord(
-			workflow.variables,
-		);
-		const mergedExecutionVariables = {
-			...(workflow.variableValues || {}),
-			...(executionVariables || {}),
-		};
-
-		if (Object.keys(mergedExecutionVariables).length > 0) {
-			const resolvedVars = resolveTemplateRecord(
-				mergedExecutionVariables,
-				timezone,
-			);
-			const replacements = buildVariableReplacements(
-				resolvedVars,
-				normalizedVariables,
-			);
-			query = resolveWorkflowVariables(query, replacements, "execution");
-			displayQuery = resolveWorkflowVariables(
-				displayQuery,
-				replacements,
-				"execution",
-			);
-			definition = replaceWorkflowVariablesInValue(
-				definition,
-				replacements,
-				"execution",
-			) as WorkflowDefinition | undefined;
-		}
-
-		return {
-			query: resolveTemplateString(query, timezone),
-			displayQuery: resolveTemplateString(displayQuery, timezone),
-			definition: validateWorkflowDefinition(
-				resolveTemplateValue(definition, timezone) as
-					| WorkflowDefinition
-					| undefined,
-			),
-		};
+		return this.resolveExecutionLike(workflow, executionVariables, false);
 	}
 
 	/**
@@ -745,6 +703,24 @@ export class WorkflowVariableResolver {
 		displayQuery: string;
 		definition?: WorkflowDefinition;
 	} {
+		return this.resolveExecutionLike(workflow, providedVariables, true);
+	}
+
+	/**
+	 * Shared execution-time variable substitution. Only `execution`-scoped
+	 * replacements apply, EXCEPT when `forceResolveAt` is true (document-slot
+	 * fills), where every provided value is applied regardless of its declared
+	 * `resolveAt`. Built-in template tokens (e.g. `{{today}}`) are always resolved.
+	 */
+	private resolveExecutionLike(
+		workflow: WorkflowTextFields,
+		providedVariables: Record<string, string> | undefined,
+		forceResolveAt: boolean,
+	): {
+		query: string;
+		displayQuery: string;
+		definition?: WorkflowDefinition;
+	} {
 		const { timezone } = workflow;
 		let query = workflow.content;
 		let displayQuery = workflow.title;
@@ -759,16 +735,16 @@ export class WorkflowVariableResolver {
 
 		if (Object.keys(mergedVariables).length > 0) {
 			const resolvedVars = resolveTemplateRecord(mergedVariables, timezone);
-			// Force every replacement to apply now (resolveAt-agnostic): the values
-			// are already final, so creation- and execution-scoped tokens alike are
-			// substituted in a single pass.
-			const replacements = buildVariableReplacements(
+			let replacements = buildVariableReplacements(
 				resolvedVars,
 				normalizedVariables,
-			).map((replacement) => ({
-				...replacement,
-				resolveAt: "execution" as const,
-			}));
+			);
+			if (forceResolveAt) {
+				replacements = replacements.map((replacement) => ({
+					...replacement,
+					resolveAt: "execution" as const,
+				}));
+			}
 			query = resolveWorkflowVariables(query, replacements, "execution");
 			displayQuery = resolveWorkflowVariables(
 				displayQuery,

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -725,4 +725,71 @@ export class WorkflowVariableResolver {
 			),
 		};
 	}
+
+	/**
+	 * Resolves a workflow for filling a document slot.
+	 *
+	 * Unlike {@link resolveForExecution}, the document context has no
+	 * creation/execution distinction: every variable value is already decided
+	 * (entered in the document-creation dialog or fixed by the workplace) and
+	 * stored on the slot binding. So all provided values are substituted
+	 * regardless of each variable's declared `resolveAt`, then built-in template
+	 * tokens (e.g. `{{today}}`) are resolved. This does NOT change how standalone
+	 * workflow execution resolves variables.
+	 */
+	resolveForDocumentFill(
+		workflow: WorkflowTextFields,
+		providedVariables?: Record<string, string>,
+	): {
+		query: string;
+		displayQuery: string;
+		definition?: WorkflowDefinition;
+	} {
+		const { timezone } = workflow;
+		let query = workflow.content;
+		let displayQuery = workflow.title;
+		let definition = workflow.definition;
+		const normalizedVariables = normalizeWorkflowVariablesRecord(
+			workflow.variables,
+		);
+		const mergedVariables = {
+			...(workflow.variableValues || {}),
+			...(providedVariables || {}),
+		};
+
+		if (Object.keys(mergedVariables).length > 0) {
+			const resolvedVars = resolveTemplateRecord(mergedVariables, timezone);
+			// Force every replacement to apply now (resolveAt-agnostic): the values
+			// are already final, so creation- and execution-scoped tokens alike are
+			// substituted in a single pass.
+			const replacements = buildVariableReplacements(
+				resolvedVars,
+				normalizedVariables,
+			).map((replacement) => ({
+				...replacement,
+				resolveAt: "execution" as const,
+			}));
+			query = resolveWorkflowVariables(query, replacements, "execution");
+			displayQuery = resolveWorkflowVariables(
+				displayQuery,
+				replacements,
+				"execution",
+			);
+			definition = replaceWorkflowVariablesInValue(
+				definition,
+				replacements,
+				"execution",
+			) as WorkflowDefinition | undefined;
+		}
+
+		return {
+			query: resolveTemplateString(query, timezone),
+			displayQuery: resolveTemplateString(displayQuery, timezone),
+			definition: validateWorkflowDefinition(
+				resolveTemplateValue(definition, timezone) as
+					| WorkflowDefinition
+					| undefined,
+			),
+		};
+	}
 }

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -83,6 +83,14 @@ export interface DocumentSlot {
  *   are read-only metadata. After a manual edit (`editedManually = true`) they
  *   may no longer be in sync with `content`.
  */
+/** AI-generated advice derived from a document's rendered content. */
+export interface DocumentAdvice {
+	/** Generated advice text (plain prose / light markdown). */
+	content: string;
+	/** ISO timestamp when generated. */
+	generatedAt: string;
+}
+
 export interface Document {
 	documentId: string;
 	userId: string;
@@ -93,6 +101,8 @@ export interface Document {
 	content: string;
 	/** Structured render artifacts captured at creation (read-only metadata). */
 	blocks?: WorkflowRenderedBlock[];
+	/** Cached AI advice generated from the rendered content. */
+	advice?: DocumentAdvice;
 	/** Placeholder slots referenced by `{{slot:slotId}}` tokens in `content`. */
 	slots?: DocumentSlot[];
 	/**

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -21,13 +21,64 @@ export enum DocumentSource {
 }
 
 /**
+ * A resolved result fragment produced by a workflow/query execution.
+ *
+ * This is the same shape a workflow already produces (markdown + structured
+ * render blocks); it fills a single {@link DocumentSlot}.
+ */
+export interface DocumentFragment {
+	/** Rendered markdown for this fragment. */
+	content: string;
+	/** Structured render artifacts (tables/graphs) for rich rendering. */
+	blocks?: WorkflowRenderedBlock[];
+	/** What produced this fragment. */
+	source:
+		| { type: "WORKFLOW"; workflowId: string }
+		| { type: "QUERY"; query: string };
+	/** ISO timestamp when the fragment was resolved. */
+	resolvedAt: string;
+}
+
+export type DocumentSlotStatus = "empty" | "running" | "resolved" | "failed";
+
+/**
+ * A placeholder within a document body, addressed by a `{{slot:slotId}}` token
+ * in {@link Document.content}. Filled on demand by a bound workflow/query.
+ */
+export interface DocumentSlot {
+	/** Matches the `{{slot:slotId}}` token in the document content. */
+	slotId: string;
+	/** Human-readable label for the slot. */
+	label?: string;
+	/** Fill lifecycle status. */
+	status: DocumentSlotStatus;
+	/**
+	 * Pre-declared source that fills this slot. A fill request may override
+	 * the workflow/variables explicitly.
+	 */
+	binding?:
+		| {
+				type: "WORKFLOW";
+				workflowId: string;
+				executionVariables?: Record<string, string>;
+		  }
+		| { type: "QUERY"; query: string };
+	/** Resolved result once filled. */
+	fragment?: DocumentFragment;
+	/** Error message when `status === "failed"`. */
+	error?: string;
+}
+
+/**
  * A first-class, mutable document.
  *
  * Documents hold the canonical result of a workflow/query as markdown and are
  * referenced from threads (rather than embedded), so manual edits are always
  * reflected wherever the document is rendered.
  *
- * - `content` is the canonical markdown (the edit target).
+ * - `content` is the canonical markdown (the edit target). It may contain
+ *   `{{slot:slotId}}` tokens that are substituted with the resolved fragment
+ *   of the matching {@link DocumentSlot}.
  * - `blocks` are the structured render artifacts captured at creation time and
  *   are read-only metadata. After a manual edit (`editedManually = true`) they
  *   may no longer be in sync with `content`.
@@ -42,6 +93,10 @@ export interface Document {
 	content: string;
 	/** Structured render artifacts captured at creation (read-only metadata). */
 	blocks?: WorkflowRenderedBlock[];
+	/** Placeholder slots referenced by `{{slot:slotId}}` tokens in `content`. */
+	slots?: DocumentSlot[];
+	/** Optional grouping key for viewing related documents together. */
+	groupId?: string;
 	/** Where this document came from. */
 	source: DocumentSource;
 	/** Source workflow when `source === WORKFLOW`. */
@@ -65,4 +120,5 @@ export type DocumentFilter = {
 	workflowId?: string;
 	threadId?: string;
 	source?: DocumentSource;
+	groupId?: string;
 };

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -95,8 +95,15 @@ export interface Document {
 	blocks?: WorkflowRenderedBlock[];
 	/** Placeholder slots referenced by `{{slot:slotId}}` tokens in `content`. */
 	slots?: DocumentSlot[];
-	/** Optional grouping key for viewing related documents together. */
-	groupId?: string;
+	/**
+	 * Faceted grouping dimensions, e.g.
+	 * `{ category: "logbook", workplaceId: "123", month: "2026-06" }`.
+	 *
+	 * The hierarchy/nesting order is NOT encoded here — it is decided at query
+	 * or render time by choosing an order of label keys. This keeps grouping
+	 * extensible to any number of levels without schema changes.
+	 */
+	labels?: Record<string, string>;
 	/** Where this document came from. */
 	source: DocumentSource;
 	/** Source workflow when `source === WORKFLOW`. */
@@ -115,10 +122,13 @@ export interface Document {
 
 /**
  * Optional filters for listing documents.
+ *
+ * `labels` is a subset match: every provided key/value must equal the
+ * document's corresponding label.
  */
 export type DocumentFilter = {
 	workflowId?: string;
 	threadId?: string;
 	source?: DocumentSource;
-	groupId?: string;
+	labels?: Record<string, string>;
 };

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,0 +1,68 @@
+import type { WorkflowRenderedBlock } from "./memory.js";
+
+/**
+ * Storage/render format of a document body.
+ * Currently only markdown is supported.
+ */
+export enum DocumentFormat {
+	MARKDOWN = "MARKDOWN",
+}
+
+/**
+ * Origin of a document.
+ * - WORKFLOW: produced by a user workflow execution
+ * - QUERY: produced by a standard query response
+ * - MANUAL: created directly by a human
+ */
+export enum DocumentSource {
+	WORKFLOW = "WORKFLOW",
+	QUERY = "QUERY",
+	MANUAL = "MANUAL",
+}
+
+/**
+ * A first-class, mutable document.
+ *
+ * Documents hold the canonical result of a workflow/query as markdown and are
+ * referenced from threads (rather than embedded), so manual edits are always
+ * reflected wherever the document is rendered.
+ *
+ * - `content` is the canonical markdown (the edit target).
+ * - `blocks` are the structured render artifacts captured at creation time and
+ *   are read-only metadata. After a manual edit (`editedManually = true`) they
+ *   may no longer be in sync with `content`.
+ */
+export interface Document {
+	documentId: string;
+	userId: string;
+	title: string;
+	/** Body format. Defaults to MARKDOWN. */
+	format: DocumentFormat;
+	/** Canonical markdown body — the display and edit target. */
+	content: string;
+	/** Structured render artifacts captured at creation (read-only metadata). */
+	blocks?: WorkflowRenderedBlock[];
+	/** Where this document came from. */
+	source: DocumentSource;
+	/** Source workflow when `source === WORKFLOW`. */
+	workflowId?: string;
+	/** Thread this document was created in (back-reference). */
+	threadId?: string;
+	/** Incremented on every update. Starts at 1. */
+	version: number;
+	/** True once a human has edited `content`; `blocks` may then be stale. */
+	editedManually?: boolean;
+	/** ISO timestamp of creation. */
+	createdAt: string;
+	/** ISO timestamp of the last update. */
+	updatedAt: string;
+}
+
+/**
+ * Optional filters for listing documents.
+ */
+export type DocumentFilter = {
+	workflowId?: string;
+	threadId?: string;
+	source?: DocumentSource;
+};

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -2,12 +2,26 @@ import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-export type MCPConfig =
-	| { type: "stdio"; params: StdioServerParameters }
-	| { type: "websocket"; url: URL }
-	| { type: "sse"; url: URL; options?: SSEClientTransportOptions }
-	| {
-			type: "streamableHttp";
-			url: URL;
-			options?: StreamableHTTPClientTransportOptions;
-	  };
+/**
+ * Per-connector knobs shared across every transport type.
+ *
+ * `requestTimeoutMs` overrides the MCP SDK's default per-request timeout
+ * (`DEFAULT_REQUEST_TIMEOUT_MSEC`, 60s) for tool calls on this connector. Raise
+ * it for connectors that expose long-running tools (e.g. multi-day reasoning
+ * scans) so a slow-but-valid call isn't aborted as a -32001 timeout.
+ */
+interface MCPConfigCommon {
+	requestTimeoutMs?: number;
+}
+
+export type MCPConfig = MCPConfigCommon &
+	(
+		| { type: "stdio"; params: StdioServerParameters }
+		| { type: "websocket"; url: URL }
+		| { type: "sse"; url: URL; options?: SSEClientTransportOptions }
+		| {
+				type: "streamableHttp";
+				url: URL;
+				options?: StreamableHTTPClientTransportOptions;
+		  }
+	);

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -11,14 +11,45 @@ export enum MessageRole {
 }
 
 /**
+ * A plain-text segment within a "rich" message.
+ */
+export type TextPart = {
+	type: "text";
+	text: string;
+};
+
+/**
+ * A reference to a {@link Document} within a "rich" message.
+ *
+ * The body is NOT embedded — clients resolve `documentId` to fetch the latest
+ * document (rendering it inline or as a link). `title` is a label hint only.
+ */
+export type DocumentPart = {
+	type: "document";
+	documentId: string;
+	/** Label hint for rendering (e.g. link text). Not the canonical title. */
+	title?: string;
+};
+
+/**
+ * A single segment of a "rich" message. Discriminated by `type`.
+ */
+export type MessagePart = TextPart | DocumentPart;
+
+/**
  * Content structure for message content.
  *
  * Supports multi-part content with different types (text, images, etc.).
+ *
+ * - `type: "text"` — `parts` is `string[]` (legacy/simple text).
+ * - `type: "document"` — `parts` is a single `[DocumentPart]` (document-only).
+ * - `type: "rich"` — `parts` is `MessagePart[]`, mixing text and document
+ *   references in display order.
  */
 export type MessageContentObject = {
-	/** Content type (e.g., "text", "image", "tool_use") */
+	/** Content type (e.g., "text", "document", "rich"). */
 	type: string;
-	/** Array of content parts, structure depends on content type */
+	/** Array of content parts, structure depends on content type. */
 	parts: unknown[];
 };
 

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -42,6 +42,10 @@ export type StreamEvent =
 	  }
 	| { event: "error"; data: { message: string } }
 	| { event: "thread_id"; data: ThreadMetadata }
+	| {
+			event: "document_id";
+			data: { documentId: string; slotId: string };
+	  }
 	| { event: "intent_process"; data: { subquery: string; actionPlan: string } }
 	| { event: "collection_name"; data: { name: string } }
 	| {

--- a/src/utils/document-render.ts
+++ b/src/utils/document-render.ts
@@ -1,0 +1,44 @@
+import type { Document, DocumentSlot } from "@/types/document";
+
+/** Matches `{{slot:slotId}}` tokens (slotId: letters, digits, _ or -). */
+const SLOT_TOKEN = /\{\{\s*slot:([A-Za-z0-9_-]+)\s*\}\}/g;
+
+export type RenderSlotPlaceholder = (slot: DocumentSlot) => string;
+
+const defaultPlaceholder: RenderSlotPlaceholder = (slot) => {
+	switch (slot.status) {
+		case "running":
+			return `_${slot.label ?? slot.slotId} 조회 중…_`;
+		case "failed":
+			return `_${slot.label ?? slot.slotId} 조회 실패_`;
+		default:
+			return `_${slot.label ?? slot.slotId} (조회 전)_`;
+	}
+};
+
+/**
+ * Renders a document to final markdown by substituting each `{{slot:slotId}}`
+ * token in `content` with the resolved fragment of the matching slot. Slots
+ * that are not yet resolved fall back to a status placeholder.
+ *
+ * Tokens with no matching slot are left untouched.
+ */
+export function renderDocument(
+	document: Document,
+	placeholder: RenderSlotPlaceholder = defaultPlaceholder,
+): string {
+	const slotsById = new Map(
+		(document.slots ?? []).map((slot) => [slot.slotId, slot]),
+	);
+
+	return document.content.replace(SLOT_TOKEN, (token, slotId: string) => {
+		const slot = slotsById.get(slotId);
+		if (!slot) {
+			return token;
+		}
+		if (slot.status === "resolved" && slot.fragment) {
+			return slot.fragment.content;
+		}
+		return placeholder(slot);
+	});
+}

--- a/src/utils/thread-messages.ts
+++ b/src/utils/thread-messages.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { MemoryModule } from "@/modules";
-import type { MessageObject, MessageRole, ThreadObject } from "@/types/memory";
+import type {
+	MessageObject,
+	MessagePart,
+	MessageRole,
+	ThreadObject,
+} from "@/types/memory";
 
 export function createTextMessage(
 	role: MessageRole,
@@ -38,6 +43,40 @@ export async function appendTextMessageToThread(
 	metadata?: Record<string, unknown>,
 ): Promise<void> {
 	const message = createTextMessage(role, content, metadata);
+	thread.messages.push(message);
+	await memoryModule
+		.getThreadMemory()
+		?.addMessagesToThread(thread.userId, thread.threadId, [message]);
+}
+
+/**
+ * Creates a "rich" message mixing text and document-reference parts.
+ *
+ * Parts are rendered in order by the client. Document parts carry only a
+ * `documentId` (and optional label `title`) — the body is resolved on demand.
+ */
+export function createRichMessage(
+	role: MessageRole,
+	parts: MessagePart[],
+	metadata?: Record<string, unknown>,
+): MessageObject {
+	return {
+		messageId: randomUUID(),
+		role,
+		timestamp: Date.now(),
+		content: { type: "rich", parts },
+		metadata,
+	};
+}
+
+export async function appendRichMessageToThread(
+	memoryModule: MemoryModule,
+	thread: ThreadObject,
+	role: MessageRole,
+	parts: MessagePart[],
+	metadata?: Record<string, unknown>,
+): Promise<void> {
+	const message = createRichMessage(role, parts, metadata);
 	thread.messages.push(message);
 	await memoryModule
 		.getThreadMemory()

--- a/tests/services/document-advice.service.test.ts
+++ b/tests/services/document-advice.service.test.ts
@@ -78,4 +78,15 @@ describe("DocumentAdviceService", () => {
 		await collect(service.generateAdviceStream("doc-1"));
 		expect(updateDocument).not.toHaveBeenCalled();
 	});
+
+	it("uses the provided advicePrompt as the system prompt", async () => {
+		const { modelModule, memoryModule, model } = makeModules();
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+		await collect(
+			service.generateAdviceStream("doc-1", { advicePrompt: "커스텀 프롬프트" }),
+		);
+		expect(model.generateMessages).toHaveBeenCalledWith(
+			expect.objectContaining({ systemPrompt: "커스텀 프롬프트" }),
+		);
+	});
 });

--- a/tests/services/document-advice.service.test.ts
+++ b/tests/services/document-advice.service.test.ts
@@ -1,0 +1,81 @@
+import { DocumentAdviceService } from "@/services/document-advice.service";
+import type { MemoryModule, ModelModule } from "@/modules";
+
+async function collect(gen: AsyncGenerator<unknown>): Promise<unknown[]> {
+	const out: unknown[] = [];
+	for await (const e of gen) out.push(e);
+	return out;
+}
+
+describe("DocumentAdviceService", () => {
+	const document = {
+		documentId: "doc-1",
+		userId: "u1",
+		title: "Log",
+		format: "MARKDOWN",
+		content: "## 매출\n{{slot:rev}}\n",
+		version: 2,
+		source: "MANUAL",
+		slots: [
+			{
+				slotId: "rev",
+				status: "resolved",
+				fragment: { content: "총매출 100만원", source: { type: "QUERY", query: "" }, resolvedAt: "t" },
+			},
+		],
+		createdAt: "t0",
+		updatedAt: "t0",
+	};
+
+	function makeModules(updateDocument = jest.fn(async () => undefined)) {
+		const model = {
+			generateMessages: jest.fn(() => [{ role: "user", content: "x" }]),
+			fetchStreamWithContextMessage: jest.fn(async () => ({
+				async *[Symbol.asyncIterator]() {
+					yield { delta: { content: "좋은 " } };
+					yield { delta: { content: "하루였습니다." } };
+				},
+			})),
+		};
+		const modelModule = {
+			getModel: () => model,
+			getModelOptions: () => ({}),
+		} as unknown as ModelModule;
+		const memoryModule = {
+			getDocumentMemory: () => ({
+				getDocument: jest.fn(async () => document),
+				updateDocument,
+			}),
+			getAgentMemory: () => ({}),
+		} as unknown as MemoryModule;
+		return { modelModule, memoryModule, model, updateDocument };
+	}
+
+	it("streams advice text and caches it on the document", async () => {
+		const { modelModule, memoryModule, updateDocument } = makeModules();
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+
+		const events = await collect(service.generateAdviceStream("doc-1"));
+
+		const text = events
+			.filter((e: any) => e.event === "text_chunk")
+			.map((e: any) => e.data.delta)
+			.join("");
+		expect(text).toBe("좋은 하루였습니다.");
+
+		const lastCall = updateDocument.mock.calls.at(-1);
+		expect(lastCall?.[0]).toBe("doc-1");
+		expect((lastCall?.[1] as any).advice.content).toBe("좋은 하루였습니다.");
+		expect(typeof (lastCall?.[1] as any).advice.generatedAt).toBe("string");
+	});
+
+	it("does not persist when the model produces no content", async () => {
+		const { modelModule, memoryModule, model, updateDocument } = makeModules();
+		(model.fetchStreamWithContextMessage as jest.Mock).mockResolvedValue({
+			async *[Symbol.asyncIterator]() {},
+		});
+		const service = new DocumentAdviceService(modelModule, memoryModule);
+		await collect(service.generateAdviceStream("doc-1"));
+		expect(updateDocument).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -67,6 +67,7 @@ describe("WorkflowExecutionService", () => {
 				})),
 				addMessagesToThread: jest.fn(async () => undefined),
 			}),
+			getDocumentMemory: () => undefined,
 		} as unknown as MemoryModule;
 		const modelModule = {} as ModelModule;
 		const toolCallingService = {} as ToolCallingService;
@@ -145,5 +146,118 @@ describe("WorkflowExecutionService", () => {
 					event.data.delta === "unexpected early text",
 			),
 		).toBeUndefined();
+	});
+
+	it("creates a document and appends a rich reference message when document memory is available", async () => {
+		const workflow = {
+			workflowId: "workflow-1",
+			userId: "user-1",
+			title: "Daily Report",
+			content: "Daily Report",
+			active: true,
+			definition: {
+				tasks: [
+					{ taskId: "task-1", title: "Collect data", prompt: "Collect data" },
+				],
+				response: {
+					blocks: [
+						{ blockId: "block-1", type: "heading" as const, text: "Summary" },
+					],
+				},
+			},
+		};
+		const userWorkflowService = {
+			getWorkflow: jest.fn(async () => workflow),
+			updateWorkflow: jest.fn(async () => undefined),
+		} as unknown as UserWorkflowService;
+		const queryService = {} as QueryService;
+		const workflowVariableResolver = {
+			resolveForExecution: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
+		} as unknown as WorkflowVariableResolver;
+
+		const addMessagesToThread = jest.fn(async () => undefined);
+		const createDocument = jest.fn(async (doc) => doc);
+		const memoryModule = {
+			getThreadMemory: () => ({
+				createThread: jest.fn(async () => ({
+					type: ThreadType.WORKFLOW,
+					userId: workflow.userId,
+					threadId: "thread-1",
+					title: workflow.title,
+					workflowId: workflow.workflowId,
+				})),
+				addMessagesToThread,
+			}),
+			getDocumentMemory: () => ({ createDocument }),
+		} as unknown as MemoryModule;
+		const modelModule = {} as ModelModule;
+		const toolCallingService = {} as ToolCallingService;
+
+		const service = new WorkflowExecutionService(
+			userWorkflowService,
+			queryService,
+			workflowVariableResolver,
+			modelModule,
+			memoryModule,
+			toolCallingService,
+		);
+
+		(service as any).workflowTaskRunner = {
+			executeTask: async function* () {
+				return {
+					taskId: "task-1",
+					title: "Collect data",
+					status: "completed",
+					content: "task result body",
+					startedAt: 1,
+					completedAt: 2,
+				} satisfies WorkflowTaskResult;
+			},
+		};
+		(service as any).workflowResponseComposer = {
+			renderResponseBlock: async function* () {
+				yield {
+					event: "text_chunk",
+					data: { delta: "## Summary\n\n" },
+				} satisfies StreamEvent;
+				return {
+					blockId: "block-1",
+					type: "heading",
+					content: "## Summary\n\n",
+				};
+			},
+		};
+
+		await collectEvents(service.executeWorkflowStream(workflow.workflowId));
+
+		expect(createDocument).toHaveBeenCalledTimes(1);
+		const createdDoc = createDocument.mock.calls[0][0];
+		expect(createdDoc).toMatchObject({
+			userId: "user-1",
+			source: "WORKFLOW",
+			format: "MARKDOWN",
+			content: "## Summary\n\n",
+			version: 1,
+			workflowId: "workflow-1",
+			threadId: "thread-1",
+		});
+
+		// Find the rich reference message appended for the document.
+		const richCall = addMessagesToThread.mock.calls.find(
+			(call: any[]) => call[2]?.[0]?.content?.type === "rich",
+		);
+		expect(richCall).toBeDefined();
+		const richMessage = (richCall as any[])[2][0];
+		expect(richMessage.content.parts).toEqual([
+			{
+				type: "document",
+				documentId: createdDoc.documentId,
+				title: "Daily Report",
+			},
+		]);
 	});
 });

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -260,4 +260,121 @@ describe("WorkflowExecutionService", () => {
 			},
 		]);
 	});
+
+	it("fills a document slot from its bound workflow without creating a thread", async () => {
+		const workflow = {
+			workflowId: "workflow-1",
+			userId: "user-1",
+			title: "Revenue",
+			content: "Revenue",
+			active: true,
+			definition: {
+				tasks: [
+					{ taskId: "task-1", title: "Collect data", prompt: "Collect data" },
+				],
+				response: {
+					blocks: [
+						{ blockId: "block-1", type: "heading" as const, text: "Summary" },
+					],
+				},
+			},
+		};
+		const userWorkflowService = {
+			getWorkflow: jest.fn(async () => workflow),
+			updateWorkflow: jest.fn(async () => undefined),
+		} as unknown as UserWorkflowService;
+		const queryService = {} as QueryService;
+		const workflowVariableResolver = {
+			resolveForExecution: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
+		} as unknown as WorkflowVariableResolver;
+
+		const document = {
+			documentId: "doc-1",
+			userId: "user-1",
+			title: "Monthly Report",
+			format: "MARKDOWN",
+			content: "## 매출\n{{slot:revenue}}\n",
+			version: 1,
+			source: "MANUAL",
+			slots: [
+				{
+					slotId: "revenue",
+					status: "empty",
+					binding: { type: "WORKFLOW", workflowId: "workflow-1" },
+				},
+			],
+			createdAt: "t0",
+			updatedAt: "t0",
+		};
+		const createThread = jest.fn();
+		const updateDocument = jest.fn(async () => undefined);
+		const memoryModule = {
+			getThreadMemory: () => ({ createThread }),
+			getDocumentMemory: () => ({
+				getDocument: jest.fn(async () => document),
+				updateDocument,
+			}),
+		} as unknown as MemoryModule;
+		const modelModule = {} as ModelModule;
+		const toolCallingService = {} as ToolCallingService;
+
+		const service = new WorkflowExecutionService(
+			userWorkflowService,
+			queryService,
+			workflowVariableResolver,
+			modelModule,
+			memoryModule,
+			toolCallingService,
+		);
+
+		(service as any).workflowTaskRunner = {
+			executeTask: async function* () {
+				return {
+					taskId: "task-1",
+					title: "Collect data",
+					status: "completed",
+					content: "task result body",
+					startedAt: 1,
+					completedAt: 2,
+				} satisfies WorkflowTaskResult;
+			},
+		};
+		(service as any).workflowResponseComposer = {
+			renderResponseBlock: async function* () {
+				yield {
+					event: "text_chunk",
+					data: { delta: "## Summary\n\n" },
+				} satisfies StreamEvent;
+				return { blockId: "block-1", type: "heading", content: "## Summary\n\n" };
+			},
+		};
+
+		const events = await collectEvents(
+			service.fillDocumentSlotStream("doc-1", "revenue"),
+		);
+
+		// No thread is created for slot fills.
+		expect(createThread).not.toHaveBeenCalled();
+
+		// Emits a document_id event identifying the target slot.
+		expect(events).toContainEqual({
+			event: "document_id",
+			data: { documentId: "doc-1", slotId: "revenue" },
+		});
+
+		// Last slot update writes the resolved fragment into the slot.
+		const lastUpdate =
+			updateDocument.mock.calls[updateDocument.mock.calls.length - 1];
+		expect(lastUpdate[0]).toBe("doc-1");
+		const updatedSlot = (lastUpdate[1] as any).slots[0];
+		expect(updatedSlot.status).toBe("resolved");
+		expect(updatedSlot.fragment).toMatchObject({
+			content: "## Summary\n\n",
+			source: { type: "WORKFLOW", workflowId: "workflow-1" },
+		});
+	});
 });

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -55,6 +55,11 @@ describe("WorkflowExecutionService", () => {
 				displayQuery: workflow.title,
 				definition: workflow.definition,
 			})),
+			resolveForDocumentFill: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
 		} as unknown as WorkflowVariableResolver;
 		const memoryModule = {
 			getThreadMemory: () => ({
@@ -177,6 +182,11 @@ describe("WorkflowExecutionService", () => {
 				displayQuery: workflow.title,
 				definition: workflow.definition,
 			})),
+			resolveForDocumentFill: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
 		} as unknown as WorkflowVariableResolver;
 
 		const addMessagesToThread = jest.fn(async () => undefined);
@@ -290,6 +300,11 @@ describe("WorkflowExecutionService", () => {
 				displayQuery: workflow.title,
 				definition: workflow.definition,
 			})),
+			resolveForDocumentFill: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
 		} as unknown as WorkflowVariableResolver;
 
 		const document = {
@@ -375,6 +390,123 @@ describe("WorkflowExecutionService", () => {
 		expect(updatedSlot.fragment).toMatchObject({
 			content: "## Summary\n\n",
 			source: { type: "WORKFLOW", workflowId: "workflow-1" },
+		});
+	});
+
+	it("fills a document slot from a bound workflow template when no user workflow matches", async () => {
+		const template = {
+			templateId: "template-1",
+			title: "Revenue",
+			description: "",
+			active: true,
+			content: "Revenue",
+			definition: {
+				tasks: [
+					{ taskId: "task-1", title: "Collect data", prompt: "Collect data" },
+				],
+				response: {
+					blocks: [
+						{ blockId: "block-1", type: "heading" as const, text: "Summary" },
+					],
+				},
+			},
+		};
+		// No user workflow with this id → must fall back to the template.
+		const userWorkflowService = {
+			getWorkflow: jest.fn(async () => undefined),
+			updateWorkflow: jest.fn(async () => undefined),
+		} as unknown as UserWorkflowService;
+		const queryService = {} as QueryService;
+		const getTemplate = jest.fn(async () => template);
+		const resolveForDocumentFill = jest.fn(() => ({
+			query: template.content,
+			displayQuery: template.title,
+			definition: template.definition,
+		}));
+		const workflowVariableResolver = {
+			resolveForExecution: jest.fn(),
+			resolveForDocumentFill,
+		} as unknown as WorkflowVariableResolver;
+
+		const document = {
+			documentId: "doc-1",
+			userId: "user-1",
+			title: "Monthly Report",
+			format: "MARKDOWN",
+			content: "## 매출\n{{slot:revenue}}\n",
+			version: 1,
+			source: "MANUAL",
+			slots: [
+				{
+					slotId: "revenue",
+					status: "empty",
+					binding: { type: "WORKFLOW", workflowId: "template-1" },
+				},
+			],
+			createdAt: "t0",
+			updatedAt: "t0",
+		};
+		const updateDocument = jest.fn(async () => undefined);
+		const memoryModule = {
+			getThreadMemory: () => ({ createThread: jest.fn() }),
+			getWorkflowTemplateMemory: () => ({ getTemplate }),
+			getDocumentMemory: () => ({
+				getDocument: jest.fn(async () => document),
+				updateDocument,
+			}),
+		} as unknown as MemoryModule;
+
+		const service = new WorkflowExecutionService(
+			userWorkflowService,
+			queryService,
+			workflowVariableResolver,
+			{} as ModelModule,
+			memoryModule,
+			{} as ToolCallingService,
+		);
+
+		(service as any).workflowTaskRunner = {
+			executeTask: async function* () {
+				return {
+					taskId: "task-1",
+					title: "Collect data",
+					status: "completed",
+					content: "task result body",
+					startedAt: 1,
+					completedAt: 2,
+				} satisfies WorkflowTaskResult;
+			},
+		};
+		(service as any).workflowResponseComposer = {
+			renderResponseBlock: async function* () {
+				yield {
+					event: "text_chunk",
+					data: { delta: "## Summary\n\n" },
+				} satisfies StreamEvent;
+				return { blockId: "block-1", type: "heading", content: "## Summary\n\n" };
+			},
+		};
+
+		const events = await collectEvents(
+			service.fillDocumentSlotStream("doc-1", "revenue"),
+		);
+
+		// Looked up the template after the user-workflow lookup missed.
+		expect(getTemplate).toHaveBeenCalledWith("template-1");
+		expect(resolveForDocumentFill).toHaveBeenCalled();
+
+		expect(events).toContainEqual({
+			event: "document_id",
+			data: { documentId: "doc-1", slotId: "revenue" },
+		});
+
+		const lastUpdate =
+			updateDocument.mock.calls[updateDocument.mock.calls.length - 1];
+		const updatedSlot = (lastUpdate[1] as any).slots[0];
+		expect(updatedSlot.status).toBe("resolved");
+		expect(updatedSlot.fragment).toMatchObject({
+			content: "## Summary\n\n",
+			source: { type: "WORKFLOW", workflowId: "template-1" },
 		});
 	});
 });

--- a/tests/services/workflow-variable-resolver.service.test.ts
+++ b/tests/services/workflow-variable-resolver.service.test.ts
@@ -180,6 +180,62 @@ describe("WorkflowVariableResolver", () => {
 		);
 	});
 
+	describe("resolveForDocumentFill", () => {
+		it("substitutes provided variables regardless of resolveAt declaration, including undeclared keys", () => {
+			const resolver = new WorkflowVariableResolver();
+
+			const result = resolver.resolveForDocumentFill(
+				{
+					title: "{{workplace}} 매출",
+					content: "{{workplace}} / {{date}} / {{plu}}",
+					timezone: "Asia/Seoul",
+					// workplace declared as creation, date/plu not declared at all.
+					variables: {
+						workplace: {
+							id: "workplace",
+							label: "매장",
+							type: "text",
+							resolveAt: "creation",
+						},
+					},
+					definition: {
+						tasks: [
+							{
+								taskId: "fetch",
+								title: "조회",
+								prompt: "매장 {{workplace}} 일자 {{date}} 품목 {{plu}}",
+							},
+						],
+						response: { blocks: [] },
+					},
+				},
+				{ workplace: "온달", date: "2026-06-16", plu: "1234" },
+			);
+
+			expect(result.query).toBe("온달 / 2026-06-16 / 1234");
+			expect(result.displayQuery).toBe("온달 매출");
+			expect(result.definition?.tasks[0].prompt).toBe(
+				"매장 온달 일자 2026-06-16 품목 1234",
+			);
+		});
+
+		it("still resolves built-in template tokens in the workflow body", () => {
+			const resolver = new WorkflowVariableResolver();
+
+			const result = resolver.resolveForDocumentFill(
+				{
+					title: "리포트",
+					content: "{{workplace}} {{today}}",
+					timezone: "Asia/Seoul",
+					definition: { tasks: [], response: { blocks: [] } },
+				},
+				{ workplace: "온달" },
+			);
+
+			expect(result.query).toMatch(/^온달 \d{4}-\d{2}-\d{2}$/);
+		});
+	});
+
 	it("replaces placeholders by variable id as well as variable key", () => {
 		const resolver = new WorkflowVariableResolver();
 

--- a/tests/utils/document-render.test.ts
+++ b/tests/utils/document-render.test.ts
@@ -1,0 +1,51 @@
+import { renderDocument } from "@/utils/document-render";
+import type { Document } from "@/types/document";
+
+function makeDoc(partial: Partial<Document>): Document {
+	return {
+		documentId: "doc-1",
+		userId: "user-1",
+		title: "Doc",
+		format: "MARKDOWN" as Document["format"],
+		content: "",
+		source: "MANUAL" as Document["source"],
+		version: 1,
+		createdAt: "t0",
+		updatedAt: "t0",
+		...partial,
+	};
+}
+
+describe("renderDocument", () => {
+	it("substitutes a resolved slot token with its fragment content", () => {
+		const doc = makeDoc({
+			content: "## 매출\n{{slot:revenue}}\n끝",
+			slots: [
+				{
+					slotId: "revenue",
+					status: "resolved",
+					fragment: {
+						content: "| 월 | 매출 |\n|---|---|\n| 6 | 100 |",
+						source: { type: "WORKFLOW", workflowId: "wf-1" },
+						resolvedAt: "t1",
+					},
+				},
+			],
+		});
+
+		expect(renderDocument(doc)).toBe(
+			"## 매출\n| 월 | 매출 |\n|---|---|\n| 6 | 100 |\n끝",
+		);
+	});
+
+	it("renders a placeholder for unresolved slots and leaves unknown tokens intact", () => {
+		const doc = makeDoc({
+			content: "{{slot:revenue}} / {{slot:unknown}}",
+			slots: [{ slotId: "revenue", status: "empty", label: "매출" }],
+		});
+
+		const out = renderDocument(doc);
+		expect(out).toContain("매출 (조회 전)");
+		expect(out).toContain("{{slot:unknown}}");
+	});
+});


### PR DESCRIPTION
## Summary

`@ainetwork/adk`에 **Document(문서) 시스템**과 **AI 문서 조언(advice)** 기능을 추가합니다. 워크플로우/쿼리 결과를 스레드에 임베드하는 대신, 편집 가능한 1급(first-class) 엔티티인 `Document`로 승격하여 스레드에서 참조하도록 했습니다. 부수적으로 MCP 커넥터별 요청 타임아웃 설정과 Express 5 쿼리 파서 설정을 함께 포함합니다.

## Motivation

- 워크플로우 결과 markdown을 스레드 메시지에 그대로 박아두면, 수동 편집이 렌더링되는 모든 곳에 반영되지 않습니다. 문서를 별도 엔티티로 분리하고 스레드는 `documentId`만 참조하게 하여, 편집이 항상 최신으로 반영되도록 했습니다.
- 로그북(운영 메모 + 매출/지표) 같은 문서에 대해, 입력된 내용을 바탕으로 운영자에게 도움이 되는 짧은 조언을 스트리밍으로 제공할 필요가 있었습니다.

## What's included

### 1. Document 시스템

- **타입** (`src/types/document.ts`): `Document`, `DocumentSlot`, `DocumentFragment`, `DocumentAdvice`, `DocumentFilter`, `DocumentFormat`, `DocumentSource` 신규 추가.
  - 버전 관리(`version`)와 수동 편집 추적(`editedManually`) 포함.
  - `labels`를 통한 스키마리스 facet 그룹핑 — 계층/중첩 순서는 쿼리·렌더 시점에 결정되어 스키마 변경 없이 임의 레벨 그룹핑 가능.
- **슬롯 채우기**: 문서 본문의 `{{slot:slotId}}` 토큰을 워크플로우/쿼리 바인딩으로 on-demand 채움. 상태 lifecycle은 `empty → running → resolved/failed`.
- **렌더링** (`src/utils/document-render.ts`): `renderDocument()`가 해결된 fragment로 토큰을 치환하고, 미해결 슬롯은 상태 placeholder로 대체. 매칭되는 슬롯이 없는 토큰은 그대로 둠.
- **메모리 인터페이스** (`src/modules/memory/base.memory.ts`): `IDocumentMemory`(`getDocument`/`createDocument`/`updateDocument`/`deleteDocument`/`listDocuments`)를 **선택적**으로 추가. 문서를 지원하지 않는 기존 메모리 구현과 하위 호환.
- **워크플로우 승격** (`src/services/workflow-execution.service.ts`): document memory가 있으면 user-workflow 실행 결과를 1급 문서로 승격하고, 스레드에서 `DocumentPart`로 참조. (없으면 기존 inline 방식 유지)
- **리치 메시지** (`src/types/memory.ts`): `MessagePart`(`TextPart` | `DocumentPart`) 도입으로 텍스트와 문서 참조 혼합 가능. 기존 text 형식과 호환.
- **API** (`/api/document`, memory가 `IDocumentMemory`를 제공할 때만 마운트):
  - `GET /api/document` — 목록 (`workflowId`/`threadId`/`source` 및 subset-match `labels[...]` 필터)
  - `GET /api/document/:id`
  - `POST /api/document` — 생성 (`source: MANUAL`)
  - `POST /api/document/:id/slots/:slotId/fill` — 슬롯 채우기 (non-streaming)
  - `POST /api/document/:id/slots/:slotId/fill/stream` — 슬롯 채우기 (SSE)
  - `POST /api/document/update/:id` — 수정 (`editedManually` 마킹)
  - `POST /api/document/delete/:id`

### 2. AI 문서 조언 (Advice)

- **서비스** (`src/services/document-advice.service.ts`): `DocumentAdviceService.generateAdviceStream`가 렌더된 문서 내용에 대해 single-turn 스트리밍 completion을 수행하고 `text_chunk` 이벤트를 SSE로 방출.
- **캐싱**: 완료 시 `document.advice`(`{ content, generatedAt }`)에 저장. **버전을 bump하지 않아** 동시 편집과의 lost-update를 회피. 에러/빈 출력 시에는 아무것도 저장하지 않음.
- **프롬프트 우선순위**: 호출별 `advicePrompt`(요청 body) → agent-memory 훅 `getDocumentAdvicePrompt()` → 내장 기본 프롬프트(한국어).
- **API**: `POST /api/document/:id/advice/stream` (body: `{ advicePrompt?: string }`)

### 3. 부가 변경

- **MCP 커넥터별 타임아웃** (`src/types/mcp.ts`, `src/modules/mcp/mcp.module.ts`): `MCPConfig.requestTimeoutMs`로 SDK 기본 60s 요청 타임아웃을 커넥터 단위로 override. `resetTimeoutOnProgress`를 켜서 progress notification을 스트리밍하는 장기 실행 툴이 타임아웃으로 중단되지 않도록 함.
- **Express 5 쿼리 파서** (`src/index.ts`): query parser를 `"extended"`로 설정해 `?labels[category]=logbook` 같은 중첩/bracket 파라미터가 `req.query`에서 객체로 파싱되도록 함 (`DocumentFilter.labels` 지원).
- **신규 스트림 이벤트** (`src/types/stream.ts`): 슬롯 채우기 스트림용 `document_id` (`{ documentId, slotId }`).
- **DI 컨테이너** (`src/container/index.ts`): `DocumentAdviceService`, `DocumentApiController` 와이어링.