### PR TITLE
Feat/intent workflow mapping

### DIFF
--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -105,6 +105,7 @@ class Container {
 				this.getToolCallingService(),
 				getOnIntentFallback(),
 				this.getPIIService(),
+				this.getWorkflowExecutionService(),
 			);
 		}
 		return this._intentFulfillService;

--- a/src/services/intents/fulfill.service.ts
+++ b/src/services/intents/fulfill.service.ts
@@ -17,6 +17,7 @@ import { PIIFilterMode, type PIIService } from "../pii.service";
 import fulfillPrompt from "../prompts/fulfill";
 import toolSelectPrompt from "../prompts/tool-select";
 import type { ToolCallingService } from "../tool-calling.service";
+import type { WorkflowExecutionService } from "../workflow-execution.service";
 import { AggregateService } from "./aggregate.service";
 
 export class IntentFulfillService {
@@ -26,6 +27,7 @@ export class IntentFulfillService {
 	private aggregateService: AggregateService;
 	private piiService?: PIIService;
 	private toolCallingService: ToolCallingService;
+	private workflowExecutionService?: WorkflowExecutionService;
 
 	constructor(
 		modelModule: ModelModule,
@@ -33,6 +35,7 @@ export class IntentFulfillService {
 		toolCallingService: ToolCallingService,
 		onIntentFallback?: OnIntentFallback,
 		piiService?: PIIService,
+		workflowExecutionService?: WorkflowExecutionService,
 	) {
 		this.modelModule = modelModule;
 		this.memoryModule = memoryModule;
@@ -40,6 +43,7 @@ export class IntentFulfillService {
 		this.onIntentFallback = onIntentFallback;
 		this.aggregateService = new AggregateService(modelModule, memoryModule);
 		this.piiService = piiService;
+		this.workflowExecutionService = workflowExecutionService;
 	}
 
 	/**
@@ -124,7 +128,59 @@ export class IntentFulfillService {
 			}
 		}
 
+		if (intent?.workflowId && this.workflowExecutionService) {
+			return this.intentWorkflowFulfilling(triggeredIntent, thread);
+		}
+
 		return this.intentFulfilling(subquery, thread, intent);
+	}
+
+	/**
+	 * Fulfills an intent by running its mapped workflow. If the workflow
+	 * fails before producing any event (unknown id, missing definition),
+	 * falls back to the prompt-based fulfillment path so a stale mapping
+	 * never disables the intent. Failures after streaming started are
+	 * rethrown to avoid duplicating a partial response.
+	 */
+	private async *intentWorkflowFulfilling(
+		triggeredIntent: TriggeredIntent,
+		thread: ThreadObject,
+	): AsyncGenerator<StreamEvent> {
+		const { subquery = "", intent } = triggeredIntent;
+		const workflowId = intent?.workflowId;
+		if (!workflowId || !this.workflowExecutionService) {
+			yield* this.intentFulfilling(subquery, thread, intent);
+			return;
+		}
+
+		loggers.intent.info("Fulfilling intent via mapped workflow", {
+			intentName: intent?.name,
+			workflowId,
+		});
+
+		let yielded = false;
+		try {
+			const stream = this.workflowExecutionService.executeIntentWorkflowStream(
+				workflowId,
+				thread,
+				subquery,
+			);
+			for await (const event of stream) {
+				yielded = true;
+				yield event;
+			}
+			return;
+		} catch (error) {
+			if (yielded) {
+				throw error;
+			}
+			loggers.intent.warn(
+				"Intent workflow unavailable, falling back to prompt fulfillment",
+				{ intentName: intent?.name, workflowId, error },
+			);
+		}
+
+		yield* this.intentFulfilling(subquery, thread, intent);
 	}
 
 	/**

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -32,6 +32,7 @@ import type { UserWorkflowService } from "./user-workflow.service.js";
 import { WorkflowResponseComposer } from "./workflow-response-composer.service.js";
 import { WorkflowTableService } from "./workflow-table.service.js";
 import { WorkflowTaskRunner } from "./workflow-task-runner.service.js";
+import { WorkflowVariableExtractionService } from "./workflow-variable-extraction.service.js";
 import type { WorkflowVariableResolver } from "./workflow-variable-resolver.service.js";
 
 type WorkflowExecutionResult = {
@@ -45,6 +46,7 @@ export class WorkflowExecutionService {
 	private memoryModule: MemoryModule;
 	private workflowTaskRunner: WorkflowTaskRunner;
 	private workflowResponseComposer: WorkflowResponseComposer;
+	private workflowVariableExtraction: WorkflowVariableExtractionService;
 
 	constructor(
 		userWorkflowService: UserWorkflowService,
@@ -65,6 +67,9 @@ export class WorkflowExecutionService {
 		this.workflowResponseComposer = new WorkflowResponseComposer(
 			modelModule,
 			new WorkflowTableService(),
+		);
+		this.workflowVariableExtraction = new WorkflowVariableExtractionService(
+			modelModule,
 		);
 	}
 
@@ -216,6 +221,86 @@ export class WorkflowExecutionService {
 				error: updateError,
 			});
 		}
+
+		if (executionError) {
+			throw executionError;
+		}
+	}
+
+	/**
+	 * Runs an intent-mapped workflow and streams its progress into the chat
+	 * stream. Unlike {@link executeWorkflowStream}, this does NOT create or
+	 * persist a workflow thread, document, or lastRunAt bookkeeping — the
+	 * chat thread (persisted by the intent fulfillment path) is the only
+	 * artifact. Accepts a user workflow id or a template id, like slot
+	 * bindings. Variable values are extracted from the subquery via one LLM
+	 * call and merged over the workflow's stored variableValues. Setup
+	 * failures (unknown id, no definition) throw before the first yield so
+	 * callers can fall back; task failures throw after streaming.
+	 */
+	async *executeIntentWorkflowStream(
+		workflowId: string,
+		chatThread: ThreadObject,
+		subquery: string,
+		signal?: AbortSignal,
+	): AsyncGenerator<StreamEvent> {
+		const workflow = await this.getFillableWorkflow(workflowId);
+		if (!workflow) {
+			throw new Error(`User workflow or template not found: ${workflowId}`);
+		}
+
+		const variables = this.workflowVariableResolver.normalizeVariables(
+			workflow.variables,
+		);
+		let extractedVariables: Record<string, string> | undefined;
+		if (variables && Object.keys(variables).length > 0) {
+			extractedVariables =
+				await this.workflowVariableExtraction.extractFromQuery(
+					variables,
+					subquery,
+					"timezone" in workflow ? workflow.timezone : undefined,
+				);
+		}
+
+		// Document-fill semantics: an intent-mapped run has no creation step,
+		// so every provided value applies regardless of its declared
+		// resolveAt; values the model couldn't extract fall back to the
+		// workflow's stored variableValues.
+		const { definition } = this.workflowVariableResolver.resolveForDocumentFill(
+			workflow,
+			extractedVariables,
+		);
+		if (!definition) {
+			throw new Error(
+				`Workflow ${workflowId} has no valid structured definition; cannot fulfill intent`,
+			);
+		}
+
+		loggers.agent.info("Executing intent-mapped workflow", {
+			workflowId,
+			workflowTitle: workflow.title,
+			taskCount: definition.tasks.length,
+			chatThreadId: chatThread.threadId,
+			extractedVariableIds: Object.keys(extractedVariables ?? {}),
+		});
+
+		// Ephemeral, non-persisted thread: carries threadId for A2A correlation
+		// and task context, but is never written to the thread store.
+		const thread: ThreadObject = {
+			type: ThreadType.WORKFLOW,
+			userId: chatThread.userId,
+			threadId: randomUUID(),
+			title: workflow.title,
+			workflowId,
+			messages: [],
+		};
+
+		const { executionError } = yield* this.renderStructuredDefinition(
+			definition,
+			thread,
+			workflowId,
+			signal,
+		);
 
 		if (executionError) {
 			throw executionError;

--- a/src/services/workflow-variable-extraction.service.ts
+++ b/src/services/workflow-variable-extraction.service.ts
@@ -2,8 +2,13 @@ import type { ModelModule } from "@/modules";
 import type { WorkflowVariable } from "@/types/memory";
 import { loggers } from "@/utils/logger";
 
-function describeVariable(spec: WorkflowVariable): string {
-	const lines = [`- id: "${spec.id}" (${spec.type}) — ${spec.label}`];
+function describeVariable(key: string, spec: WorkflowVariable): string {
+	// The JSON key MUST be the variables-record key: the resolver looks
+	// values up by record key (and only then derives {{key}}/{{id}} tokens),
+	// so values keyed by spec.id alone never substitute {{record_key}} tokens.
+	const alias =
+		spec.id && spec.id !== key ? `, also known as "${spec.id}"` : "";
+	const lines = [`- key: "${key}" (${spec.type}) — ${spec.label}${alias}`];
 	if (
 		(spec.type === "dropdown" || spec.type === "select") &&
 		spec.options?.length
@@ -55,7 +60,7 @@ Only when the request names dates the tokens cannot express (e.g.
 dates against today's date and output "YYYY-MM-DD" literals. Never invent
 token names beyond the list above.
 
-Respond with a single JSON object mapping variable ids to string values.
+Respond with a single JSON object mapping variable keys to string values.
 Rules:
 - Include a variable ONLY if its value is clearly stated or derivable from the request. If unsure, OMIT the key entirely — never guess.
 - All values must be strings in the format specified per variable.
@@ -98,8 +103,8 @@ export class WorkflowVariableExtractionService {
 		query: string,
 		timezone?: string,
 	): Promise<Record<string, string> | undefined> {
-		const specs = Object.values(variables);
-		if (specs.length === 0) {
+		const entries = Object.entries(variables);
+		if (entries.length === 0) {
 			return undefined;
 		}
 
@@ -109,7 +114,7 @@ export class WorkflowVariableExtractionService {
 				timeZone: effectiveTimezone,
 			});
 			const systemPrompt = buildExtractionPrompt(
-				specs.map(describeVariable).join("\n"),
+				entries.map(([key, spec]) => describeVariable(key, spec)).join("\n"),
 				today,
 				effectiveTimezone,
 			);
@@ -129,8 +134,10 @@ export class WorkflowVariableExtractionService {
 
 			const parsed = JSON.parse(response.content) as Record<string, unknown>;
 			const values: Record<string, string> = {};
-			for (const spec of specs) {
-				const value = parsed[spec.id];
+			for (const [key, spec] of entries) {
+				// Prefer the record key; accept the spec id as a fallback in case
+				// the model answered with the alias.
+				const value = parsed[key] ?? parsed[spec.id];
 				if (typeof value !== "string" || !value.trim()) {
 					continue;
 				}
@@ -144,7 +151,7 @@ export class WorkflowVariableExtractionService {
 				) {
 					continue;
 				}
-				values[spec.id] = value.trim();
+				values[key] = value.trim();
 			}
 
 			if (Object.keys(values).length === 0) {

--- a/src/services/workflow-variable-extraction.service.ts
+++ b/src/services/workflow-variable-extraction.service.ts
@@ -1,0 +1,166 @@
+import type { ModelModule } from "@/modules";
+import type { WorkflowVariable } from "@/types/memory";
+import { loggers } from "@/utils/logger";
+
+function describeVariable(spec: WorkflowVariable): string {
+	const lines = [`- id: "${spec.id}" (${spec.type}) — ${spec.label}`];
+	if (
+		(spec.type === "dropdown" || spec.type === "select") &&
+		spec.options?.length
+	) {
+		lines.push(
+			`  value MUST be exactly one of: ${spec.options
+				.map((option) => `"${option}"`)
+				.join(", ")}`,
+		);
+	}
+	if (spec.type === "date_range") {
+		lines.push('  value format: "YYYY-MM-DD ~ YYYY-MM-DD"');
+	}
+	if (spec.type === "date_parts") {
+		lines.push(
+			'  value format: "YYYY-MM-DD" (use "YYYY-MM" or "YYYY" if the query is less specific)',
+		);
+	}
+	if (spec.type === "number") {
+		lines.push("  value: the number as a plain string");
+	}
+	return lines.join("\n");
+}
+
+function buildExtractionPrompt(
+	variableList: string,
+	today: string,
+	timezone: string,
+): string {
+	return `You extract workflow variable values from a user's request.
+
+Today's date is ${today} (timezone: ${timezone}).
+
+Variables to extract:
+${variableList}
+
+For RELATIVE date expressions, output built-in tokens instead of computing
+dates yourself — the system resolves them deterministically in the
+workflow's timezone. Available tokens: {{today}}, {{yesterday}},
+{{tomorrow}}, {{today+N}}, {{today-N}}, {{startOfWeek}}, {{endOfWeek}},
+{{startOfMonth}}, {{endOfMonth}}, {{year}}, {{month}}, {{day}}.
+Examples:
+- "오늘" → "{{today}}"
+- "지난 일주일" / "최근 7일" → "{{today-7}} ~ {{yesterday}}"
+- "이번 주" → "{{startOfWeek}} ~ {{endOfWeek}}"
+- "이번 달" → "{{startOfMonth}} ~ {{endOfMonth}}"
+Only when the request names dates the tokens cannot express (e.g.
+"7월 20일부터 26일까지", "지난주 월요일부터 금요일까지"), compute absolute
+dates against today's date and output "YYYY-MM-DD" literals. Never invent
+token names beyond the list above.
+
+Respond with a single JSON object mapping variable ids to string values.
+Rules:
+- Include a variable ONLY if its value is clearly stated or derivable from the request. If unsure, OMIT the key entirely — never guess.
+- All values must be strings in the format specified per variable.
+- Respond with the JSON object only, no other text.`;
+}
+
+/** Token grammar of src/utils/template-variables.ts (resolveVariable). An
+ * unknown token would survive resolution as a literal "{{...}}" string in
+ * the task prompt, so values containing one are rejected here and fall
+ * back to the workflow's stored defaults. */
+const KNOWN_TEMPLATE_TOKEN_PATTERN =
+	/^(?:today|yesterday|tomorrow|now|year|month|day|startOfWeek|endOfWeek|startOfMonth|endOfMonth|today[+-]\d+|(?:year|month|day)[+-]\d+)(?:\|[^}]+)?$/;
+
+function hasUnknownTemplateTokens(value: string): boolean {
+	for (const match of value.matchAll(/\{\{(.+?)\}\}/g)) {
+		if (!KNOWN_TEMPLATE_TOKEN_PATTERN.test(match[1].trim())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export class WorkflowVariableExtractionService {
+	private modelModule: ModelModule;
+
+	constructor(modelModule: ModelModule) {
+		this.modelModule = modelModule;
+	}
+
+	/**
+	 * Extracts workflow variable values from a natural-language query with a
+	 * single non-streaming LLM call. Returns only values that survive
+	 * validation (dropdown/select values must match options); anything
+	 * missing falls back to the workflow's stored variableValues at resolve
+	 * time. Fails open (returns undefined) on any model or parse error so
+	 * intent fulfillment never breaks on extraction.
+	 */
+	async extractFromQuery(
+		variables: Record<string, WorkflowVariable>,
+		query: string,
+		timezone?: string,
+	): Promise<Record<string, string> | undefined> {
+		const specs = Object.values(variables);
+		if (specs.length === 0) {
+			return undefined;
+		}
+
+		const effectiveTimezone = timezone || "Asia/Seoul";
+		const today = new Date().toLocaleDateString("en-CA", {
+			timeZone: effectiveTimezone,
+		});
+		const systemPrompt = buildExtractionPrompt(
+			specs.map(describeVariable).join("\n"),
+			today,
+			effectiveTimezone,
+		);
+
+		try {
+			const modelInstance = this.modelModule.getModel();
+			const messages = modelInstance.generateMessages({
+				query: `User request: """${query}"""`,
+				systemPrompt,
+			});
+			const response = await modelInstance.fetch(
+				messages,
+				this.modelModule.getModelOptions(),
+			);
+			if (!response.content) {
+				return undefined;
+			}
+
+			const parsed = JSON.parse(response.content) as Record<string, unknown>;
+			const values: Record<string, string> = {};
+			for (const spec of specs) {
+				const value = parsed[spec.id];
+				if (typeof value !== "string" || !value.trim()) {
+					continue;
+				}
+				if (hasUnknownTemplateTokens(value)) {
+					continue;
+				}
+				if (
+					(spec.type === "dropdown" || spec.type === "select") &&
+					spec.options?.length &&
+					!spec.options.includes(value.trim())
+				) {
+					continue;
+				}
+				values[spec.id] = value.trim();
+			}
+
+			if (Object.keys(values).length === 0) {
+				return undefined;
+			}
+
+			loggers.intent.info("Extracted workflow variables from query", {
+				variableIds: Object.keys(values),
+			});
+			return values;
+		} catch (error) {
+			loggers.intent.warn(
+				"Workflow variable extraction failed; using stored defaults",
+				{ error },
+			);
+			return undefined;
+		}
+	}
+}

--- a/src/services/workflow-variable-extraction.service.ts
+++ b/src/services/workflow-variable-extraction.service.ts
@@ -103,17 +103,17 @@ export class WorkflowVariableExtractionService {
 			return undefined;
 		}
 
-		const effectiveTimezone = timezone || "Asia/Seoul";
-		const today = new Date().toLocaleDateString("en-CA", {
-			timeZone: effectiveTimezone,
-		});
-		const systemPrompt = buildExtractionPrompt(
-			specs.map(describeVariable).join("\n"),
-			today,
-			effectiveTimezone,
-		);
-
 		try {
+			const effectiveTimezone = timezone || "Asia/Seoul";
+			const today = new Date().toLocaleDateString("en-CA", {
+				timeZone: effectiveTimezone,
+			});
+			const systemPrompt = buildExtractionPrompt(
+				specs.map(describeVariable).join("\n"),
+				today,
+				effectiveTimezone,
+			);
+
 			const modelInstance = this.modelModule.getModel();
 			const messages = modelInstance.generateMessages({
 				query: `User request: """${query}"""`,

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -148,6 +148,11 @@ export interface Intent {
 	 * - "auto": LLM decides (default)
 	 */
 	toolChoice?: IntentToolChoice;
+	/** When set, fulfilling this intent runs the mapped workflow instead of
+	 * the prompt-based inference loop. Accepts a user workflow id or a
+	 * workflow template id (user workflow wins), like document slot bindings.
+	 */
+	workflowId?: string;
 }
 
 export type TriggeredIntent = {

--- a/tests/services/intent-workflow-dispatch.test.ts
+++ b/tests/services/intent-workflow-dispatch.test.ts
@@ -152,4 +152,31 @@ describe("getIntentStream workflow dispatch", () => {
 		).rejects.toThrow("task failed");
 		expect(promptSpy).not.toHaveBeenCalled();
 	});
+
+	it("uses prompt path when workflowExecutionService is not wired", async () => {
+		const service = new IntentFulfillService(
+			{} as unknown as ModelModule,
+			{} as unknown as MemoryModule,
+			{} as unknown as ToolCallingService,
+			undefined,
+			undefined,
+		);
+		const promptSpy = jest
+			.spyOn(service as never, "intentFulfilling" as never)
+			.mockImplementation(async function* () {
+				yield { event: "text_chunk", data: { delta: "프롬프트 응답" } };
+			} as never);
+
+		const events = await collect(
+			getStream(service, {
+				subquery: SUBQUERY,
+				intent: { ...BASE_INTENT, workflowId: "wf-1" },
+			}),
+		);
+
+		expect(promptSpy).toHaveBeenCalled();
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "프롬프트 응답" } },
+		]);
+	});
 });

--- a/tests/services/intent-workflow-dispatch.test.ts
+++ b/tests/services/intent-workflow-dispatch.test.ts
@@ -1,0 +1,155 @@
+import type { MemoryModule, ModelModule } from "@/modules";
+import { IntentFulfillService } from "@/services/intents/fulfill.service";
+import type { ToolCallingService } from "@/services/tool-calling.service";
+import type { WorkflowExecutionService } from "@/services/workflow-execution.service";
+import {
+	type ThreadObject,
+	ThreadType,
+	type TriggeredIntent,
+} from "@/types/memory";
+import type { StreamEvent } from "@/types/stream";
+
+const THREAD: ThreadObject = {
+	type: ThreadType.CHAT,
+	userId: "chat-user",
+	threadId: "thread-1",
+	title: "채팅",
+	messages: [],
+};
+
+const BASE_INTENT = {
+	id: "intent-1",
+	name: "weekly-report",
+	description: "주간 리포트 요청",
+	status: "active",
+	prompt: "리포트를 작성해줘",
+};
+
+const SUBQUERY = "이번 주 리포트 만들어줘";
+
+function build() {
+	const workflowExecutionService = {
+		executeIntentWorkflowStream: jest.fn(),
+	} as unknown as WorkflowExecutionService;
+	const service = new IntentFulfillService(
+		{} as unknown as ModelModule,
+		{} as unknown as MemoryModule,
+		{} as unknown as ToolCallingService,
+		undefined,
+		undefined,
+		workflowExecutionService,
+	);
+	const promptSpy = jest
+		.spyOn(service as never, "intentFulfilling" as never)
+		.mockImplementation(async function* () {
+			yield { event: "text_chunk", data: { delta: "프롬프트 응답" } };
+		} as never);
+	return { service, workflowExecutionService, promptSpy };
+}
+
+function getStream(
+	service: IntentFulfillService,
+	triggeredIntent: TriggeredIntent,
+) {
+	return (
+		service as unknown as {
+			getIntentStream: (
+				t: TriggeredIntent,
+				thread: ThreadObject,
+			) => AsyncGenerator<StreamEvent>;
+		}
+	).getIntentStream(triggeredIntent, THREAD);
+}
+
+async function collect(stream: AsyncGenerator<StreamEvent>) {
+	const events: StreamEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("getIntentStream workflow dispatch", () => {
+	afterEach(() => jest.restoreAllMocks());
+
+	it("routes to the workflow engine with the subquery when intent.workflowId is set", async () => {
+		const { service, workflowExecutionService, promptSpy } = build();
+		(
+			workflowExecutionService.executeIntentWorkflowStream as jest.Mock
+		).mockImplementation(async function* () {
+			yield { event: "text_chunk", data: { delta: "워크플로우 응답" } };
+		});
+
+		const events = await collect(
+			getStream(service, {
+				subquery: SUBQUERY,
+				intent: { ...BASE_INTENT, workflowId: "wf-1" },
+			}),
+		);
+
+		expect(
+			workflowExecutionService.executeIntentWorkflowStream,
+		).toHaveBeenCalledWith("wf-1", THREAD, SUBQUERY);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "워크플로우 응답" } },
+		]);
+	});
+
+	it("keeps the prompt path when workflowId is absent", async () => {
+		const { service, workflowExecutionService, promptSpy } = build();
+		const events = await collect(
+			getStream(service, {
+				subquery: SUBQUERY,
+				intent: { ...BASE_INTENT },
+			}),
+		);
+		expect(
+			workflowExecutionService.executeIntentWorkflowStream,
+		).not.toHaveBeenCalled();
+		expect(promptSpy).toHaveBeenCalled();
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "프롬프트 응답" } },
+		]);
+	});
+
+	it("falls back to the prompt path when the workflow fails before yielding", async () => {
+		const { service, workflowExecutionService } = build();
+		(
+			workflowExecutionService.executeIntentWorkflowStream as jest.Mock
+		).mockImplementation(async function* () {
+			throw new Error("User workflow or template not found: wf-1");
+		});
+
+		const events = await collect(
+			getStream(service, {
+				subquery: SUBQUERY,
+				intent: { ...BASE_INTENT, workflowId: "wf-1" },
+			}),
+		);
+
+		expect(events).toEqual([
+			{ event: "text_chunk", data: { delta: "프롬프트 응답" } },
+		]);
+	});
+
+	it("rethrows when the workflow fails after streaming started", async () => {
+		const { service, workflowExecutionService, promptSpy } = build();
+		(
+			workflowExecutionService.executeIntentWorkflowStream as jest.Mock
+		).mockImplementation(async function* () {
+			yield { event: "text_chunk", data: { delta: "부분 결과" } };
+			throw new Error("task failed");
+		});
+
+		await expect(
+			collect(
+				getStream(service, {
+					subquery: SUBQUERY,
+					intent: { ...BASE_INTENT, workflowId: "wf-1" },
+				}),
+			),
+		).rejects.toThrow("task failed");
+		expect(promptSpy).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/workflow-execution-intent.test.ts
+++ b/tests/services/workflow-execution-intent.test.ts
@@ -1,0 +1,214 @@
+import type { MemoryModule, ModelModule } from "@/modules";
+import type { ToolCallingService } from "@/services/tool-calling.service";
+import type { UserWorkflowService } from "@/services/user-workflow.service";
+import { WorkflowExecutionService } from "@/services/workflow-execution.service";
+import { WorkflowVariableExtractionService } from "@/services/workflow-variable-extraction.service";
+import { WorkflowVariableResolver } from "@/services/workflow-variable-resolver.service";
+import { type ThreadObject, ThreadType } from "@/types/memory";
+import type { StreamEvent } from "@/types/stream";
+
+const DEFINITION = {
+	tasks: [{ taskId: "t1", prompt: "{{workplace}}의 {{period}} 매출을 조회한다" }],
+	response: {
+		blocks: [{ blockId: "b1", type: "text" as const, prompt: "요약한다" }],
+	},
+};
+
+const USER_WORKFLOW = {
+	workflowId: "wf-1",
+	userId: "owner-1",
+	title: "주간 리포트",
+	content: "주간 리포트를 생성한다",
+	active: true,
+	definition: DEFINITION,
+	variables: {
+		workplace: {
+			id: "workplace",
+			label: "업장",
+			type: "dropdown" as const,
+			options: ["강남점", "판교점"],
+		},
+		period: { id: "period", label: "기간", type: "date_range" as const },
+	},
+	variableValues: { workplace: "판교점", period: "2026-01-01 ~ 2026-01-07" },
+};
+
+const CHAT_THREAD: ThreadObject = {
+	type: ThreadType.CHAT,
+	userId: "chat-user",
+	threadId: "thread-1",
+	title: "채팅",
+	messages: [],
+};
+
+const SUBQUERY = "지난주 강남점 리포트 만들어줘";
+
+function build(options?: { userWorkflow?: unknown; template?: unknown }) {
+	const getTemplate = jest.fn(async () => options?.template);
+	const service = new WorkflowExecutionService(
+		{
+			getWorkflow: jest.fn(async () => options?.userWorkflow),
+		} as unknown as UserWorkflowService,
+		new WorkflowVariableResolver(),
+		{} as unknown as ModelModule,
+		{
+			getWorkflowTemplateMemory: () => ({ getTemplate }),
+		} as unknown as MemoryModule,
+		{} as unknown as ToolCallingService,
+	);
+	return { service, getTemplate };
+}
+
+function mockExtraction(result: Record<string, string> | undefined) {
+	return jest
+		.spyOn(WorkflowVariableExtractionService.prototype, "extractFromQuery")
+		.mockResolvedValue(result);
+}
+
+function mockRender(
+	service: WorkflowExecutionService,
+	impl: () => Generator<StreamEvent, unknown, unknown>,
+) {
+	return jest
+		.spyOn(service as never, "renderStructuredDefinition" as never)
+		.mockImplementation(impl as never);
+}
+
+async function collect(stream: AsyncGenerator<StreamEvent>) {
+	const events: StreamEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("executeIntentWorkflowStream", () => {
+	afterEach(() => jest.restoreAllMocks());
+
+	it("throws before yielding when no workflow or template matches", async () => {
+		const { service } = build();
+		await expect(
+			collect(
+				service.executeIntentWorkflowStream("missing", CHAT_THREAD, SUBQUERY),
+			),
+		).rejects.toThrow("User workflow or template not found: missing");
+	});
+
+	it("throws when the workflow has no structured definition", async () => {
+		mockExtraction(undefined);
+		const { service } = build({
+			userWorkflow: { ...USER_WORKFLOW, definition: undefined },
+		});
+		await expect(
+			collect(
+				service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+			),
+		).rejects.toThrow("no valid structured definition");
+	});
+
+	it("injects extracted variables into the definition (stored values as fallback)", async () => {
+		const extractSpy = mockExtraction({ period: "2026-07-20 ~ 2026-07-26" });
+		const { service } = build({ userWorkflow: USER_WORKFLOW });
+		const renderSpy = mockRender(service, function* () {
+			return { finalContent: "", renderedBlocks: [] };
+		});
+
+		await collect(
+			service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+		);
+
+		expect(extractSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ workplace: expect.anything() }),
+			SUBQUERY,
+			undefined,
+		);
+		const [definition] = renderSpy.mock.calls[0] as unknown as [
+			{ tasks: Array<{ prompt: string }> },
+		];
+		// period는 추출값, workplace는 저장된 variableValues 기본값으로 삽입된다
+		expect(definition.tasks[0].prompt).toBe(
+			"판교점의 2026-07-20 ~ 2026-07-26 매출을 조회한다",
+		);
+	});
+
+	it("runs the definition on an ephemeral thread owned by the chat user", async () => {
+		mockExtraction(undefined);
+		const { service } = build({ userWorkflow: USER_WORKFLOW });
+		const renderSpy = mockRender(service, function* () {
+			yield { event: "text_chunk", data: { delta: "결과" } } as StreamEvent;
+			return { finalContent: "결과", renderedBlocks: [] };
+		});
+
+		const events = await collect(
+			service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+		);
+
+		expect(events).toEqual([{ event: "text_chunk", data: { delta: "결과" } }]);
+		const [, thread, workflowId] = renderSpy.mock.calls[0] as unknown as [
+			unknown,
+			ThreadObject,
+			string,
+		];
+		expect(thread).toMatchObject({
+			type: ThreadType.WORKFLOW,
+			userId: "chat-user",
+			workflowId: "wf-1",
+			messages: [],
+		});
+		expect(workflowId).toBe("wf-1");
+	});
+
+	it("skips extraction for workflows without variables", async () => {
+		const extractSpy = mockExtraction(undefined);
+		const { service } = build({
+			userWorkflow: {
+				...USER_WORKFLOW,
+				variables: undefined,
+				variableValues: undefined,
+				definition: {
+					tasks: [{ taskId: "t1", prompt: "매출을 조회한다" }],
+					response: DEFINITION.response,
+				},
+			},
+		});
+		mockRender(service, function* () {
+			return { finalContent: "", renderedBlocks: [] };
+		});
+		await collect(
+			service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+		);
+		expect(extractSpy).not.toHaveBeenCalled();
+	});
+
+	it("falls back to a template when no user workflow matches", async () => {
+		mockExtraction(undefined);
+		const { service, getTemplate } = build({
+			template: { ...USER_WORKFLOW, templateId: "wf-1" },
+		});
+		mockRender(service, function* () {
+			return { finalContent: "", renderedBlocks: [] };
+		});
+		await collect(
+			service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+		);
+		expect(getTemplate).toHaveBeenCalledWith("wf-1");
+	});
+
+	it("rethrows executionError after streaming", async () => {
+		mockExtraction(undefined);
+		const { service } = build({ userWorkflow: USER_WORKFLOW });
+		mockRender(service, function* () {
+			yield { event: "text_chunk", data: { delta: "부분" } } as StreamEvent;
+			return {
+				finalContent: "부분",
+				renderedBlocks: [],
+				executionError: new Error("task failed"),
+			};
+		});
+		await expect(
+			collect(
+				service.executeIntentWorkflowStream("wf-1", CHAT_THREAD, SUBQUERY),
+			),
+		).rejects.toThrow("task failed");
+	});
+});

--- a/tests/services/workflow-variable-extraction.test.ts
+++ b/tests/services/workflow-variable-extraction.test.ts
@@ -112,6 +112,54 @@ describe("extractFromQuery", () => {
 		expect(fetch).not.toHaveBeenCalled();
 	});
 
+	// Regression: real templates key the variables record differently from the
+	// spec's id field (e.g. key "workplace_id", id "업장명"). The resolver looks
+	// values up by RECORD KEY, so extraction must key its output by record key
+	// or substitution silently misses every {{record_key}} token.
+	const MISMATCHED_VARIABLES: Record<string, WorkflowVariable> = {
+		workplace_id: {
+			id: "업장명",
+			label: "분석할 매장을 선택해주세요",
+			type: "dropdown",
+			options: ["강남점", "홍대점"],
+		},
+		date_range: {
+			id: "대상기간",
+			label: "분석 기간",
+			type: "date_range",
+		},
+	};
+
+	it("keys extracted values by the variables record key, not the spec id", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				workplace_id: "강남점",
+				date_range: "{{today-7}} ~ {{yesterday}}",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(MISMATCHED_VARIABLES, "지난주 강남점 매출 알려줘"),
+		).resolves.toEqual({
+			workplace_id: "강남점",
+			date_range: "{{today-7}} ~ {{yesterday}}",
+		});
+	});
+
+	it("re-keys values the model returned under the spec id to the record key", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				업장명: "강남점",
+				대상기간: "{{today-7}} ~ {{yesterday}}",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(MISMATCHED_VARIABLES, "지난주 강남점 매출 알려줘"),
+		).resolves.toEqual({
+			workplace_id: "강남점",
+			date_range: "{{today-7}} ~ {{yesterday}}",
+		});
+	});
+
 	it("fails open on malformed variable spec (options not array)", async () => {
 		const { service, fetch } = build({ content: "{}" });
 		const malformed = {

--- a/tests/services/workflow-variable-extraction.test.ts
+++ b/tests/services/workflow-variable-extraction.test.ts
@@ -111,4 +111,20 @@ describe("extractFromQuery", () => {
 			.toBeUndefined();
 		expect(fetch).not.toHaveBeenCalled();
 	});
+
+	it("fails open on malformed variable spec (options not array)", async () => {
+		const { service, fetch } = build({ content: "{}" });
+		const malformed = {
+			bad: {
+				id: "bad",
+				label: "업장",
+				type: "dropdown",
+				options: "강남점",
+			} as never,
+		};
+		await expect(
+			service.extractFromQuery(malformed, "매출 분석해줘"),
+		).resolves.toBeUndefined();
+		expect(fetch).not.toHaveBeenCalled();
+	});
 });

--- a/tests/services/workflow-variable-extraction.test.ts
+++ b/tests/services/workflow-variable-extraction.test.ts
@@ -1,0 +1,114 @@
+import type { ModelModule } from "@/modules";
+import { WorkflowVariableExtractionService } from "@/services/workflow-variable-extraction.service";
+import type { WorkflowVariable } from "@/types/memory";
+
+const VARIABLES: Record<string, WorkflowVariable> = {
+	workplace: {
+		id: "workplace",
+		label: "분석할 업장을 선택해주세요",
+		type: "dropdown",
+		options: ["강남점", "판교점"],
+	},
+	period: {
+		id: "period",
+		label: "분석 기간",
+		type: "date_range",
+		resolveAt: "execution",
+	},
+};
+
+function build(fetchResult: { content?: string } | Error) {
+	const fetch = jest.fn(async () => {
+		if (fetchResult instanceof Error) {
+			throw fetchResult;
+		}
+		return fetchResult;
+	});
+	const generateMessages = jest.fn(() => [{ role: "user" }]);
+	const modelModule = {
+		getModel: () => ({ generateMessages, fetch }),
+		getModelOptions: () => ({}),
+	} as unknown as ModelModule;
+	const service = new WorkflowVariableExtractionService(modelModule);
+	return { service, fetch, generateMessages };
+}
+
+describe("extractFromQuery", () => {
+	it("returns values the model extracted for declared variables", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				workplace: "강남점",
+				period: "2026-07-20 ~ 2026-07-26",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(VARIABLES, "지난주 강남점 매출 분석해줘"),
+		).resolves.toEqual({
+			workplace: "강남점",
+			period: "2026-07-20 ~ 2026-07-26",
+		});
+	});
+
+	it("drops dropdown values that are not in options and unknown keys", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				workplace: "없는지점",
+				period: "2026-07-20 ~ 2026-07-26",
+				hallucinated: "값",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(VARIABLES, "지난주 매출 분석해줘"),
+		).resolves.toEqual({ period: "2026-07-20 ~ 2026-07-26" });
+	});
+
+	it("accepts built-in template tokens for relative dates", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				period: "{{today-7}} ~ {{yesterday}}",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(VARIABLES, "지난 일주일 매출 분석해줘"),
+		).resolves.toEqual({ period: "{{today-7}} ~ {{yesterday}}" });
+	});
+
+	it("drops values containing unknown template tokens", async () => {
+		const { service } = build({
+			content: JSON.stringify({
+				period: "{{lastWeekStart}} ~ {{lastWeekEnd}}",
+			}),
+		});
+		await expect(
+			service.extractFromQuery(VARIABLES, "지난주 매출 분석해줘"),
+		).resolves.toBeUndefined();
+	});
+
+	it("returns undefined when the model extracts nothing usable", async () => {
+		const { service } = build({ content: JSON.stringify({}) });
+		await expect(
+			service.extractFromQuery(VARIABLES, "매출 분석해줘"),
+		).resolves.toBeUndefined();
+	});
+
+	it("fails open on invalid JSON", async () => {
+		const { service } = build({ content: "죄송하지만 JSON이 아닙니다" });
+		await expect(
+			service.extractFromQuery(VARIABLES, "매출 분석해줘"),
+		).resolves.toBeUndefined();
+	});
+
+	it("fails open on model errors", async () => {
+		const { service } = build(new Error("rate limited"));
+		await expect(
+			service.extractFromQuery(VARIABLES, "매출 분석해줘"),
+		).resolves.toBeUndefined();
+	});
+
+	it("skips the model call entirely when there are no variables", async () => {
+		const { service, fetch } = build({ content: "{}" });
+		await expect(service.extractFromQuery({}, "매출 분석해줘")).resolves
+			.toBeUndefined();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Intent → Workflow 매핑 실행

인텐트에 `workflowId`가 설정되어 있으면, 해당 인텐트 트리거 시 prompt 기반 추론 루프 대신
매핑된 워크플로우를 실행합니다. 사용자 질의에서 워크플로우 변수 값을 추출해 삽입하며,
매핑이 없는 인텐트는 기존 경로가 한 줄도 달라지지 않습니다.

### 동작 방식

1. **디스패치** — `IntentFulfillService.getIntentStream`에서 `intent.workflowId` 존재 시
   워크플로우 경로로 분기. `onIntentFallback` 분기가 항상 먼저 평가됩니다.
2. **변수 추출** — 워크플로우에 `variables`가 선언된 경우에만 LLM 1회 비스트리밍 호출로
   subquery에서 `{변수키: 값}`을 추출 (`WorkflowVariableExtractionService`).
   - 상대 날짜("오늘", "지난 일주일")는 LLM이 직접 계산하지 않고 `{{today}}`, `{{today-7}} ~ {{yesterday}}`
     같은 빌트인 토큰을 출력 → 리졸버가 타임존 반영해 결정론적으로 해석
   - dropdown/select 값은 options 정확 일치 검증, 알 수 없는 토큰이 섞인 값은 폐기
   - **모든 실패는 fail-open** (undefined 반환 → 저장된 `variableValues` 기본값으로 실행)
3. **변수 해석** — `resolveForDocumentFill` 재사용. 인텐트 실행에는 creation 단계가 없어
   `resolveAt: "creation"`(기본값) 변수까지 강제 적용되어야 하며, 이는 document slot fill과
   동일한 상황입니다. 추출값 > 저장된 `variableValues` 우선순위로 병합.
4. **실행** — `executeIntentWorkflowStream`: user workflow 우선, 같은 ID의 template 폴백
   (slot binding과 동일 규칙). **ephemeral 스레드**에서 실행되어 워크플로우 스레드/Document를
   만들지 않고, 최종 텍스트는 기존 intentFulfill 경로가 채팅 스레드에 저장합니다.
5. **폴백 계약** — 셋업 실패(워크플로우 없음/definition 없음)는 첫 yield 전에 throw되어
   prompt 경로로 폴백. 실행 도중 실패는 그대로 전파 (부분 응답 중복 방지).

### 변경 사항

- `Intent.workflowId?: string` 필드 추가 (`src/types/memory.ts`)
- `WorkflowVariableExtractionService` 신설 (`src/services/workflow-variable-extraction.service.ts`)
- `WorkflowExecutionService.executeIntentWorkflowStream` 신설
- `IntentFulfillService` constructor에 6번째 optional 파라미터 + 디스패치/폴백 로직, DI 배선

### 하위호환

- `workflowId` 없는 인텐트: 코드 경로 불변 (테스트로 고정)
- 기존 5-인자 `IntentFulfillService` 생성자 호출: 그대로 동작 — 매핑된 인텐트도 prompt 경로로 폴백 (테스트로 고정)