### PR TITLE
feat: make workflow task title optional, fall back to taskId for display

### DIFF
--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -26,6 +26,7 @@ import {
 	appendTextMessageToThread,
 } from "@/utils/thread-messages.js";
 import { injectDocumentContext } from "@/utils/workflow-document-context.js";
+import { workflowTaskLabel } from "@/utils/workflow-task-results.js";
 import type { ToolCallingService } from "./tool-calling.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
 import { WorkflowResponseComposer } from "./workflow-response-composer.service.js";
@@ -269,7 +270,7 @@ export class WorkflowExecutionService {
 				if (firstFailedTaskId) {
 					taskResults[task.taskId] = {
 						taskId: task.taskId,
-						title: task.title,
+						title: workflowTaskLabel(task),
 						agent: task.agent,
 						status: "skipped",
 						content: "",
@@ -280,7 +281,7 @@ export class WorkflowExecutionService {
 					yield {
 						event: "thinking_process",
 						data: {
-							title: `[워크플로우] 작업 건너뜀: ${task.title}`,
+							title: `[워크플로우] 작업 건너뜀: ${workflowTaskLabel(task)}`,
 							description: `이전 작업(${firstFailedTaskId}) 실패로 인해 건너뜁니다.`,
 							metadata: {
 								phase: "task_skipped",
@@ -294,7 +295,7 @@ export class WorkflowExecutionService {
 				}
 
 				loggers.agent.debug(
-					`Workflow task starting (${i + 1}/${definition.tasks.length}): ${task.title}`,
+					`Workflow task starting (${i + 1}/${definition.tasks.length}): ${workflowTaskLabel(task)}`,
 					{
 						workflowId,
 						threadId: thread.threadId,
@@ -318,7 +319,7 @@ export class WorkflowExecutionService {
 								workflowId,
 								threadId: thread.threadId,
 								taskId: task.taskId,
-								taskTitle: task.title,
+								taskTitle: workflowTaskLabel(task),
 								deltaPreview: result.value.data.delta.slice(0, 200),
 							},
 						);
@@ -329,7 +330,7 @@ export class WorkflowExecutionService {
 				}
 				taskResults[task.taskId] = result.value;
 				loggers.agent.debug(
-					`Workflow task finished (${i + 1}/${definition.tasks.length}): ${task.title}`,
+					`Workflow task finished (${i + 1}/${definition.tasks.length}): ${workflowTaskLabel(task)}`,
 					{
 						workflowId,
 						threadId: thread.threadId,

--- a/src/services/workflow-task-runner.service.ts
+++ b/src/services/workflow-task-runner.service.ts
@@ -7,7 +7,10 @@ import {
 } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
 import { loggers } from "@/utils/logger.js";
-import { serializeTaskResults } from "@/utils/workflow-task-results.js";
+import {
+	serializeTaskResults,
+	workflowTaskLabel,
+} from "@/utils/workflow-task-results.js";
 import type { ToolCallingService } from "./tool-calling.service.js";
 
 export class WorkflowTaskRunner {
@@ -34,7 +37,7 @@ export class WorkflowTaskRunner {
 		yield {
 			event: "thinking_process",
 			data: {
-				title: `[워크플로우] 작업 실행: ${task.title}`,
+				title: `[워크플로우] 작업 실행: ${workflowTaskLabel(task)}`,
 				description: task.agent
 					? `${task.agent.connectorName} 에이전트에 작업을 위임합니다.`
 					: "로컬에서 작업을 실행합니다.",
@@ -54,7 +57,7 @@ export class WorkflowTaskRunner {
 
 			taskResult = {
 				taskId: task.taskId,
-				title: task.title,
+				title: workflowTaskLabel(task),
 				agent: task.agent,
 				status: "completed",
 				content,
@@ -67,7 +70,7 @@ export class WorkflowTaskRunner {
 			loggers.agent.error(`Workflow task failed: ${task.taskId}`, { error });
 			taskResult = {
 				taskId: task.taskId,
-				title: task.title,
+				title: workflowTaskLabel(task),
 				agent: task.agent,
 				status: "failed",
 				content: "",
@@ -81,7 +84,7 @@ export class WorkflowTaskRunner {
 			event: "task_result",
 			data: {
 				taskId: task.taskId,
-				title: task.title,
+				title: workflowTaskLabel(task),
 				status: taskResult.status,
 				agent: task.agent?.connectorName,
 				error: taskResult.error,
@@ -195,7 +198,7 @@ ${task.prompt}`;
 			event: "task_output",
 			data: {
 				taskId: task.taskId,
-				title: task.title,
+				title: workflowTaskLabel(task),
 				delta,
 				agent: task.agent?.connectorName,
 			},

--- a/src/services/workflow-variable-resolver.service.ts
+++ b/src/services/workflow-variable-resolver.service.ts
@@ -337,10 +337,10 @@ export function validateWorkflowDefinition(
 			);
 		}
 
-		if (typeof task.title !== "string" || !task.title.trim()) {
+		if (task.title !== undefined && typeof task.title !== "string") {
 			throw new AinHttpError(
 				StatusCodes.BAD_REQUEST,
-				`Task "${task.taskId}" must use a non-empty title string.`,
+				`Task "${task.taskId}" title must be a string.`,
 			);
 		}
 

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -189,7 +189,8 @@ export interface WorkflowTaskAgent {
 
 export interface WorkflowTask {
 	taskId: string;
-	title: string;
+	/** Display label; falls back to taskId in progress events and logs. */
+	title?: string;
 	prompt: string;
 	agent?: WorkflowTaskAgent;
 }

--- a/src/utils/workflow-task-results.ts
+++ b/src/utils/workflow-task-results.ts
@@ -1,4 +1,11 @@
-import type { WorkflowTaskResult } from "@/types/memory";
+import type { WorkflowTask, WorkflowTaskResult } from "@/types/memory";
+
+/** Display label for a task: its title when set, otherwise the taskId. */
+export function workflowTaskLabel(
+	task: Pick<WorkflowTask, "taskId" | "title">,
+): string {
+	return task.title?.trim() || task.taskId;
+}
 
 export function serializeTaskResults(
 	taskResults: WorkflowTaskResult[],

--- a/tests/services/workflow-variable-resolver.service.test.ts
+++ b/tests/services/workflow-variable-resolver.service.test.ts
@@ -144,10 +144,20 @@ describe("WorkflowVariableResolver", () => {
 		);
 	});
 
-	it("rejects tasks missing a title", () => {
+	it("accepts tasks without a title", () => {
+		const resolver = new WorkflowVariableResolver();
+		const definition: WorkflowDefinition = {
+			tasks: [{ taskId: "fetch", prompt: "데이터를 조회한다." }],
+			response: { blocks: [] },
+		};
+
+		expect(resolver.normalizeDefinition(definition)).toEqual(definition);
+	});
+
+	it("rejects tasks with a non-string title", () => {
 		const resolver = new WorkflowVariableResolver();
 		const definition = {
-			tasks: [{ taskId: "fetch", prompt: "데이터를 조회한다." }],
+			tasks: [{ taskId: "fetch", title: 123, prompt: "데이터를 조회한다." }],
 			response: { blocks: [] },
 		} as unknown as WorkflowDefinition;
 
@@ -155,7 +165,7 @@ describe("WorkflowVariableResolver", () => {
 			AinHttpError,
 		);
 		expect(() => resolver.normalizeDefinition(definition)).toThrow(
-			'Task "fetch" must use a non-empty title string.',
+			'Task "fetch" title must be a string.',
 		);
 	});
 


### PR DESCRIPTION
Task titles were enforced as non-empty by validateWorkflowDefinition, but they are only display labels. Relax validation to reject only non-string titles, and route every display site (progress events, task results, logs) through a shared workflowTaskLabel() helper that falls back to the taskId, so frontends keep rendering a label without changes.