### PR TITLE
support atomic update for document slot

### DIFF
--- a/src/modules/memory/base.memory.ts
+++ b/src/modules/memory/base.memory.ts
@@ -1,4 +1,4 @@
-import type { Document, DocumentFilter } from "@/types/document";
+import type { Document, DocumentFilter, DocumentSlot } from "@/types/document";
 import type {
 	Intent,
 	MessageObject,
@@ -127,6 +127,19 @@ export interface IDocumentMemory {
 	updateDocument(
 		documentId: string,
 		document: Partial<Document>,
+	): Promise<void>;
+	/**
+	 * Atomically patch a single slot of a document. Concurrent fills of
+	 * different slots must not clobber each other, so implementations MUST
+	 * target only the matched slot (e.g. Mongo's positional `$` operator)
+	 * rather than rewriting the whole `slots` array from a caller snapshot,
+	 * and MUST bump `version`/`updatedAt` in the same write. Keys whose value
+	 * is `undefined` are removed from the slot.
+	 */
+	updateDocumentSlot(
+		documentId: string,
+		slotId: string,
+		patch: Partial<DocumentSlot>,
 	): Promise<void>;
 	deleteDocument(documentId: string): Promise<void>;
 	listDocuments(userId?: string, filter?: DocumentFilter): Promise<Document[]>;

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -569,9 +569,11 @@ export class WorkflowExecutionService {
 	}
 
 	/**
-	 * Writes a partial update to a single slot and persists the document with a
-	 * bumped version. Mutates the in-memory `document.slots` so subsequent
-	 * updates in the same run build on the latest state.
+	 * Atomically patches a single slot via the memory layer. Must NOT rebuild
+	 * the whole slots array from `document` (a snapshot taken when the fill
+	 * started): concurrent fills of other slots would clobber each other's
+	 * results. `updateDocumentSlot` targets only the matched slot and bumps
+	 * `version`/`updatedAt` in the same write.
 	 */
 	private async updateSlot(
 		documentMemory: NonNullable<ReturnType<MemoryModule["getDocumentMemory"]>>,
@@ -579,17 +581,7 @@ export class WorkflowExecutionService {
 		slotId: string,
 		patch: Partial<DocumentSlot>,
 	): Promise<void> {
-		const slots = (document.slots ?? []).map((slot) =>
-			slot.slotId === slotId ? { ...slot, ...patch } : slot,
-		);
-		document.slots = slots;
-		document.version += 1;
-		document.updatedAt = new Date().toISOString();
-		await documentMemory.updateDocument(document.documentId, {
-			slots,
-			version: document.version,
-			updatedAt: document.updatedAt,
-		});
+		await documentMemory.updateDocumentSlot(document.documentId, slotId, patch);
 	}
 
 	private async *executeLegacyWorkflowStream(

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -326,12 +326,12 @@ describe("WorkflowExecutionService", () => {
 			updatedAt: "t0",
 		};
 		const createThread = jest.fn();
-		const updateDocument = jest.fn(async () => undefined);
+		const updateDocumentSlot = jest.fn(async () => undefined);
 		const memoryModule = {
 			getThreadMemory: () => ({ createThread }),
 			getDocumentMemory: () => ({
 				getDocument: jest.fn(async () => document),
-				updateDocument,
+				updateDocumentSlot,
 			}),
 		} as unknown as MemoryModule;
 		const modelModule = {} as ModelModule;
@@ -381,13 +381,14 @@ describe("WorkflowExecutionService", () => {
 			data: { documentId: "doc-1", slotId: "revenue" },
 		});
 
-		// Last slot update writes the resolved fragment into the slot.
+		// Last slot update patches the target slot with the resolved fragment.
 		const lastUpdate =
-			updateDocument.mock.calls[updateDocument.mock.calls.length - 1];
+			updateDocumentSlot.mock.calls[updateDocumentSlot.mock.calls.length - 1];
 		expect(lastUpdate[0]).toBe("doc-1");
-		const updatedSlot = (lastUpdate[1] as any).slots[0];
-		expect(updatedSlot.status).toBe("resolved");
-		expect(updatedSlot.fragment).toMatchObject({
+		expect(lastUpdate[1]).toBe("revenue");
+		const patch = lastUpdate[2] as any;
+		expect(patch.status).toBe("resolved");
+		expect(patch.fragment).toMatchObject({
 			content: "## Summary\n\n",
 			source: { type: "WORKFLOW", workflowId: "workflow-1" },
 		});
@@ -446,13 +447,13 @@ describe("WorkflowExecutionService", () => {
 			createdAt: "t0",
 			updatedAt: "t0",
 		};
-		const updateDocument = jest.fn(async () => undefined);
+		const updateDocumentSlot = jest.fn(async () => undefined);
 		const memoryModule = {
 			getThreadMemory: () => ({ createThread: jest.fn() }),
 			getWorkflowTemplateMemory: () => ({ getTemplate }),
 			getDocumentMemory: () => ({
 				getDocument: jest.fn(async () => document),
-				updateDocument,
+				updateDocumentSlot,
 			}),
 		} as unknown as MemoryModule;
 
@@ -501,10 +502,11 @@ describe("WorkflowExecutionService", () => {
 		});
 
 		const lastUpdate =
-			updateDocument.mock.calls[updateDocument.mock.calls.length - 1];
-		const updatedSlot = (lastUpdate[1] as any).slots[0];
-		expect(updatedSlot.status).toBe("resolved");
-		expect(updatedSlot.fragment).toMatchObject({
+			updateDocumentSlot.mock.calls[updateDocumentSlot.mock.calls.length - 1];
+		expect(lastUpdate[1]).toBe("revenue");
+		const patch = lastUpdate[2] as any;
+		expect(patch.status).toBe("resolved");
+		expect(patch.fragment).toMatchObject({
 			content: "## Summary\n\n",
 			source: { type: "WORKFLOW", workflowId: "template-1" },
 		});


### PR DESCRIPTION
## Summary

Make per-slot document updates atomic so concurrent fills of different slots no longer clobber each other.

Previously `WorkflowExecutionService.updateSlot` rebuilt the **entire** `slots` array from `document` — a snapshot captured when the fill started — and wrote it back via `updateDocument`. When two slots were filled concurrently, the slower write would overwrite the array with a stale snapshot, losing the other slot's result. This change routes slot updates through a new `updateDocumentSlot` memory method that targets only the matched slot and bumps `version`/`updatedAt` in the same write.

## Changes

- **`IDocumentMemory`** ([base.memory.ts](src/modules/memory/base.memory.ts)): add `updateDocumentSlot(documentId, slotId, patch)` to the interface. The contract requires implementations to patch **only** the matched slot (e.g. Mongo's positional `$` operator) rather than rewriting the whole array, and to bump `version`/`updatedAt` in the same write. Keys whose value is `undefined` are removed from the slot.
- **`WorkflowExecutionService.updateSlot`** ([workflow-execution.service.ts](src/services/workflow-execution.service.ts)): delegate to `documentMemory.updateDocumentSlot` instead of mapping over `document.slots` and calling `updateDocument` with a full snapshot.
- **Tests** ([workflow-execution.service.test.ts](tests/services/workflow-execution.service.test.ts)): updated the two slot-update assertions to mock `updateDocumentSlot` and verify it's called with `(documentId, slotId, patch)`.

## Migration note

`updateDocumentSlot` is a **new required method** on `IDocumentMemory`. Every memory provider implementation (e.g. inmemory, mongodb in `ain-adk-providers`) must implement it before consuming this version of the ADK.
