### PR TITLE
Feature/logbook advice workflow

### DIFF
--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -154,7 +154,6 @@ class Container {
 		if (!this._workflowExecutionService) {
 			this._workflowExecutionService = new WorkflowExecutionService(
 				this.getUserWorkflowService(),
-				this.getQueryService(),
 				this.getWorkflowVariableResolver(),
 				getModelModule(),
 				getMemoryModule(),

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -445,7 +445,19 @@ export class DocumentApiController {
 					id,
 					res.locals.authzChecked === true,
 				);
-				const { advicePrompt } = req.body as { advicePrompt?: string };
+				const { advicePrompt, adviceWorkflowId, executionVariables } =
+					req.body as {
+						advicePrompt?: string;
+						adviceWorkflowId?: string;
+						executionVariables?: Record<string, string>;
+					};
+				if (adviceWorkflowId) {
+					return this.workflowExecutionService.generateDocumentAdviceStream(
+						id,
+						{ workflowId: adviceWorkflowId, executionVariables },
+						signal,
+					);
+				}
 				return this.documentAdviceService.generateAdviceStream(
 					id,
 					{ advicePrompt },

--- a/src/controllers/api/user-workflow.api.controller.ts
+++ b/src/controllers/api/user-workflow.api.controller.ts
@@ -74,6 +74,12 @@ export class UserWorkflowApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const workflowData = req.body as UserWorkflow;
+			if (!workflowData.definition) {
+				throw new AinHttpError(
+					StatusCodes.BAD_REQUEST,
+					"definition is required",
+				);
+			}
 			const created = await this.userWorkflowCoordinatorService.createWorkflow({
 				...workflowData,
 				userId,

--- a/src/controllers/api/workflow-template.api.controller.ts
+++ b/src/controllers/api/workflow-template.api.controller.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
+import { validateWorkflowDefinition } from "@/services/workflow-variable-resolver.service.js";
 import { AinHttpError } from "@/types/agent.js";
 import type { WorkflowTemplate } from "@/types/memory";
 
@@ -58,6 +59,7 @@ export class WorkflowTemplateApiController {
 					"definition is required",
 				);
 			}
+			validateWorkflowDefinition(template.definition);
 			const templateMemory = this.memoryModule.getWorkflowTemplateMemory();
 			const created = await templateMemory.createTemplate(template);
 			res.status(StatusCodes.CREATED).json(created);
@@ -74,6 +76,15 @@ export class WorkflowTemplateApiController {
 		try {
 			const { id } = req.params as { id: string };
 			const template = req.body as Partial<WorkflowTemplate>;
+			if (Object.hasOwn(template, "definition")) {
+				if (!template.definition) {
+					throw new AinHttpError(
+						StatusCodes.BAD_REQUEST,
+						"definition is required",
+					);
+				}
+				validateWorkflowDefinition(template.definition);
+			}
 			const templateMemory = this.memoryModule.getWorkflowTemplateMemory();
 			await templateMemory.updateTemplate(id, template);
 			res.status(StatusCodes.OK).send();

--- a/src/controllers/api/workflow-template.api.controller.ts
+++ b/src/controllers/api/workflow-template.api.controller.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
+import { AinHttpError } from "@/types/agent.js";
 import type { WorkflowTemplate } from "@/types/memory";
 
 export class WorkflowTemplateApiController {
@@ -51,6 +52,12 @@ export class WorkflowTemplateApiController {
 	) => {
 		try {
 			const template = req.body as WorkflowTemplate;
+			if (!template.definition) {
+				throw new AinHttpError(
+					StatusCodes.BAD_REQUEST,
+					"definition is required",
+				);
+			}
 			const templateMemory = this.memoryModule.getWorkflowTemplateMemory();
 			const created = await templateMemory.createTemplate(template);
 			res.status(StatusCodes.CREATED).json(created);

--- a/src/controllers/api/workflow-template.api.controller.ts
+++ b/src/controllers/api/workflow-template.api.controller.ts
@@ -11,14 +11,15 @@ export class WorkflowTemplateApiController {
 	}
 
 	public handleGetAllTemplates = async (
-		_req: Request,
+		req: Request,
 		res: Response,
 		next: NextFunction,
 	) => {
 		try {
+			const includeHidden = req.query.includeHidden === "true";
 			const templateMemory = this.memoryModule.getWorkflowTemplateMemory();
 			const templates = await templateMemory.listTemplates();
-			res.json(templates);
+			res.json(includeHidden ? templates : templates.filter((t) => !t.hidden));
 		} catch (error) {
 			next(error);
 		}

--- a/src/services/document-advice.service.ts
+++ b/src/services/document-advice.service.ts
@@ -33,9 +33,16 @@ export class DocumentAdviceService {
 		}
 
 		const renderedContent = renderDocument(document);
+		const customPrompt = options?.advicePrompt?.trim();
 		const systemPrompt =
-			options?.advicePrompt?.trim() ||
-			(await documentAdvicePrompt(this.memoryModule));
+			customPrompt || (await documentAdvicePrompt(this.memoryModule));
+
+		const startedAt = Date.now();
+		loggers.agent.info("Generating document advice (single inference)", {
+			documentId,
+			promptSource: customPrompt ? "template" : "default",
+			contentLength: renderedContent.length,
+		});
 
 		const model = this.modelModule.getModel();
 		const modelOptions = this.modelModule.getModelOptions();
@@ -61,6 +68,10 @@ export class DocumentAdviceService {
 		}
 
 		if (!content.trim()) {
+			loggers.agent.warn("Document advice generation produced no content", {
+				documentId,
+				durationMs: Date.now() - startedAt,
+			});
 			return;
 		}
 
@@ -76,5 +87,11 @@ export class DocumentAdviceService {
 				error: saveError,
 			});
 		}
+
+		loggers.agent.info("Document advice generated", {
+			documentId,
+			adviceLength: content.length,
+			durationMs: Date.now() - startedAt,
+		});
 	}
 }

--- a/src/services/user-workflow.service.ts
+++ b/src/services/user-workflow.service.ts
@@ -32,6 +32,11 @@ export class UserWorkflowService {
 		};
 		const { content, title, definition } =
 			this.workflowVariableResolver.resolveForCreation(normalizedWorkflow);
+		if (!definition) {
+			throw new Error(
+				"Workflow definition is required: structured definition missing or invalid",
+			);
+		}
 
 		const newWorkflow: UserWorkflow = {
 			...normalizedWorkflow,

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -24,7 +24,6 @@ import {
 	appendRichMessageToThread,
 	appendTextMessageToThread,
 } from "@/utils/thread-messages.js";
-import type { QueryService } from "./query.service.js";
 import type { ToolCallingService } from "./tool-calling.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
 import { WorkflowResponseComposer } from "./workflow-response-composer.service.js";
@@ -39,7 +38,6 @@ type WorkflowExecutionResult = {
 
 export class WorkflowExecutionService {
 	private userWorkflowService: UserWorkflowService;
-	private queryService: QueryService;
 	private workflowVariableResolver: WorkflowVariableResolver;
 	private memoryModule: MemoryModule;
 	private workflowTaskRunner: WorkflowTaskRunner;
@@ -47,7 +45,6 @@ export class WorkflowExecutionService {
 
 	constructor(
 		userWorkflowService: UserWorkflowService,
-		queryService: QueryService,
 		workflowVariableResolver: WorkflowVariableResolver,
 		modelModule: ModelModule,
 		memoryModule: MemoryModule,
@@ -55,7 +52,6 @@ export class WorkflowExecutionService {
 		a2aModule?: A2AModule,
 	) {
 		this.userWorkflowService = userWorkflowService;
-		this.queryService = queryService;
 		this.workflowVariableResolver = workflowVariableResolver;
 		this.memoryModule = memoryModule;
 		this.workflowTaskRunner = new WorkflowTaskRunner(
@@ -110,8 +106,9 @@ export class WorkflowExecutionService {
 			);
 
 		if (!definition) {
-			yield* this.executeLegacyWorkflowStream(workflow, query, displayQuery);
-			return;
+			throw new Error(
+				`Workflow ${workflowId} has no valid structured definition; legacy content execution is no longer supported`,
+			);
 		}
 
 		loggers.agent.info(
@@ -582,41 +579,6 @@ export class WorkflowExecutionService {
 		patch: Partial<DocumentSlot>,
 	): Promise<void> {
 		await documentMemory.updateDocumentSlot(document.documentId, slotId, patch);
-	}
-
-	private async *executeLegacyWorkflowStream(
-		workflow: UserWorkflow,
-		query: string,
-		displayQuery: string,
-	): AsyncGenerator<StreamEvent> {
-		loggers.agent.info(`Executing legacy user workflow: ${workflow.title}`, {
-			workflowId: workflow.workflowId,
-			resolvedQuery: query,
-		});
-
-		let threadId: string | undefined;
-		const stream = this.queryService.handleQuery(
-			{
-				type: ThreadType.WORKFLOW,
-				userId: workflow.userId,
-				workflowId: workflow.workflowId,
-				title: workflow.title,
-			},
-			{ query, displayQuery },
-		);
-
-		for await (const event of stream) {
-			if (event.event === "thread_id") {
-				threadId = event.data.threadId;
-			}
-			yield event;
-		}
-
-		await this.userWorkflowService.updateWorkflow(workflow.workflowId, {
-			userId: workflow.userId,
-			lastRunAt: Date.now(),
-			lastThreadId: threadId,
-		});
 	}
 
 	/**

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -19,11 +19,13 @@ import {
 	type WorkflowTemplate,
 } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
+import { renderDocument } from "@/utils/document-render.js";
 import { loggers } from "@/utils/logger.js";
 import {
 	appendRichMessageToThread,
 	appendTextMessageToThread,
 } from "@/utils/thread-messages.js";
+import { injectDocumentContext } from "@/utils/workflow-document-context.js";
 import type { ToolCallingService } from "./tool-calling.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
 import { WorkflowResponseComposer } from "./workflow-response-composer.service.js";
@@ -423,6 +425,95 @@ export class WorkflowExecutionService {
 		}
 
 		return { finalContent, renderedBlocks, executionError };
+	}
+
+	/**
+	 * Generates AI advice for a document by running the bound advice workflow
+	 * over the document's rendered content, then caches the result on
+	 * `document.advice`. Mirrors {@link fillDocumentSlotStream}: ephemeral
+	 * non-persisted thread — the advice field is the only artifact.
+	 */
+	async *generateDocumentAdviceStream(
+		documentId: string,
+		options: {
+			workflowId: string;
+			executionVariables?: Record<string, string>;
+		},
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+		const documentMemory = this.memoryModule.getDocumentMemory();
+		if (!documentMemory) {
+			throw new Error("Document memory is not initialized");
+		}
+		const document = await documentMemory.getDocument(documentId);
+		if (!document) {
+			throw new Error(`Document not found: ${documentId}`);
+		}
+
+		const workflow = await this.getFillableWorkflow(options.workflowId);
+		if (!workflow) {
+			throw new Error(
+				`User workflow or template not found: ${options.workflowId}`,
+			);
+		}
+
+		const { definition } = this.workflowVariableResolver.resolveForDocumentFill(
+			workflow,
+			options.executionVariables,
+		);
+		if (!definition) {
+			throw new Error(
+				`Workflow ${options.workflowId} has no valid structured definition; cannot generate advice`,
+			);
+		}
+
+		const renderedContent = renderDocument(document);
+		const definitionWithDocument = injectDocumentContext(
+			definition,
+			renderedContent,
+		);
+
+		// Ephemeral, non-persisted thread: carries threadId for A2A correlation
+		// and task context, but is never written to the thread store.
+		const thread: ThreadObject = {
+			type: ThreadType.WORKFLOW,
+			userId: document.userId,
+			threadId: randomUUID(),
+			title: workflow.title,
+			workflowId: options.workflowId,
+			messages: [],
+		};
+
+		const { finalContent, executionError } =
+			yield* this.renderStructuredDefinition(
+				definitionWithDocument,
+				thread,
+				options.workflowId,
+				signal,
+			);
+
+		if (executionError) {
+			throw executionError;
+		}
+		if (!finalContent.trim()) {
+			return;
+		}
+
+		try {
+			// Persist only the advice (metadata); do NOT bump version off a
+			// pre-stream read, which could clobber a concurrent edit (lost update).
+			await documentMemory.updateDocument(documentId, {
+				advice: {
+					content: finalContent,
+					generatedAt: new Date().toISOString(),
+				},
+			});
+		} catch (saveError) {
+			loggers.agent.error("Failed to cache document advice", {
+				documentId,
+				error: saveError,
+			});
+		}
 	}
 
 	/**

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -473,6 +473,15 @@ export class WorkflowExecutionService {
 			renderedContent,
 		);
 
+		const startedAt = Date.now();
+		loggers.agent.info("Generating document advice via workflow", {
+			documentId,
+			workflowId: options.workflowId,
+			workflowTitle: workflow.title,
+			taskCount: definition.tasks.length,
+			contentLength: renderedContent.length,
+		});
+
 		// Ephemeral, non-persisted thread: carries threadId for A2A correlation
 		// and task context, but is never written to the thread store.
 		const thread: ThreadObject = {
@@ -493,9 +502,22 @@ export class WorkflowExecutionService {
 			);
 
 		if (executionError) {
+			// renderStructuredDefinition already logged the task-level failure;
+			// this ties it to the advice request before the SSE layer reports it.
+			loggers.agent.error("Document advice workflow failed", {
+				documentId,
+				workflowId: options.workflowId,
+				durationMs: Date.now() - startedAt,
+				error: executionError.message,
+			});
 			throw executionError;
 		}
 		if (!finalContent.trim()) {
+			loggers.agent.warn("Document advice workflow produced no content", {
+				documentId,
+				workflowId: options.workflowId,
+				durationMs: Date.now() - startedAt,
+			});
 			return;
 		}
 
@@ -514,6 +536,13 @@ export class WorkflowExecutionService {
 				error: saveError,
 			});
 		}
+
+		loggers.agent.info("Document advice generated via workflow", {
+			documentId,
+			workflowId: options.workflowId,
+			adviceLength: finalContent.length,
+			durationMs: Date.now() - startedAt,
+		});
 	}
 
 	/**

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -315,7 +315,7 @@ function resolveWorkflowVariables(
 	return applyReplacements(input, replacements, resolveAt);
 }
 
-function validateWorkflowDefinition(
+export function validateWorkflowDefinition(
 	definition?: WorkflowDefinition,
 ): WorkflowDefinition | undefined {
 	if (!definition) {
@@ -327,6 +327,29 @@ function validateWorkflowDefinition(
 			StatusCodes.BAD_REQUEST,
 			"Workflow definition.tasks must be an array.",
 		);
+	}
+
+	for (const [index, task] of definition.tasks.entries()) {
+		if (typeof task.taskId !== "string" || !task.taskId.trim()) {
+			throw new AinHttpError(
+				StatusCodes.BAD_REQUEST,
+				`Workflow task at index ${index} must use a non-empty taskId string.`,
+			);
+		}
+
+		if (typeof task.title !== "string" || !task.title.trim()) {
+			throw new AinHttpError(
+				StatusCodes.BAD_REQUEST,
+				`Task "${task.taskId}" must use a non-empty title string.`,
+			);
+		}
+
+		if (typeof task.prompt !== "string" || !task.prompt.trim()) {
+			throw new AinHttpError(
+				StatusCodes.BAD_REQUEST,
+				`Task "${task.taskId}" must use a non-empty prompt string.`,
+			);
+		}
 	}
 
 	if (!Array.isArray(definition.response?.blocks)) {

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -639,7 +639,7 @@ export class WorkflowVariableResolver {
 		definition?: WorkflowDefinition;
 	} {
 		let { content, title } = workflow;
-		let { definition } = workflow;
+		let definition: WorkflowDefinition | undefined = workflow.definition;
 		const normalizedVariables = normalizeWorkflowVariablesRecord(
 			workflow.variables,
 		);
@@ -724,7 +724,7 @@ export class WorkflowVariableResolver {
 		const { timezone } = workflow;
 		let query = workflow.content;
 		let displayQuery = workflow.title;
-		let definition = workflow.definition;
+		let definition: WorkflowDefinition | undefined = workflow.definition;
 		const normalizedVariables = normalizeWorkflowVariablesRecord(
 			workflow.variables,
 		);

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -717,6 +717,10 @@ export class WorkflowVariableResolver {
 	 * regardless of each variable's declared `resolveAt`, then built-in template
 	 * tokens (e.g. `{{today}}`) are resolved. This does NOT change how standalone
 	 * workflow execution resolves variables.
+	 *
+	 * Empty/whitespace-only values mean "not entered" (slot bindings persist
+	 * such keys for display) and are dropped here so they don't override the
+	 * workflow's own `variableValues` defaults with blanks.
 	 */
 	resolveForDocumentFill(
 		workflow: WorkflowTextFields,
@@ -726,7 +730,14 @@ export class WorkflowVariableResolver {
 		displayQuery: string;
 		definition?: WorkflowDefinition;
 	} {
-		return this.resolveExecutionLike(workflow, providedVariables, true);
+		const nonEmptyVariables = providedVariables
+			? Object.fromEntries(
+					Object.entries(providedVariables).filter(
+						([, value]) => value.trim() !== "",
+					),
+				)
+			: undefined;
+		return this.resolveExecutionLike(workflow, nonEmptyVariables, true);
 	}
 
 	/**

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -426,6 +426,11 @@ export interface WorkflowTemplate {
 	definition?: WorkflowDefinition;
 	/** Variable schema definitions (type, label, options) for UI rendering */
 	variables?: Record<string, WorkflowVariable>;
+	/**
+	 * Hidden templates are excluded from list responses by default
+	 * (e.g. document-advice-only workflows). Fetch-by-id is unaffected.
+	 */
+	hidden?: boolean;
 }
 
 /**

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -422,8 +422,8 @@ export interface WorkflowTemplate {
 	category?: string;
 	/** The prompt/instruction template with {{variable}} placeholders */
 	content: string;
-	/** Structured workflow definition. If omitted, legacy content execution is used. */
-	definition?: WorkflowDefinition;
+	/** Structured workflow definition (tasks → response blocks). Required. */
+	definition: WorkflowDefinition;
 	/** Variable schema definitions (type, label, options) for UI rendering */
 	variables?: Record<string, WorkflowVariable>;
 	/**
@@ -455,8 +455,8 @@ export interface UserWorkflow {
 	templateId?: string;
 	/** The prompt/instruction content with {{variable}} placeholders */
 	content: string;
-	/** Structured workflow definition. If omitted, legacy content execution is used. */
-	definition?: WorkflowDefinition;
+	/** Structured workflow definition (tasks → response blocks). Required. */
+	definition: WorkflowDefinition;
 	/** Variable schema definitions (copied from template, used for UI rendering) */
 	variables?: Record<string, WorkflowVariable>;
 	/** User-provided variable values (can contain template variables like {{today}}) */

--- a/src/utils/sse-stream.ts
+++ b/src/utils/sse-stream.ts
@@ -78,6 +78,15 @@ export async function streamEventsToSSE(
 		// can distinguish e.g. 403 (no permission) from a generic failure — the
 		// SSE headers are already sent, so it can't come back as a real status.
 		const status = (error as { status?: number })?.status;
+		// The error only reaches the client as an SSE event; without this log a
+		// failed stream leaves no server-side trace at all.
+		loggers.intentStream.error(`${options.logLabel} failed`, {
+			userId: options.userId,
+			threadId: currentThreadId,
+			status,
+			error: errMsg,
+			...options.logContext,
+		});
 		res.write(
 			`event: error\ndata: ${JSON.stringify({ message: errMsg, status })}\n\n`,
 		);

--- a/src/utils/workflow-document-context.ts
+++ b/src/utils/workflow-document-context.ts
@@ -1,0 +1,39 @@
+import type { WorkflowDefinition } from "@/types/memory.js";
+
+export const DOCUMENT_CONTEXT_TOKEN = "{{document}}";
+
+/**
+ * Injects a document's rendered content into a workflow definition.
+ *
+ * Task prompts referencing {{document}} get it substituted; if no task
+ * references the token, the content is appended to the FIRST task's prompt
+ * so the document context is always present regardless of how the workflow
+ * was authored. Returns a new definition (input is not mutated).
+ */
+export function injectDocumentContext(
+	definition: WorkflowDefinition,
+	renderedContent: string,
+): WorkflowDefinition {
+	const hasToken = definition.tasks.some((task) =>
+		task.prompt.includes(DOCUMENT_CONTEXT_TOKEN),
+	);
+	const tasks = definition.tasks.map((task, index) => {
+		if (hasToken) {
+			if (!task.prompt.includes(DOCUMENT_CONTEXT_TOKEN)) {
+				return task;
+			}
+			return {
+				...task,
+				prompt: task.prompt.replaceAll(DOCUMENT_CONTEXT_TOKEN, renderedContent),
+			};
+		}
+		if (index === 0) {
+			return {
+				...task,
+				prompt: `${task.prompt}\n\n[문서 내용]\n${renderedContent}`,
+			};
+		}
+		return task;
+	});
+	return { ...definition, tasks };
+}

--- a/tests/controllers/document-advice-routing.test.ts
+++ b/tests/controllers/document-advice-routing.test.ts
@@ -1,0 +1,75 @@
+import { DocumentApiController } from "@/controllers/api/document.api.controller";
+import type { MemoryModule } from "@/modules";
+import type { DocumentAdviceService } from "@/services/document-advice.service";
+import type { SchedulerService } from "@/services/scheduler.service";
+import type { WorkflowExecutionService } from "@/services/workflow-execution.service";
+import { streamEventsToSSE } from "@/utils/sse-stream";
+
+jest.mock("@/utils/sse-stream", () => ({
+	streamEventsToSSE: jest.fn(async () => {}),
+}));
+
+function build() {
+	const memoryModule = {
+		getDocumentMemory: () => ({
+			getDocument: jest.fn(async () => ({ documentId: "d1", userId: "u1" })),
+		}),
+	} as unknown as MemoryModule;
+	const workflowExecutionService = {
+		generateDocumentAdviceStream: jest.fn(),
+	} as unknown as WorkflowExecutionService;
+	const documentAdviceService = {
+		generateAdviceStream: jest.fn(),
+	} as unknown as DocumentAdviceService;
+	const controller = new DocumentApiController(
+		memoryModule,
+		workflowExecutionService,
+		documentAdviceService,
+		{} as unknown as SchedulerService,
+	);
+	return { controller, workflowExecutionService, documentAdviceService };
+}
+
+async function invoke(controller: DocumentApiController, body: object) {
+	const req = { params: { id: "d1" }, body } as never;
+	const res = { locals: { userId: "u1" } } as never;
+	await controller.handleGenerateAdviceStream(req, res);
+	// setup 콜백을 직접 실행해 분기를 검증
+	const options = (streamEventsToSSE as jest.Mock).mock.calls.at(-1)?.[2];
+	await options.setup(new AbortController().signal);
+}
+
+describe("handleGenerateAdviceStream routing", () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it("routes to workflow execution when adviceWorkflowId is present", async () => {
+		const { controller, workflowExecutionService, documentAdviceService } =
+			build();
+		await invoke(controller, {
+			adviceWorkflowId: "wf-1",
+			executionVariables: { period: "2026-07" },
+		});
+		expect(
+			workflowExecutionService.generateDocumentAdviceStream,
+		).toHaveBeenCalledWith(
+			"d1",
+			{ workflowId: "wf-1", executionVariables: { period: "2026-07" } },
+			expect.anything(),
+		);
+		expect(documentAdviceService.generateAdviceStream).not.toHaveBeenCalled();
+	});
+
+	it("falls back to single-inference advice when adviceWorkflowId is absent", async () => {
+		const { controller, workflowExecutionService, documentAdviceService } =
+			build();
+		await invoke(controller, { advicePrompt: "프롬프트" });
+		expect(documentAdviceService.generateAdviceStream).toHaveBeenCalledWith(
+			"d1",
+			{ advicePrompt: "프롬프트" },
+			expect.anything(),
+		);
+		expect(
+			workflowExecutionService.generateDocumentAdviceStream,
+		).not.toHaveBeenCalled();
+	});
+});

--- a/tests/controllers/workflow-template.api.controller.test.ts
+++ b/tests/controllers/workflow-template.api.controller.test.ts
@@ -1,6 +1,6 @@
 import { WorkflowTemplateApiController } from "@/controllers/api/workflow-template.api.controller";
 import type { MemoryModule } from "@/modules";
-import type { WorkflowTemplate } from "@/types/memory";
+import type { WorkflowDefinition, WorkflowTemplate } from "@/types/memory";
 
 function buildController(templates: WorkflowTemplate[]) {
 	const memoryModule = {
@@ -10,6 +10,26 @@ function buildController(templates: WorkflowTemplate[]) {
 	} as unknown as MemoryModule;
 	return new WorkflowTemplateApiController(memoryModule);
 }
+
+function buildControllerWithTemplateMemory(templateMemory: {
+	createTemplate?: jest.Mock;
+	updateTemplate?: jest.Mock;
+}) {
+	const memoryModule = {
+		getWorkflowTemplateMemory: () => templateMemory,
+	} as unknown as MemoryModule;
+	return new WorkflowTemplateApiController(memoryModule);
+}
+
+const validDefinition: WorkflowDefinition = {
+	tasks: [{ taskId: "fetch", title: "조회", prompt: "데이터를 조회한다." }],
+	response: { blocks: [] },
+};
+
+const invalidDefinition = {
+	tasks: "not-an-array",
+	response: { blocks: [] },
+} as unknown as WorkflowDefinition;
 
 const visible = { templateId: "t1", title: "매출 분석" } as WorkflowTemplate;
 const hiddenTemplate = {
@@ -56,5 +76,105 @@ describe("handleCreateTemplate", () => {
 		expect(next).toHaveBeenCalledWith(
 			expect.objectContaining({ status: 400 }),
 		);
+	});
+
+	it("rejects template creation with a structurally invalid definition", async () => {
+		const createTemplate = jest.fn();
+		const controller = buildControllerWithTemplateMemory({ createTemplate });
+		const status = jest.fn().mockReturnThis();
+		const next = jest.fn();
+		await controller.handleCreateTemplate(
+			{
+				body: {
+					templateId: "t1",
+					title: "제목",
+					content: "c",
+					definition: invalidDefinition,
+				},
+			} as never,
+			{ status, json: jest.fn(), send: jest.fn() } as never,
+			next,
+		);
+		expect(next).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 400 }),
+		);
+		expect(createTemplate).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleUpdateTemplate", () => {
+	it("rejects update with definition: null", async () => {
+		const updateTemplate = jest.fn();
+		const controller = buildControllerWithTemplateMemory({ updateTemplate });
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const next = jest.fn();
+		await controller.handleUpdateTemplate(
+			{ params: { id: "t1" }, body: { definition: null } } as never,
+			{ status } as never,
+			next,
+		);
+		expect(next).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 400 }),
+		);
+		expect(updateTemplate).not.toHaveBeenCalled();
+	});
+
+	it("rejects update with a structurally invalid definition", async () => {
+		const updateTemplate = jest.fn();
+		const controller = buildControllerWithTemplateMemory({ updateTemplate });
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const next = jest.fn();
+		await controller.handleUpdateTemplate(
+			{
+				params: { id: "t1" },
+				body: { definition: invalidDefinition },
+			} as never,
+			{ status } as never,
+			next,
+		);
+		expect(next).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 400 }),
+		);
+		expect(updateTemplate).not.toHaveBeenCalled();
+	});
+
+	it("passes through updates without a definition key untouched", async () => {
+		const updateTemplate = jest.fn(async () => undefined);
+		const controller = buildControllerWithTemplateMemory({ updateTemplate });
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const next = jest.fn();
+		await controller.handleUpdateTemplate(
+			{ params: { id: "t1" }, body: { title: "새 제목" } } as never,
+			{ status } as never,
+			next,
+		);
+		expect(next).not.toHaveBeenCalled();
+		expect(updateTemplate).toHaveBeenCalledWith("t1", { title: "새 제목" });
+		expect(status).toHaveBeenCalledWith(200);
+		expect(send).toHaveBeenCalled();
+	});
+
+	it("accepts updates with a valid definition", async () => {
+		const updateTemplate = jest.fn(async () => undefined);
+		const controller = buildControllerWithTemplateMemory({ updateTemplate });
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const next = jest.fn();
+		await controller.handleUpdateTemplate(
+			{
+				params: { id: "t1" },
+				body: { definition: validDefinition },
+			} as never,
+			{ status } as never,
+			next,
+		);
+		expect(next).not.toHaveBeenCalled();
+		expect(updateTemplate).toHaveBeenCalledWith("t1", {
+			definition: validDefinition,
+		});
+		expect(status).toHaveBeenCalledWith(200);
 	});
 });

--- a/tests/controllers/workflow-template.api.controller.test.ts
+++ b/tests/controllers/workflow-template.api.controller.test.ts
@@ -1,0 +1,43 @@
+import { WorkflowTemplateApiController } from "@/controllers/api/workflow-template.api.controller";
+import type { MemoryModule } from "@/modules";
+import type { WorkflowTemplate } from "@/types/memory";
+
+function buildController(templates: WorkflowTemplate[]) {
+	const memoryModule = {
+		getWorkflowTemplateMemory: () => ({
+			listTemplates: jest.fn(async () => templates),
+		}),
+	} as unknown as MemoryModule;
+	return new WorkflowTemplateApiController(memoryModule);
+}
+
+const visible = { templateId: "t1", title: "매출 분석" } as WorkflowTemplate;
+const hiddenTemplate = {
+	templateId: "t2",
+	title: "advice 전용",
+	hidden: true,
+} as WorkflowTemplate;
+
+describe("handleGetAllTemplates", () => {
+	it("excludes hidden templates by default", async () => {
+		const controller = buildController([visible, hiddenTemplate]);
+		const json = jest.fn();
+		await controller.handleGetAllTemplates(
+			{ query: {} } as never,
+			{ json } as never,
+			jest.fn(),
+		);
+		expect(json).toHaveBeenCalledWith([visible]);
+	});
+
+	it("includes hidden templates when includeHidden=true", async () => {
+		const controller = buildController([visible, hiddenTemplate]);
+		const json = jest.fn();
+		await controller.handleGetAllTemplates(
+			{ query: { includeHidden: "true" } } as never,
+			{ json } as never,
+			jest.fn(),
+		);
+		expect(json).toHaveBeenCalledWith([visible, hiddenTemplate]);
+	});
+});

--- a/tests/controllers/workflow-template.api.controller.test.ts
+++ b/tests/controllers/workflow-template.api.controller.test.ts
@@ -41,3 +41,20 @@ describe("handleGetAllTemplates", () => {
 		expect(json).toHaveBeenCalledWith([visible, hiddenTemplate]);
 	});
 });
+
+describe("handleCreateTemplate", () => {
+	it("rejects template creation without definition", async () => {
+		const controller = buildController([]);
+		const status = jest.fn().mockReturnThis();
+		const next = jest.fn();
+		await controller.handleCreateTemplate(
+			{ body: { templateId: "t1", title: "제목", content: "c" } } as never,
+			{ status, json: jest.fn(), send: jest.fn() } as never,
+			next,
+		);
+		// AinHttpError는 `status` 프로퍼티를 쓴다 (src/types/agent.ts:43-49)
+		expect(next).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 400 }),
+		);
+	});
+});

--- a/tests/services/scheduler.service.test.ts
+++ b/tests/services/scheduler.service.test.ts
@@ -1,7 +1,16 @@
 import { JobRunnerService } from "@/services/job-runner.service";
 import { SchedulerService } from "@/services/scheduler.service";
-import type { UserWorkflow } from "@/types/memory";
+import type { UserWorkflow, WorkflowDefinition } from "@/types/memory";
 import { loggers } from "@/utils/logger";
+
+const minimalDefinition: WorkflowDefinition = {
+	tasks: [{ taskId: "t1", title: "분석", prompt: "분석해줘" }],
+	response: {
+		blocks: [
+			{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t1"] },
+		],
+	},
+};
 
 function makeWorkflow(overrides: Partial<UserWorkflow> = {}): UserWorkflow {
 	return {
@@ -10,6 +19,7 @@ function makeWorkflow(overrides: Partial<UserWorkflow> = {}): UserWorkflow {
 		title: "테스트 워크플로우",
 		active: true,
 		content: "",
+		definition: minimalDefinition,
 		schedule: "0 9 * * *",
 		...overrides,
 	};

--- a/tests/services/user-workflow-coordinator.service.test.ts
+++ b/tests/services/user-workflow-coordinator.service.test.ts
@@ -1,4 +1,14 @@
 import { UserWorkflowCoordinatorService } from "@/services/user-workflow-coordinator.service";
+import type { WorkflowDefinition } from "@/types/memory";
+
+const minimalDefinition: WorkflowDefinition = {
+	tasks: [{ taskId: "t1", title: "분석", prompt: "분석해줘" }],
+	response: {
+		blocks: [
+			{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t1"] },
+		],
+	},
+};
 
 describe("UserWorkflowCoordinatorService cron validation", () => {
 	const userWorkflowService = {
@@ -27,6 +37,7 @@ describe("UserWorkflowCoordinatorService cron validation", () => {
 				title: "t",
 				active: true,
 				content: "",
+				definition: minimalDefinition,
 				schedule: "not a cron",
 			}),
 		).rejects.toThrow(/Invalid cron/);

--- a/tests/services/user-workflow.service.test.ts
+++ b/tests/services/user-workflow.service.test.ts
@@ -1,8 +1,21 @@
 import type { MemoryModule } from "@/modules";
 import type { IUserWorkflowMemory } from "@/modules/memory/base.memory";
-import type { UserWorkflow, WorkflowVariable } from "@/types/memory";
+import type {
+	UserWorkflow,
+	WorkflowDefinition,
+	WorkflowVariable,
+} from "@/types/memory";
 import { UserWorkflowService } from "@/services/user-workflow.service";
 import type { WorkflowVariableResolver } from "@/services/workflow-variable-resolver.service";
+
+const minimalDefinition: WorkflowDefinition = {
+	tasks: [{ taskId: "t1", title: "분석", prompt: "분석해줘" }],
+	response: {
+		blocks: [
+			{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t1"] },
+		],
+	},
+};
 
 describe("UserWorkflowService", () => {
 	it("defaults content to title when content is missing", async () => {
@@ -35,6 +48,7 @@ describe("UserWorkflowService", () => {
 			title: "일일 매출 분석",
 			content: "" as unknown as string,
 			active: true,
+			definition: minimalDefinition,
 		});
 
 		expect(workflowVariableResolver.resolveForCreation).toHaveBeenCalledWith(
@@ -96,6 +110,7 @@ describe("UserWorkflowService", () => {
 			title: "업장 리포트",
 			content: "업장 리포트",
 			active: true,
+			definition: minimalDefinition,
 			variables: {
 				store: {
 					id: "store",
@@ -123,5 +138,31 @@ describe("UserWorkflowService", () => {
 				},
 			}),
 		);
+	});
+
+	it("rejects creation when resolver returns no valid definition", async () => {
+		const memoryModule = {
+			getUserWorkflowMemory: () => ({ createUserWorkflow: jest.fn() }),
+		} as unknown as MemoryModule;
+		const resolver = {
+			normalizeVariables: jest.fn((v) => v),
+			resolveForCreation: jest.fn(() => ({
+				content: "c",
+				title: "t",
+				definition: undefined, // validateWorkflowDefinition이 거부한 경우
+			})),
+		} as unknown as WorkflowVariableResolver;
+		const service = new UserWorkflowService(memoryModule, resolver);
+
+		await expect(
+			service.createWorkflow({
+				workflowId: "",
+				userId: "u1",
+				title: "t",
+				content: "c",
+				active: true,
+				definition: { tasks: [], response: { blocks: [] } },
+			}),
+		).rejects.toThrow(/definition/i);
 	});
 });

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -3,8 +3,24 @@ import { WorkflowExecutionService } from "@/services/workflow-execution.service"
 import type { ToolCallingService } from "@/services/tool-calling.service";
 import type { UserWorkflowService } from "@/services/user-workflow.service";
 import type { WorkflowVariableResolver } from "@/services/workflow-variable-resolver.service";
-import { ThreadType, type WorkflowTaskResult } from "@/types/memory";
+import { type Document, DocumentFormat } from "@/types/document";
+import {
+	ThreadType,
+	type WorkflowDefinition,
+	type WorkflowRenderedBlock,
+	type WorkflowTaskResult,
+	type WorkflowTemplate,
+} from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
+
+const minimalDefinition: WorkflowDefinition = {
+	tasks: [{ taskId: "t1", title: "분석", prompt: "분석해줘" }],
+	response: {
+		blocks: [
+			{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t1"] },
+		],
+	},
+};
 
 async function collectEvents<T>(
 	stream: AsyncGenerator<T, unknown, unknown>,
@@ -532,5 +548,178 @@ describe("WorkflowExecutionService", () => {
 		await expect(stream.next()).rejects.toThrow(
 			/no valid structured definition/,
 		);
+	});
+});
+
+function buildAdviceService(overrides: {
+	document?: Partial<Document> | null;
+	template?: Partial<WorkflowTemplate> | null;
+	renderResult?: {
+		finalContent: string;
+		renderedBlocks: WorkflowRenderedBlock[];
+		executionError?: Error;
+	};
+	renderEvents?: StreamEvent[];
+}) {
+	const updateDocument = jest.fn(async () => {});
+	const document =
+		overrides.document === null
+			? undefined
+			: {
+					documentId: "d1",
+					userId: "u1",
+					title: "6월 로그북",
+					format: DocumentFormat.MARKDOWN,
+					content: "## 매출\n오늘 매출 100만원",
+					version: 1,
+					createdAt: "2026-07-01T00:00:00.000Z",
+					updatedAt: "2026-07-01T00:00:00.000Z",
+					...overrides.document,
+				};
+	const template =
+		overrides.template === null
+			? undefined
+			: {
+					templateId: "wf-advice",
+					title: "advice workflow",
+					description: "",
+					active: true,
+					content: "advice",
+					definition: minimalDefinition,
+					...overrides.template,
+				};
+	const memoryModule = {
+		getDocumentMemory: () => ({
+			getDocument: jest.fn(async () => document),
+			updateDocument,
+		}),
+		getWorkflowTemplateMemory: () => ({
+			getTemplate: jest.fn(async () => template),
+		}),
+	} as unknown as MemoryModule;
+	const userWorkflowService = {
+		getWorkflow: jest.fn(async () => undefined), // 템플릿 폴백 경로 사용
+	} as unknown as UserWorkflowService;
+	const resolver = {
+		resolveForDocumentFill: jest.fn(() => ({
+			query: "q",
+			displayQuery: "dq",
+			definition: template?.definition,
+		})),
+	} as unknown as WorkflowVariableResolver;
+	const service = new WorkflowExecutionService(
+		userWorkflowService,
+		resolver,
+		{} as unknown as ModelModule,
+		memoryModule,
+		{} as unknown as ToolCallingService,
+	);
+	const renderSpy = jest
+		.spyOn(
+			service as unknown as {
+				renderStructuredDefinition: (
+					...args: unknown[]
+				) => AsyncGenerator<StreamEvent>;
+			},
+			"renderStructuredDefinition",
+		)
+		.mockImplementation(async function* () {
+			for (const event of overrides.renderEvents ?? []) {
+				yield event;
+			}
+			return (
+				overrides.renderResult ?? {
+					finalContent: "",
+					renderedBlocks: [],
+					executionError: undefined,
+				}
+			);
+		});
+	return { service, updateDocument, renderSpy, resolver };
+}
+
+describe("generateDocumentAdviceStream", () => {
+	it("streams events and caches finalContent on document.advice", async () => {
+		const { service, updateDocument } = buildAdviceService({
+			renderEvents: [{ event: "text_chunk", data: { delta: "조언입니다" } }],
+			renderResult: {
+				finalContent: "조언입니다",
+				renderedBlocks: [],
+				executionError: undefined,
+			},
+		});
+		const events: StreamEvent[] = [];
+		for await (const e of service.generateDocumentAdviceStream("d1", {
+			workflowId: "wf-advice",
+		})) {
+			events.push(e);
+		}
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "조언입니다" } },
+		]);
+		expect(updateDocument).toHaveBeenCalledWith("d1", {
+			advice: expect.objectContaining({ content: "조언입니다" }),
+		});
+	});
+
+	it("injects rendered document content into the definition", async () => {
+		const { service, renderSpy } = buildAdviceService({
+			template: {
+				definition: {
+					tasks: [
+						{ taskId: "t1", title: "분석", prompt: "문서: {{document}}" },
+					],
+					response: {
+						blocks: [
+							{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t1"] },
+						],
+					},
+				},
+			},
+			renderResult: {
+				finalContent: "ok",
+				renderedBlocks: [],
+				executionError: undefined,
+			},
+		});
+		for await (const _ of service.generateDocumentAdviceStream("d1", {
+			workflowId: "wf-advice",
+		})) {
+			// drain
+		}
+		const passedDefinition = renderSpy.mock
+			.calls[0][0] as WorkflowDefinition;
+		expect(passedDefinition.tasks[0].prompt).toContain("오늘 매출 100만원");
+		expect(passedDefinition.tasks[0].prompt).not.toContain("{{document}}");
+	});
+
+	it("propagates execution errors without caching advice", async () => {
+		const { service, updateDocument } = buildAdviceService({
+			renderResult: {
+				finalContent: "",
+				renderedBlocks: [],
+				executionError: new Error("task failed"),
+			},
+		});
+		const stream = service.generateDocumentAdviceStream("d1", {
+			workflowId: "wf-advice",
+		});
+		// .rejects는 Promise를 받아야 하므로 즉시 실행해 넘긴다
+		await expect(
+			(async () => {
+				for await (const _ of stream) {
+					// drain
+				}
+			})(),
+		).rejects.toThrow("task failed");
+		expect(updateDocument).not.toHaveBeenCalled();
+	});
+
+	it("throws when workflow is not found", async () => {
+		const { service } = buildAdviceService({ template: null });
+		const stream = service.generateDocumentAdviceStream("d1", {
+			workflowId: "nope",
+		});
+		await expect(stream.next()).rejects.toThrow(/not found/);
 	});
 });

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -12,6 +12,7 @@ import {
 	type WorkflowTemplate,
 } from "@/types/memory";
 import type { StreamEvent } from "@/types/stream";
+import { loggers } from "@/utils/logger";
 
 const minimalDefinition: WorkflowDefinition = {
 	tasks: [{ taskId: "t1", title: "분석", prompt: "분석해줘" }],
@@ -721,5 +722,76 @@ describe("generateDocumentAdviceStream", () => {
 			workflowId: "nope",
 		});
 		await expect(stream.next()).rejects.toThrow(/not found/);
+	});
+
+	it("throws when resolveForDocumentFill yields no structured definition", async () => {
+		const { service, resolver } = buildAdviceService({});
+		(resolver.resolveForDocumentFill as jest.Mock).mockReturnValue({
+			query: "q",
+			displayQuery: "dq",
+			definition: undefined,
+		});
+
+		const stream = service.generateDocumentAdviceStream("d1", {
+			workflowId: "wf-advice",
+		});
+		await expect(stream.next()).rejects.toThrow(
+			/no valid structured definition/,
+		);
+	});
+
+	it("returns quietly without caching when finalContent is whitespace-only", async () => {
+		const { service, updateDocument } = buildAdviceService({
+			renderResult: {
+				finalContent: "   ",
+				renderedBlocks: [],
+				executionError: undefined,
+			},
+		});
+
+		const events: StreamEvent[] = [];
+		for await (const e of service.generateDocumentAdviceStream("d1", {
+			workflowId: "wf-advice",
+		})) {
+			events.push(e);
+		}
+
+		expect(events).toEqual([]);
+		expect(updateDocument).not.toHaveBeenCalled();
+	});
+
+	it("swallows cache-save failures and still completes the stream", async () => {
+		const errorSpy = jest
+			.spyOn(loggers.agent, "error")
+			.mockImplementation(() => loggers.agent);
+		const { service, updateDocument } = buildAdviceService({
+			renderEvents: [{ event: "text_chunk", data: { delta: "조언입니다" } }],
+			renderResult: {
+				finalContent: "조언입니다",
+				renderedBlocks: [],
+				executionError: undefined,
+			},
+		});
+		updateDocument.mockImplementation(async () => {
+			throw new Error("mongo down");
+		});
+
+		const events: StreamEvent[] = [];
+		await expect(
+			(async () => {
+				for await (const e of service.generateDocumentAdviceStream("d1", {
+					workflowId: "wf-advice",
+				})) {
+					events.push(e);
+				}
+			})(),
+		).resolves.toBeUndefined();
+
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "조언입니다" } },
+		]);
+		expect(updateDocument).toHaveBeenCalledTimes(1);
+
+		errorSpy.mockRestore();
 	});
 });

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -640,6 +640,19 @@ function buildAdviceService(overrides: {
 }
 
 describe("generateDocumentAdviceStream", () => {
+	// Silence the advice progress/outcome logs so test output stays clean.
+	let logSpies: jest.SpyInstance[] = [];
+	beforeEach(() => {
+		logSpies = (["info", "warn", "error"] as const).map((level) =>
+			jest.spyOn(loggers.agent, level).mockImplementation(() => loggers.agent),
+		);
+	});
+	afterEach(() => {
+		for (const spy of logSpies) {
+			spy.mockRestore();
+		}
+	});
+
 	it("streams events and caches finalContent on document.advice", async () => {
 		const { service, updateDocument } = buildAdviceService({
 			renderEvents: [{ event: "text_chunk", data: { delta: "조언입니다" } }],

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -1,6 +1,5 @@
 import type { MemoryModule, ModelModule } from "@/modules";
 import { WorkflowExecutionService } from "@/services/workflow-execution.service";
-import type { QueryService } from "@/services/query.service";
 import type { ToolCallingService } from "@/services/tool-calling.service";
 import type { UserWorkflowService } from "@/services/user-workflow.service";
 import type { WorkflowVariableResolver } from "@/services/workflow-variable-resolver.service";
@@ -48,7 +47,6 @@ describe("WorkflowExecutionService", () => {
 			getWorkflow: jest.fn(async () => workflow),
 			updateWorkflow: jest.fn(async () => undefined),
 		} as unknown as UserWorkflowService;
-		const queryService = {} as QueryService;
 		const workflowVariableResolver = {
 			resolveForExecution: jest.fn(() => ({
 				query: workflow.content,
@@ -79,7 +77,6 @@ describe("WorkflowExecutionService", () => {
 
 		const service = new WorkflowExecutionService(
 			userWorkflowService,
-			queryService,
 			workflowVariableResolver,
 			modelModule,
 			memoryModule,
@@ -175,7 +172,6 @@ describe("WorkflowExecutionService", () => {
 			getWorkflow: jest.fn(async () => workflow),
 			updateWorkflow: jest.fn(async () => undefined),
 		} as unknown as UserWorkflowService;
-		const queryService = {} as QueryService;
 		const workflowVariableResolver = {
 			resolveForExecution: jest.fn(() => ({
 				query: workflow.content,
@@ -209,7 +205,6 @@ describe("WorkflowExecutionService", () => {
 
 		const service = new WorkflowExecutionService(
 			userWorkflowService,
-			queryService,
 			workflowVariableResolver,
 			modelModule,
 			memoryModule,
@@ -293,7 +288,6 @@ describe("WorkflowExecutionService", () => {
 			getWorkflow: jest.fn(async () => workflow),
 			updateWorkflow: jest.fn(async () => undefined),
 		} as unknown as UserWorkflowService;
-		const queryService = {} as QueryService;
 		const workflowVariableResolver = {
 			resolveForExecution: jest.fn(() => ({
 				query: workflow.content,
@@ -339,7 +333,6 @@ describe("WorkflowExecutionService", () => {
 
 		const service = new WorkflowExecutionService(
 			userWorkflowService,
-			queryService,
 			workflowVariableResolver,
 			modelModule,
 			memoryModule,
@@ -417,7 +410,6 @@ describe("WorkflowExecutionService", () => {
 			getWorkflow: jest.fn(async () => undefined),
 			updateWorkflow: jest.fn(async () => undefined),
 		} as unknown as UserWorkflowService;
-		const queryService = {} as QueryService;
 		const getTemplate = jest.fn(async () => template);
 		const resolveForDocumentFill = jest.fn(() => ({
 			query: template.content,
@@ -459,7 +451,6 @@ describe("WorkflowExecutionService", () => {
 
 		const service = new WorkflowExecutionService(
 			userWorkflowService,
-			queryService,
 			workflowVariableResolver,
 			{} as ModelModule,
 			memoryModule,
@@ -510,5 +501,36 @@ describe("WorkflowExecutionService", () => {
 			content: "## Summary\n\n",
 			source: { type: "WORKFLOW", workflowId: "template-1" },
 		});
+	});
+
+	it("throws when the workflow has no valid structured definition", async () => {
+		const userWorkflowService = {
+			getWorkflow: jest.fn(async () => ({
+				workflowId: "w1",
+				userId: "u1",
+				title: "레거시",
+				content: "옛날 프롬프트",
+				active: true,
+			})),
+		} as unknown as UserWorkflowService;
+		const resolver = {
+			resolveForExecution: jest.fn(() => ({
+				query: "옛날 프롬프트",
+				displayQuery: "레거시",
+				definition: undefined,
+			})),
+		} as unknown as WorkflowVariableResolver;
+		const service = new WorkflowExecutionService(
+			userWorkflowService,
+			resolver,
+			{} as unknown as ModelModule,
+			{} as unknown as MemoryModule,
+			{} as unknown as ToolCallingService,
+		);
+
+		const stream = service.executeWorkflowStream("w1");
+		await expect(stream.next()).rejects.toThrow(
+			/no valid structured definition/,
+		);
 	});
 });

--- a/tests/services/workflow-variable-resolver.service.test.ts
+++ b/tests/services/workflow-variable-resolver.service.test.ts
@@ -129,6 +129,51 @@ describe("WorkflowVariableResolver", () => {
 		);
 	});
 
+	it("rejects tasks missing a prompt", () => {
+		const resolver = new WorkflowVariableResolver();
+		const definition = {
+			tasks: [{ taskId: "fetch", title: "조회" }],
+			response: { blocks: [] },
+		} as unknown as WorkflowDefinition;
+
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			AinHttpError,
+		);
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			'Task "fetch" must use a non-empty prompt string.',
+		);
+	});
+
+	it("rejects tasks missing a title", () => {
+		const resolver = new WorkflowVariableResolver();
+		const definition = {
+			tasks: [{ taskId: "fetch", prompt: "데이터를 조회한다." }],
+			response: { blocks: [] },
+		} as unknown as WorkflowDefinition;
+
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			AinHttpError,
+		);
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			'Task "fetch" must use a non-empty title string.',
+		);
+	});
+
+	it("rejects tasks missing a taskId", () => {
+		const resolver = new WorkflowVariableResolver();
+		const definition = {
+			tasks: [{ title: "조회", prompt: "데이터를 조회한다." }],
+			response: { blocks: [] },
+		} as unknown as WorkflowDefinition;
+
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			AinHttpError,
+		);
+		expect(() => resolver.normalizeDefinition(definition)).toThrow(
+			"Workflow task at index 0 must use a non-empty taskId string.",
+		);
+	});
+
 	it("applies stored execution-time variableValues and lets executionVariables override them", () => {
 		const resolver = new WorkflowVariableResolver();
 

--- a/tests/services/workflow-variable-resolver.service.test.ts
+++ b/tests/services/workflow-variable-resolver.service.test.ts
@@ -264,6 +264,37 @@ describe("WorkflowVariableResolver", () => {
 			);
 		});
 
+		it("treats empty and whitespace-only provided values as not provided so workflow defaults survive", () => {
+			const resolver = new WorkflowVariableResolver();
+
+			const result = resolver.resolveForDocumentFill(
+				{
+					title: "리포트",
+					content: "매장 {{workplace}} 품목 {{plu}} 채널 {{channel}}",
+					timezone: "Asia/Seoul",
+					variables: {
+						plu: {
+							id: "plu",
+							label: "품목",
+							type: "text",
+							resolveAt: "execution",
+						},
+						channel: {
+							id: "channel",
+							label: "채널",
+							type: "text",
+							resolveAt: "execution",
+						},
+					},
+					variableValues: { plu: "0000", channel: "전체" },
+					definition: { tasks: [], response: { blocks: [] } },
+				},
+				{ workplace: "온달", plu: "", channel: "   " },
+			);
+
+			expect(result.query).toBe("매장 온달 품목 0000 채널 전체");
+		});
+
 		it("still resolves built-in template tokens in the workflow body", () => {
 			const resolver = new WorkflowVariableResolver();
 

--- a/tests/utils/workflow-document-context.test.ts
+++ b/tests/utils/workflow-document-context.test.ts
@@ -1,0 +1,45 @@
+import type { WorkflowDefinition } from "@/types/memory";
+import {
+	DOCUMENT_CONTEXT_TOKEN,
+	injectDocumentContext,
+} from "@/utils/workflow-document-context";
+
+const baseDefinition = (prompts: string[]): WorkflowDefinition => ({
+	tasks: prompts.map((prompt, i) => ({
+		taskId: `t${i}`,
+		title: `task ${i}`,
+		prompt,
+	})),
+	response: {
+		blocks: [
+			{ blockId: "b1", type: "text", prompt: "요약", sourceTaskIds: ["t0"] },
+		],
+	},
+});
+
+describe("injectDocumentContext", () => {
+	it("substitutes {{document}} in every task prompt that references it", () => {
+		const definition = baseDefinition([
+			`다음 문서를 분석: ${DOCUMENT_CONTEXT_TOKEN}`,
+			"토큰 없는 태스크",
+			`재참조: ${DOCUMENT_CONTEXT_TOKEN} / ${DOCUMENT_CONTEXT_TOKEN}`,
+		]);
+		const result = injectDocumentContext(definition, "로그북 본문");
+		expect(result.tasks[0].prompt).toBe("다음 문서를 분석: 로그북 본문");
+		expect(result.tasks[1].prompt).toBe("토큰 없는 태스크");
+		expect(result.tasks[2].prompt).toBe("재참조: 로그북 본문 / 로그북 본문");
+	});
+
+	it("appends document content to the first task when no task references the token", () => {
+		const definition = baseDefinition(["분석해줘", "정리해줘"]);
+		const result = injectDocumentContext(definition, "로그북 본문");
+		expect(result.tasks[0].prompt).toBe("분석해줘\n\n[문서 내용]\n로그북 본문");
+		expect(result.tasks[1].prompt).toBe("정리해줘");
+	});
+
+	it("does not mutate the original definition", () => {
+		const definition = baseDefinition([`${DOCUMENT_CONTEXT_TOKEN}`]);
+		injectDocumentContext(definition, "본문");
+		expect(definition.tasks[0].prompt).toBe(DOCUMENT_CONTEXT_TOKEN);
+	});
+});


### PR DESCRIPTION
## 개요

로그북/문서의 "AI 조언" 생성을 프롬프트 기반에서 **워크플로우 실행 기반**으로 전환하고,
그 과정에서 워크플로우 실행 경로를 구조화 definition으로 일원화합니다 (⚠️ breaking).
마지막으로 문서 슬롯 fill 시 빈 execution variable이 워크플로우 기본값을 지우던 문제를 수정합니다.

## 주요 변경

### 1. 워크플로우 기반 문서 advice 생성
- `WorkflowExecutionService.generateDocumentAdviceStream` 추가: 슬롯 fill과 동일한
  ephemeral thread 방식으로 advice 워크플로우를 실행하고 결과를 `document.advice`에 저장
- `POST /api/document/:id/advice/stream`이 `adviceWorkflowId`가 오면 워크플로우 실행으로
  라우팅, 없으면 기존 `DocumentAdviceService`(advicePrompt) 경로 유지
- `{{document}}` 컨텍스트 주입 유틸(`workflow-document-context.ts`) 추가 — advice
  워크플로우 프롬프트에 현재 문서 내용을 넣을 수 있음
- advice 생성 관측용 구조화 로깅 추가

### 2. 워크플로우 실행 경로 일원화 ⚠️ BREAKING
- **레거시 content 기반(자유 텍스트) 워크플로우 실행 경로 제거**
- **워크플로우/템플릿에 구조화 `definition` 필수화** — 생성/수정 API에서 구조 검증
  (`validateWorkflowDefinition`)을 템플릿에도 동일하게 강제
- definition 없는 기존 워크플로우는 슬롯 fill 시 명시적 에러를 반환하므로,
  배포 전 기존 데이터에 definition이 채워져 있는지 확인 필요

### 3. 워크플로우 템플릿 `hidden` 플래그
- 템플릿에 `hidden` 플래그 추가, list API에서 필터링 — 내부용/개발중 템플릿을
  프론트 목록에서 숨길 수 있음

### 4. 문서 슬롯 fill의 빈 변수 처리 수정
- 슬롯 binding에는 표시용('입력값 없음')으로 빈 문자열 변수가 저장되는데,
  resolver가 이를 워크플로우 자체 기본값(`variableValues`) 위에 병합해
  `{{token}}`이 빈 문자열로 치환되는 문제가 있었음
- 기존에는 wise 프론트의 수동 fill 버튼만 클라이언트에서 빈 값을 걸러 보냈고,
  **스케줄러 자동 실행과 advice 경로는 노출**되어 있었음
- 빈 값/공백 필터를 모든 fill 경로가 공유하는 `resolveForDocumentFill`로 이동

## 배포 순서 주의

이 변경이 배포된 후 프론트(ain-enterprise-monorepo `4e0b357`)가 슬롯 fill 시
`executionVariables`를 더 이상 보내지 않습니다. **백엔드(이 PR이 반영된 에이전트)를
먼저 배포**해야 합니다 — 순서가 뒤집히면 구버전 백엔드가 저장된 빈 문자열로
기본값을 덮어쓰는 회귀가 발생합니다.