### PR TITLE
feat: per-request log correlation, structured JSON logging, A2A retry & failure visibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { createA2ARouter, createApiRouter, createQueryRouter } from "./routes";
 import { createIntentRouter } from "./routes/intent.routes";
 import type { AinAgentManifest, OnIntentFallback } from "./types/agent";
 import type { AuthzConfig } from "./types/authz";
+import { interceptConsole } from "./utils/logger";
 
 export type {
 	AinAgentManifest,
@@ -103,6 +104,10 @@ export class AINAgent {
 			onIntentFallback?: OnIntentFallback;
 		},
 	) {
+		// Mirror console.log/warn/error into the log file (no-op without
+		// LOG_FILE_PATH) so start/shutdown banners are part of the log record.
+		interceptConsole();
+
 		this.app = express();
 		// Express 5 defaults the query parser to "simple", which does not parse
 		// nested/bracket params (e.g. `?labels[category]=logbook`). Use the

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import { setOptions } from "./config/options";
 import { AuthMiddleware } from "./middlewares/auth.middleware";
 import { createAuthzMiddleware } from "./middlewares/authz.middleware";
 import { errorMiddleware } from "./middlewares/error.middleware";
+import {
+	accessLogMiddleware,
+	requestContextMiddleware,
+} from "./middlewares/request-context.middleware";
 import type {
 	A2AModule,
 	AuthModule,
@@ -145,6 +149,10 @@ export class AINAgent {
 	 * Also applies authentication middleware if configured.
 	 */
 	private initializeMiddlewares(): void {
+		// First so the whole request chain (auth included) shares one
+		// AsyncLocalStorage context and every completion gets an access log.
+		this.app.use(requestContextMiddleware());
+		this.app.use(accessLogMiddleware());
 		this.app.use(helmet());
 		this.app.use(cors());
 		this.app.use(express.json({ limit: "25mb" }));

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 import type { AuthModule } from "@/modules";
 import { AinHttpError } from "@/types/agent";
 import type { AuthResponse } from "@/types/auth";
+import { updateRequestContext } from "@/utils/request-context";
 
 export class AuthMiddleware {
 	private auth: AuthModule | undefined;
@@ -22,6 +23,7 @@ export class AuthMiddleware {
 				if (authRes.isAuthenticated) {
 					res.locals.userId = authRes.userId;
 					res.locals.email = authRes.email;
+					updateRequestContext({ userId: authRes.userId });
 					next();
 				} else {
 					const error: AinHttpError = new AinHttpError(

--- a/src/middlewares/request-context.middleware.ts
+++ b/src/middlewares/request-context.middleware.ts
@@ -44,8 +44,10 @@ export const accessLogMiddleware = (): RequestHandler => {
 		if (ACCESS_LOG_SKIP_PATHS.has(req.path)) return next();
 		const start = Date.now();
 		// Captured now: finish/close fire from HTTP internals, outside this
-		// request's AsyncLocalStorage context.
-		const requestId = getRequestContext()?.requestId;
+		// request's AsyncLocalStorage context. The object reference is kept
+		// (not just the id) so fields set later in the request — auth's
+		// userId — are visible at log time.
+		const ctx = getRequestContext();
 		let logged = false;
 		// `finish` = response fully sent; `close` also covers requests that
 		// never finish (client gave up on a hung handler) — without it those
@@ -59,7 +61,8 @@ export const accessLogMiddleware = (): RequestHandler => {
 				status: res.statusCode,
 				durationMs: Date.now() - start,
 				...(aborted ? { aborted: true } : {}),
-				...(requestId ? { requestId } : {}),
+				...(ctx?.requestId ? { requestId: ctx.requestId } : {}),
+				...(ctx?.userId ? { userId: ctx.userId } : {}),
 			});
 		};
 		res.on("finish", () => logOnce(false));

--- a/src/middlewares/request-context.middleware.ts
+++ b/src/middlewares/request-context.middleware.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+import type { RequestHandler } from "express";
+import { loggers } from "@/utils/logger";
+import {
+	getRequestContext,
+	runWithRequestContext,
+} from "@/utils/request-context";
+
+const REQUEST_ID_HEADER = "x-request-id";
+
+// Reused only when the client-supplied id is safe to embed in logs.
+const SAFE_REQUEST_ID = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Opens an AsyncLocalStorage request context for the whole request chain.
+ * Reuses the incoming X-Request-Id when present (so ids can be correlated
+ * across services), otherwise generates one, and echoes it in the response.
+ * Must be registered before anything that logs.
+ */
+export const requestContextMiddleware = (): RequestHandler => {
+	return (req, res, next) => {
+		const incoming = req.header(REQUEST_ID_HEADER)?.trim();
+		const requestId =
+			incoming && SAFE_REQUEST_ID.test(incoming) ? incoming : randomUUID();
+		res.setHeader("X-Request-Id", requestId);
+		runWithRequestContext({ requestId }, next);
+	};
+};
+
+// Health checks and agent-card discovery poll these constantly.
+const ACCESS_LOG_SKIP_PATHS = new Set([
+	"/",
+	"/.well-known/agent.json",
+	"/.well-known/agent-card.json",
+]);
+
+/**
+ * Logs one line per completed request (method, path, status, duration) so
+ * the log always records the request boundary, even when no service-level
+ * log was emitted.
+ */
+export const accessLogMiddleware = (): RequestHandler => {
+	return (req, res, next) => {
+		if (ACCESS_LOG_SKIP_PATHS.has(req.path)) return next();
+		const start = Date.now();
+		// Captured now: the finish event fires from HTTP internals, outside
+		// this request's AsyncLocalStorage context.
+		const requestId = getRequestContext()?.requestId;
+		res.on("finish", () => {
+			loggers.http.info("HTTP request", {
+				method: req.method,
+				path: req.originalUrl,
+				status: res.statusCode,
+				durationMs: Date.now() - start,
+				...(requestId ? { requestId } : {}),
+			});
+		});
+		next();
+	};
+};

--- a/src/middlewares/request-context.middleware.ts
+++ b/src/middlewares/request-context.middleware.ts
@@ -43,18 +43,27 @@ export const accessLogMiddleware = (): RequestHandler => {
 	return (req, res, next) => {
 		if (ACCESS_LOG_SKIP_PATHS.has(req.path)) return next();
 		const start = Date.now();
-		// Captured now: the finish event fires from HTTP internals, outside
-		// this request's AsyncLocalStorage context.
+		// Captured now: finish/close fire from HTTP internals, outside this
+		// request's AsyncLocalStorage context.
 		const requestId = getRequestContext()?.requestId;
-		res.on("finish", () => {
+		let logged = false;
+		// `finish` = response fully sent; `close` also covers requests that
+		// never finish (client gave up on a hung handler) — without it those
+		// leave no access log at all, hiding the very requests that matter.
+		const logOnce = (aborted: boolean) => {
+			if (logged) return;
+			logged = true;
 			loggers.http.info("HTTP request", {
 				method: req.method,
 				path: req.originalUrl,
 				status: res.statusCode,
 				durationMs: Date.now() - start,
+				...(aborted ? { aborted: true } : {}),
 				...(requestId ? { requestId } : {}),
 			});
-		});
+		};
+		res.on("finish", () => logOnce(false));
+		res.on("close", () => logOnce(!res.writableFinished));
 		next();
 	};
 };

--- a/src/modules/a2a/a2a.module.ts
+++ b/src/modules/a2a/a2a.module.ts
@@ -237,8 +237,12 @@ export class A2AModule {
 	 * Sends a message through the connector, retrying once on communication
 	 * failure (network error, stream timeout, connection reset). A failed
 	 * attempt may have left a broken task mapping for the thread, so it is
-	 * dropped to let the retry start a fresh task. Throws the last error
-	 * when every attempt failed.
+	 * dropped to let the retry start a fresh task.
+	 *
+	 * Retries ONLY when the failed attempt delivered no events: once the
+	 * consumer has seen output, the remote agent is already executing, and
+	 * re-sending would both run the task twice and replay the delivered
+	 * events. Throws the last error when no (further) attempt is allowed.
 	 */
 	private async *sendWithRetry(
 		connector: A2AConnector,
@@ -249,14 +253,22 @@ export class A2AModule {
 	): AsyncGenerator<StreamEvent, string, unknown> {
 		let lastError: unknown;
 		for (let attempt = 1; attempt <= A2AModule.MAX_SEND_ATTEMPTS; attempt++) {
+			let yielded = false;
 			try {
-				return yield* this.sendMessageToConnector(
+				const stream = this.sendMessageToConnector(
 					connector,
 					toolName,
 					query,
 					threadId,
 					metadata,
 				);
+				let step = await stream.next();
+				while (!step.done) {
+					yielded = true;
+					yield step.value;
+					step = await stream.next();
+				}
+				return step.value;
 			} catch (error) {
 				lastError = error;
 				const { message, stack } = describeA2AError(error);
@@ -265,6 +277,7 @@ export class A2AModule {
 					{ toolName, threadId, error: message, stack },
 				);
 				this.a2aTasks.delete(threadId);
+				if (yielded) throw error;
 			}
 		}
 		throw lastError;

--- a/src/modules/a2a/a2a.module.ts
+++ b/src/modules/a2a/a2a.module.ts
@@ -25,7 +25,19 @@ import { A2AConnector } from "./a2a.connector.js";
  * conversation sessions, and provides an interface for inter-agent communication.
  * Supports multi-turn conversations with task and context tracking.
  */
+// JSON.stringify(new Error(...)) is "{}" — message/stack are non-enumerable —
+// which erases the failure cause from logs and tool results. Extract them.
+const describeA2AError = (
+	error: unknown,
+): { message: string; stack?: string } =>
+	error instanceof Error
+		? { message: error.message, stack: error.stack }
+		: { message: typeof error === "string" ? error : JSON.stringify(error) };
+
 export class A2AModule {
+	/** Communication attempts per send: the first call plus one retry. */
+	private static readonly MAX_SEND_ATTEMPTS = 2;
+
 	/** Map of A2A server URLs to their corresponding tool instances */
 	private a2aConnectors: Map<string, A2AConnector> = new Map();
 	/** Map of session IDs to their A2A session state */
@@ -221,6 +233,43 @@ export class A2AModule {
 		return `[Bot Called A2A Tool ${toolName}]\n${finalText.join("\n")}`;
 	}
 
+	/**
+	 * Sends a message through the connector, retrying once on communication
+	 * failure (network error, stream timeout, connection reset). A failed
+	 * attempt may have left a broken task mapping for the thread, so it is
+	 * dropped to let the retry start a fresh task. Throws the last error
+	 * when every attempt failed.
+	 */
+	private async *sendWithRetry(
+		connector: A2AConnector,
+		toolName: string,
+		query: string,
+		threadId: string,
+		metadata?: Record<string, unknown>,
+	): AsyncGenerator<StreamEvent, string, unknown> {
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= A2AModule.MAX_SEND_ATTEMPTS; attempt++) {
+			try {
+				return yield* this.sendMessageToConnector(
+					connector,
+					toolName,
+					query,
+					threadId,
+					metadata,
+				);
+			} catch (error) {
+				lastError = error;
+				const { message, stack } = describeA2AError(error);
+				loggers.a2a.error(
+					`Error communicating with agent (attempt ${attempt}/${A2AModule.MAX_SEND_ATTEMPTS}):`,
+					{ toolName, threadId, error: message, stack },
+				);
+				this.a2aTasks.delete(threadId);
+			}
+		}
+		throw lastError;
+	}
+
 	public async *sendTask(params: {
 		connectorName: string;
 		message: string;
@@ -235,18 +284,16 @@ export class A2AModule {
 			return `[Bot Called A2A Tool ${params.connectorName}]\n"Unknown agent connector"`;
 		}
 
-		try {
-			return yield* this.sendMessageToConnector(
-				connector,
-				params.connectorName,
-				params.message,
-				params.threadId,
-				params.metadata,
-			);
-		} catch (error) {
-			loggers.a2a.error("Error communicating with agent:", { error });
-			return `[Bot Called A2A Tool ${params.connectorName}]\n${typeof error === "string" ? error : JSON.stringify(error, null, 2)}`;
-		}
+		// No catch: after the retry is exhausted the error propagates, so
+		// callers (e.g. workflow tasks) record a real failure instead of
+		// mistaking the error text for a completed result.
+		return yield* this.sendWithRetry(
+			connector,
+			params.connectorName,
+			params.message,
+			params.threadId,
+			params.metadata,
+		);
 	}
 
 	/**
@@ -274,16 +321,17 @@ export class A2AModule {
 		}
 
 		try {
-			return yield* this.sendMessageToConnector(
+			return yield* this.sendWithRetry(
 				connector,
 				tool.toolName,
 				query,
 				threadId,
 			);
 		} catch (error) {
-			loggers.a2a.error("Error communicating with agent:", { error });
-			const toolResult = `[Bot Called A2A Tool ${tool.toolName}]\n${typeof error === "string" ? error : JSON.stringify(error, null, 2)}`;
-			return toolResult;
+			// Interactive tool-calling path: surface the failure to the model
+			// as tool output (with the actual cause) instead of throwing, so
+			// the LLM can react to it mid-conversation.
+			return `[Bot Called A2A Tool ${tool.toolName}]\n${describeA2AError(error).message}`;
 		}
 	}
 }

--- a/src/services/a2a.service.ts
+++ b/src/services/a2a.service.ts
@@ -88,6 +88,15 @@ export class A2AService implements AgentExecutor {
 			eventBus.publish(initialTask);
 		}
 
+		// Logged before any await: thread loading and the LLM calls inside
+		// handleQuery emit nothing, so without this line a task that hangs
+		// there leaves zero server-side trace of the request ever arriving.
+		loggers.server.info(`Task ${taskId} started`, {
+			threadId,
+			agentId,
+			isNewTask: !existingTask,
+		});
+
 		const message: string = userMessage.parts
 			.filter((part) => part.kind === "text")
 			.map((part) => part.text)

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -15,6 +15,7 @@ import {
 import type { StreamEvent } from "@/types/stream";
 import { injectAttachedDocuments } from "@/utils/attached-documents.js";
 import { loggers } from "@/utils/logger.js";
+import { updateRequestContext } from "@/utils/request-context.js";
 import { persistTextMessage } from "@/utils/thread-messages.js";
 import { sanitizeThinkingData } from "@/utils/tool-args.js";
 import type { IntentFulfillService } from "./intents/fulfill.service";
@@ -183,6 +184,8 @@ export class QueryService {
 		}
 
 		threadId ??= randomUUID();
+		// From here on every log line in this request carries the threadId.
+		updateRequestContext({ threadId });
 		if (!thread) {
 			const title =
 				type === ThreadType.WORKFLOW && inputTitle

--- a/src/services/scheduler.service.ts
+++ b/src/services/scheduler.service.ts
@@ -8,6 +8,7 @@ import type {
 	ScheduleTrigger,
 } from "@/types/schedule.js";
 import { loggers } from "@/utils/logger.js";
+import { runWithRequestContext } from "@/utils/request-context.js";
 import type { JobRunnerService } from "./job-runner.service.js";
 import type { UserWorkflowService } from "./user-workflow.service.js";
 import type { WorkflowExecutionService } from "./workflow-execution.service.js";
@@ -165,9 +166,22 @@ export class SchedulerService {
 		trigger: ScheduleTrigger,
 		scheduledFor: number,
 	): Promise<void> {
+		// The runId doubles as the correlation id so every log line of this
+		// run carries it, the same way requestId does for HTTP requests.
+		const runId = randomUUID();
+		return runWithRequestContext({ requestId: runId }, () =>
+			this.runWorkflowJobWithRunId(runId, workflowId, trigger, scheduledFor),
+		);
+	}
+
+	private async runWorkflowJobWithRunId(
+		runId: string,
+		workflowId: string,
+		trigger: ScheduleTrigger,
+		scheduledFor: number,
+	): Promise<void> {
 		try {
 			const scheduleRunMemory = this.memoryModule.getScheduleRunMemory();
-			const runId = randomUUID();
 			const startedAt = Date.now();
 			await scheduleRunMemory?.createScheduleRun({
 				runId,
@@ -311,12 +325,23 @@ export class SchedulerService {
 		trigger: ScheduleTrigger,
 		scheduledFor: number,
 	): Promise<void> {
+		// See runWorkflowJob: runId doubles as the correlation id.
+		const runId = randomUUID();
+		return runWithRequestContext({ requestId: runId }, () =>
+			this.runAutoRefreshJobWithRunId(runId, documentId, trigger, scheduledFor),
+		);
+	}
+
+	private async runAutoRefreshJobWithRunId(
+		runId: string,
+		documentId: string,
+		trigger: ScheduleTrigger,
+		scheduledFor: number,
+	): Promise<void> {
 		try {
 			const documentMemory = this.memoryModule.getDocumentMemory();
 			const scheduleRunMemory = this.memoryModule.getScheduleRunMemory();
 			if (!documentMemory) return;
-
-			const runId = randomUUID();
 			await scheduleRunMemory?.createScheduleRun({
 				runId,
 				jobType: "SLOT_REFRESH",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -149,19 +149,32 @@ export const interceptConsole = (): winston.Logger | undefined => {
 		error: console.error,
 	};
 
+	// Re-entrancy guard: winston/transport error handling may itself call
+	// console.*; mirroring that would recurse until the stack overflows.
+	let mirroring = false;
+	const mirror = (write: (text: string) => unknown, args: unknown[]) => {
+		if (mirroring) return;
+		mirroring = true;
+		try {
+			write(formatConsoleArgs(args));
+		} finally {
+			mirroring = false;
+		}
+	};
+
 	console.log = (...args: unknown[]) => {
 		interceptedConsole?.log(...args);
-		consoleLogger.info(formatConsoleArgs(args));
+		mirror((text) => consoleLogger.info(text), args);
 	};
 
 	console.warn = (...args: unknown[]) => {
 		interceptedConsole?.warn(...args);
-		consoleLogger.warn(formatConsoleArgs(args));
+		mirror((text) => consoleLogger.warn(text), args);
 	};
 
 	console.error = (...args: unknown[]) => {
 		interceptedConsole?.error(...args);
-		consoleLogger.error(formatConsoleArgs(args));
+		mirror((text) => consoleLogger.error(text), args);
 	};
 
 	return consoleLogger;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -17,6 +17,19 @@ export const injectRequestContext = winston.format((info) => {
 	return info;
 });
 
+// Error objects passed as meta ({ error }) JSON.stringify to "{}" because
+// message/stack are non-enumerable — the log would record nothing. Convert
+// them to their stack string (which starts with "Error: <message>").
+export const serializeErrorValues = winston.format((info) => {
+	for (const key of Object.keys(info)) {
+		const value = info[key];
+		if (value instanceof Error) {
+			info[key] = value.stack ?? `${value.name}: ${value.message}`;
+		}
+	}
+	return info;
+});
+
 export const textLogFormat = printf(
 	({ level, message, timestamp, service, stack, requestId, ...meta }) => {
 		const reqTag = requestId ? ` [req:${String(requestId).slice(0, 8)}]` : "";
@@ -50,6 +63,7 @@ const buildFormat = (output: LogOutput) => {
 	if (resolveLogFormat(output) === "json") {
 		return combine(
 			errors({ stack: true }),
+			serializeErrorValues(),
 			injectRequestContext(),
 			timestamp(),
 			json(),
@@ -57,6 +71,7 @@ const buildFormat = (output: LogOutput) => {
 	}
 	return combine(
 		errors({ stack: true }),
+		serializeErrorValues(),
 		injectRequestContext(),
 		...(output === "console" ? [colorize()] : []),
 		timestamp({

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { inspect } from "node:util";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
 import { getRequestContext } from "@/utils/request-context";
@@ -113,29 +114,49 @@ export const loggers = {
 	http: getLogger("HTTP"),
 } as const;
 
-// Intercept console.log/warn/error and write to LOG_FILE_PATH
-export const interceptConsole = () => {
+const formatConsoleArgs = (args: unknown[]): string =>
+	args.map((arg) => (typeof arg === "string" ? arg : inspect(arg))).join(" ");
+
+let interceptedConsole: Pick<Console, "log" | "warn" | "error"> | undefined;
+
+// Mirrors console.log/warn/error into the log file so server start/stop
+// banners and stray console calls appear in the same .jsonl as everything
+// else. Still prints to stdout; no-op without LOG_FILE_PATH (dev console
+// stays untouched). Idempotent: only the first call patches.
+export const interceptConsole = (): winston.Logger | undefined => {
 	const logFilePath = process.env.LOG_FILE_PATH;
-	if (!logFilePath) return;
+	if (!logFilePath || interceptedConsole) return undefined;
 
 	const consoleLogger = createLogger("console");
-
-	const originalLog = console.log;
-	const originalWarn = console.warn;
-	const originalError = console.error;
+	interceptedConsole = {
+		log: console.log,
+		warn: console.warn,
+		error: console.error,
+	};
 
 	console.log = (...args: unknown[]) => {
-		originalLog(...args);
-		consoleLogger.info(args.map(String).join(" "));
+		interceptedConsole?.log(...args);
+		consoleLogger.info(formatConsoleArgs(args));
 	};
 
 	console.warn = (...args: unknown[]) => {
-		originalWarn(...args);
-		consoleLogger.warn(args.map(String).join(" "));
+		interceptedConsole?.warn(...args);
+		consoleLogger.warn(formatConsoleArgs(args));
 	};
 
 	console.error = (...args: unknown[]) => {
-		originalError(...args);
-		consoleLogger.error(args.map(String).join(" "));
+		interceptedConsole?.error(...args);
+		consoleLogger.error(formatConsoleArgs(args));
 	};
+
+	return consoleLogger;
+};
+
+// Undoes interceptConsole (used by tests; safe to call unpatched).
+export const restoreConsole = (): void => {
+	if (!interceptedConsole) return;
+	console.log = interceptedConsole.log;
+	console.warn = interceptedConsole.warn;
+	console.error = interceptedConsole.error;
+	interceptedConsole = undefined;
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,17 +1,69 @@
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
+import { getRequestContext } from "@/utils/request-context";
 
-const { combine, timestamp, printf, colorize, errors } = winston.format;
+const { combine, timestamp, printf, colorize, errors, json } = winston.format;
 
-const logFormat = printf(
-	({ level, message, timestamp, service, stack, ...meta }) => {
+// Merges the ambient request context into every log entry so lines from
+// interleaved concurrent requests stay correlatable. Values passed
+// explicitly at the call site win over the ambient ones.
+export const injectRequestContext = winston.format((info) => {
+	const ctx = getRequestContext();
+	if (!ctx) return info;
+	info.requestId ??= ctx.requestId;
+	if (ctx.userId !== undefined) info.userId ??= ctx.userId;
+	if (ctx.threadId !== undefined) info.threadId ??= ctx.threadId;
+	return info;
+});
+
+export const textLogFormat = printf(
+	({ level, message, timestamp, service, stack, requestId, ...meta }) => {
+		const reqTag = requestId ? ` [req:${String(requestId).slice(0, 8)}]` : "";
 		const metaStr = Object.keys(meta).length
 			? ` | ${JSON.stringify(meta)}`
 			: "";
 		const errorStack = stack ? `\n${stack}` : "";
-		return `${timestamp} [${service}] ${level}: ${message}${metaStr}${errorStack}`;
+		return `${timestamp} [${service}]${reqTag} ${level}: ${message}${metaStr}${errorStack}`;
 	},
 );
+
+export type LogOutput = "file" | "console";
+
+// File output defaults to structured JSON lines (grep/jq/lnav-friendly);
+// the dev console stays human-readable. LOG_FORMAT=json|text overrides both.
+export const resolveLogFormat = (output: LogOutput): "json" | "text" => {
+	const override = process.env.LOG_FORMAT?.toLowerCase();
+	if (override === "json" || override === "text") return override;
+	return output === "file" ? "json" : "text";
+};
+
+// Rotated file names get a .jsonl suffix (after the date) when the file
+// output is JSON lines, so new files are recognizable by tools and by eye.
+// Text mode keeps the legacy extension-less names.
+export const logFileExtension = (logFilePath: string): string => {
+	if (resolveLogFormat("file") !== "json") return "";
+	return /\.jsonl?$/.test(logFilePath) ? "" : ".jsonl";
+};
+
+const buildFormat = (output: LogOutput) => {
+	if (resolveLogFormat(output) === "json") {
+		return combine(
+			errors({ stack: true }),
+			injectRequestContext(),
+			timestamp(),
+			json(),
+		);
+	}
+	return combine(
+		errors({ stack: true }),
+		injectRequestContext(),
+		...(output === "console" ? [colorize()] : []),
+		timestamp({
+			format: output === "file" ? "YYYY-MM-DD HH:mm:ss" : "HH:mm:ss",
+		}),
+		textLogFormat,
+	);
+};
 
 const createLogger = (service: string) => {
 	const logFilePath = process.env.LOG_FILE_PATH;
@@ -20,24 +72,16 @@ const createLogger = (service: string) => {
 		? [
 				new DailyRotateFile({
 					filename: logFilePath,
+					extension: logFileExtension(logFilePath),
 					datePattern: "YYYY-MM-DD",
 					maxSize: process.env.LOG_MAX_SIZE || "20m",
 					maxFiles: process.env.LOG_MAX_FILES || "14d",
-					format: combine(
-						errors({ stack: true }),
-						timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
-						logFormat,
-					),
+					format: buildFormat("file"),
 				}),
 			]
 		: [
 				new winston.transports.Console({
-					format: combine(
-						errors({ stack: true }),
-						colorize(),
-						timestamp({ format: "HH:mm:ss" }),
-						logFormat,
-					),
+					format: buildFormat("console"),
 				}),
 			];
 
@@ -66,6 +110,7 @@ export const loggers = {
 	model: getLogger("Model"),
 	server: getLogger("A2AServer"),
 	fol: getLogger("FOL"),
+	http: getLogger("HTTP"),
 } as const;
 
 // Intercept console.log/warn/error and write to LOG_FILE_PATH

--- a/src/utils/request-context.ts
+++ b/src/utils/request-context.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Ambient per-request context carried across async boundaries via
+ * AsyncLocalStorage. Loggers read from it so every log line can be
+ * correlated to a request without threading IDs through parameters.
+ */
+export interface RequestContext {
+	/** Correlation ID: one per HTTP request (or per scheduled run). */
+	requestId: string;
+	userId?: string;
+	threadId?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Runs `fn` with `context` as the ambient request context. Everything in
+ * the async call tree of `fn` (awaits, promises, timers) sees the context.
+ */
+export const runWithRequestContext = <T>(
+	context: RequestContext,
+	fn: () => T,
+): T => storage.run(context, fn);
+
+/** Returns the ambient context, or undefined outside of one. */
+export const getRequestContext = (): RequestContext | undefined =>
+	storage.getStore();
+
+/**
+ * Merges fields into the current context (e.g. userId after auth,
+ * threadId once resolved). No-op when called outside of a context.
+ */
+export const updateRequestContext = (
+	patch: Partial<Omit<RequestContext, "requestId">>,
+): void => {
+	const store = storage.getStore();
+	if (store) Object.assign(store, patch);
+};

--- a/tests/intercept-console-wiring.test.ts
+++ b/tests/intercept-console-wiring.test.ts
@@ -1,0 +1,40 @@
+import { AINAgent } from "@/index";
+import type { AuthModule, MemoryModule, ModelModule } from "@/modules";
+import { restoreConsole } from "@/utils/logger";
+
+function fakeModules() {
+	const authModule = {
+		authenticate: async () => ({ isAuthenticated: true, userId: "u1" }),
+	} as unknown as AuthModule;
+	const modelModule = {} as unknown as ModelModule;
+	const memoryModule = {
+		getDocumentMemory: () => undefined,
+		getUserWorkflowMemory: () => undefined,
+		getScheduleRunMemory: () => undefined,
+		initialize: async () => undefined,
+	} as unknown as MemoryModule;
+	return { authModule, modelModule, memoryModule };
+}
+
+describe("AINAgent console interception wiring", () => {
+	const originalLog = console.log;
+	const originalPath = process.env.LOG_FILE_PATH;
+
+	afterEach(() => {
+		restoreConsole();
+		if (originalPath === undefined) delete process.env.LOG_FILE_PATH;
+		else process.env.LOG_FILE_PATH = originalPath;
+	});
+
+	it("intercepts console output when LOG_FILE_PATH is set", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		new AINAgent({ name: "test-agent", description: "test" }, fakeModules());
+		expect(console.log).not.toBe(originalLog);
+	});
+
+	it("leaves console untouched without LOG_FILE_PATH", () => {
+		delete process.env.LOG_FILE_PATH;
+		new AINAgent({ name: "test-agent", description: "test" }, fakeModules());
+		expect(console.log).toBe(originalLog);
+	});
+});

--- a/tests/middlewares/auth-context.test.ts
+++ b/tests/middlewares/auth-context.test.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import request from "supertest";
+import { AuthMiddleware } from "@/middlewares/auth.middleware";
+import { requestContextMiddleware } from "@/middlewares/request-context.middleware";
+import type { AuthModule } from "@/modules";
+import { getRequestContext } from "@/utils/request-context";
+
+const buildApp = (auth: AuthModule | undefined) => {
+	const app = express();
+	app.use(requestContextMiddleware());
+	app.use(new AuthMiddleware(auth).middleware());
+	app.get("/whoami", (_req, res) => {
+		res.json({ context: getRequestContext() ?? null });
+	});
+	return app;
+};
+
+describe("AuthMiddleware request context", () => {
+	it("adds the authenticated userId to the request context", async () => {
+		const auth = {
+			authenticate: async () => ({ isAuthenticated: true, userId: "u-42" }),
+		} as unknown as AuthModule;
+
+		const res = await request(buildApp(auth)).get("/whoami");
+		expect(res.status).toBe(200);
+		expect(res.body.context.userId).toBe("u-42");
+	});
+
+	it("leaves the context without userId when auth is skipped", async () => {
+		const res = await request(buildApp(undefined)).get("/whoami");
+		expect(res.status).toBe(200);
+		expect(res.body.context.userId).toBeUndefined();
+		expect(res.body.context.requestId).toBeDefined();
+	});
+});

--- a/tests/middlewares/request-context.middleware.test.ts
+++ b/tests/middlewares/request-context.middleware.test.ts
@@ -89,4 +89,38 @@ describe("accessLogMiddleware", () => {
 		await request(buildApp()).get("/");
 		expect(infoSpy).not.toHaveBeenCalled();
 	});
+
+	it("logs an aborted line when the client disconnects before the response", async () => {
+		const app = express();
+		app.use(requestContextMiddleware());
+		app.use(accessLogMiddleware());
+		app.get("/hang", () => {
+			// Never respond — the client gives up first.
+		});
+
+		const pending = request(app)
+			.get("/hang")
+			.set("X-Request-Id", "req-hang-1")
+			.timeout({ response: 100 })
+			.catch(() => {});
+		await pending;
+		// The close event fires on the server a beat after the client aborts.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(infoSpy).toHaveBeenCalledTimes(1);
+		const [, meta] = infoSpy.mock.calls[0];
+		expect(meta).toMatchObject({
+			method: "GET",
+			path: "/hang",
+			aborted: true,
+			requestId: "req-hang-1",
+		});
+	});
+
+	it("does not double-log when the response finishes normally", async () => {
+		await request(buildApp()).get("/echo-context");
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(infoSpy).toHaveBeenCalledTimes(1);
+		expect(infoSpy.mock.calls[0][1].aborted).toBeUndefined();
+	});
 });

--- a/tests/middlewares/request-context.middleware.test.ts
+++ b/tests/middlewares/request-context.middleware.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import request from "supertest";
+import {
+	accessLogMiddleware,
+	requestContextMiddleware,
+} from "@/middlewares/request-context.middleware";
+import { loggers } from "@/utils/logger";
+import { getRequestContext } from "@/utils/request-context";
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+let infoSpy: jest.SpyInstance;
+
+beforeEach(() => {
+	infoSpy = jest.spyOn(loggers.http, "info").mockReturnValue(loggers.http);
+});
+
+afterEach(() => {
+	infoSpy.mockRestore();
+});
+
+const buildApp = () => {
+	const app = express();
+	app.use(requestContextMiddleware());
+	app.use(accessLogMiddleware());
+	app.get("/echo-context", async (_req, res) => {
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		res.json({ context: getRequestContext() ?? null });
+	});
+	app.get("/", (_req, res) => {
+		res.send("ok");
+	});
+	return app;
+};
+
+describe("requestContextMiddleware", () => {
+	it("generates a request id, exposes it in context and response header", async () => {
+		const res = await request(buildApp()).get("/echo-context");
+		const headerId = res.headers["x-request-id"];
+		expect(headerId).toMatch(UUID_RE);
+		expect(res.body.context.requestId).toBe(headerId);
+	});
+
+	it("reuses a valid incoming X-Request-Id header", async () => {
+		const res = await request(buildApp())
+			.get("/echo-context")
+			.set("X-Request-Id", "client-id-123");
+		expect(res.headers["x-request-id"]).toBe("client-id-123");
+		expect(res.body.context.requestId).toBe("client-id-123");
+	});
+
+	it("ignores an unsafe incoming header and generates a fresh id", async () => {
+		const res = await request(buildApp())
+			.get("/echo-context")
+			.set("X-Request-Id", "bad id\twith spaces");
+		expect(res.headers["x-request-id"]).toMatch(UUID_RE);
+	});
+
+	it("gives concurrent requests distinct contexts", async () => {
+		const app = buildApp();
+		const [a, b] = await Promise.all([
+			request(app).get("/echo-context"),
+			request(app).get("/echo-context"),
+		]);
+		expect(a.body.context.requestId).not.toBe(b.body.context.requestId);
+	});
+});
+
+describe("accessLogMiddleware", () => {
+	it("logs one completion line with method, path, status, duration and requestId", async () => {
+		await request(buildApp())
+			.get("/echo-context?x=1")
+			.set("X-Request-Id", "req-log-1");
+
+		expect(infoSpy).toHaveBeenCalledTimes(1);
+		const [message, meta] = infoSpy.mock.calls[0];
+		expect(message).toBe("HTTP request");
+		expect(meta).toMatchObject({
+			method: "GET",
+			path: "/echo-context?x=1",
+			status: 200,
+			requestId: "req-log-1",
+		});
+		expect(typeof meta.durationMs).toBe("number");
+	});
+
+	it("skips health-check style paths", async () => {
+		await request(buildApp()).get("/");
+		expect(infoSpy).not.toHaveBeenCalled();
+	});
+});

--- a/tests/middlewares/request-context.middleware.test.ts
+++ b/tests/middlewares/request-context.middleware.test.ts
@@ -5,7 +5,10 @@ import {
 	requestContextMiddleware,
 } from "@/middlewares/request-context.middleware";
 import { loggers } from "@/utils/logger";
-import { getRequestContext } from "@/utils/request-context";
+import {
+	getRequestContext,
+	updateRequestContext,
+} from "@/utils/request-context";
 
 const UUID_RE =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -115,6 +118,25 @@ describe("accessLogMiddleware", () => {
 			aborted: true,
 			requestId: "req-hang-1",
 		});
+	});
+
+	it("includes the userId that auth sets after the middleware registered", async () => {
+		const app = express();
+		app.use(requestContextMiddleware());
+		app.use(accessLogMiddleware());
+		app.use((_req, _res, next) => {
+			updateRequestContext({ userId: "u-9" });
+			next();
+		});
+		app.get("/me", (_req, res) => {
+			res.send("ok");
+		});
+
+		await request(app).get("/me");
+		await new Promise((resolve) => setTimeout(resolve, 30));
+
+		expect(infoSpy).toHaveBeenCalledTimes(1);
+		expect(infoSpy.mock.calls[0][1]).toMatchObject({ userId: "u-9" });
 	});
 
 	it("does not double-log when the response finishes normally", async () => {

--- a/tests/modules/a2a-retry.test.ts
+++ b/tests/modules/a2a-retry.test.ts
@@ -11,9 +11,25 @@ const thinkingEvent: StreamEvent = {
 	data: { title: "working", description: "" },
 } as StreamEvent;
 
-async function* failingStream(): AsyncGenerator<StreamEvent, string, unknown> {
-	yield thinkingEvent;
+// Dies before producing anything — the remote may never have seen the
+// request, so retrying is safe.
+async function* failingBeforeYield(): AsyncGenerator<
+	StreamEvent,
+	string,
+	unknown
+> {
 	throw new Error("boom: stream idle timeout");
+}
+
+// Dies after events were already delivered — the remote is executing and
+// the consumer already saw output, so a retry would duplicate both.
+async function* failingAfterYield(): AsyncGenerator<
+	StreamEvent,
+	string,
+	unknown
+> {
+	yield thinkingEvent;
+	throw new Error("boom: connection reset mid-stream");
 }
 
 async function* successStream(): AsyncGenerator<StreamEvent, string, unknown> {
@@ -52,15 +68,15 @@ describe("A2AModule retry behaviour", () => {
 		errorSpy.mockRestore();
 	});
 
-	it("sendTask retries once and returns the second attempt's result", async () => {
+	it("sendTask retries when the first attempt died before yielding anything", async () => {
 		const module = buildModule();
 		const sendSpy = jest
 			// biome-ignore lint/suspicious/noExplicitAny: private method
 			.spyOn(module as any, "sendMessageToConnector")
-			.mockImplementationOnce(failingStream)
+			.mockImplementationOnce(failingBeforeYield)
 			.mockImplementationOnce(successStream);
 
-		const { result } = await drain(
+		const { events, result } = await drain(
 			module.sendTask({
 				connectorName: "analysis-agent",
 				message: "analyze",
@@ -70,6 +86,29 @@ describe("A2AModule retry behaviour", () => {
 
 		expect(result).toBe("[Bot Called A2A Tool analysis-agent]\nanalysis result");
 		expect(sendSpy).toHaveBeenCalledTimes(2);
+		// Consumers see the successful attempt's events exactly once.
+		expect(events).toEqual([thinkingEvent]);
+	});
+
+	it("sendTask does NOT retry once events were already delivered", async () => {
+		const module = buildModule();
+		const sendSpy = jest
+			// biome-ignore lint/suspicious/noExplicitAny: private method
+			.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementation(failingAfterYield);
+
+		await expect(
+			drain(
+				module.sendTask({
+					connectorName: "analysis-agent",
+					message: "analyze",
+					threadId: THREAD_ID,
+				}),
+			),
+		).rejects.toThrow("boom: connection reset mid-stream");
+		// A retry here would re-execute the remote task and replay the
+		// already-delivered events to the consumer.
+		expect(sendSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("sendTask propagates the error when the retry also fails", async () => {
@@ -77,7 +116,7 @@ describe("A2AModule retry behaviour", () => {
 		const sendSpy = jest
 			// biome-ignore lint/suspicious/noExplicitAny: private method
 			.spyOn(module as any, "sendMessageToConnector")
-			.mockImplementation(failingStream);
+			.mockImplementation(failingBeforeYield);
 
 		await expect(
 			drain(
@@ -95,7 +134,7 @@ describe("A2AModule retry behaviour", () => {
 		const module = buildModule();
 		// biome-ignore lint/suspicious/noExplicitAny: private method
 		jest.spyOn(module as any, "sendMessageToConnector")
-			.mockImplementation(failingStream);
+			.mockImplementation(failingBeforeYield);
 
 		await drain(
 			module.sendTask({
@@ -119,7 +158,7 @@ describe("A2AModule retry behaviour", () => {
 		(module as any).a2aTasks.set(THREAD_ID, "broken-task");
 		// biome-ignore lint/suspicious/noExplicitAny: private method
 		jest.spyOn(module as any, "sendMessageToConnector")
-			.mockImplementation(failingStream);
+			.mockImplementation(failingBeforeYield);
 
 		await drain(
 			module.sendTask({
@@ -145,7 +184,7 @@ describe("A2AModule retry behaviour", () => {
 		const sendSpy = jest
 			// biome-ignore lint/suspicious/noExplicitAny: private method
 			.spyOn(module as any, "sendMessageToConnector")
-			.mockImplementation(failingStream);
+			.mockImplementation(failingBeforeYield);
 
 		const { result } = await drain(
 			module.useTool(tool, "analyze", THREAD_ID),

--- a/tests/modules/a2a-retry.test.ts
+++ b/tests/modules/a2a-retry.test.ts
@@ -1,0 +1,159 @@
+import { A2AModule } from "@/modules/a2a/a2a.module";
+import type { ConnectorTool } from "@/types/connector";
+import { CONNECTOR_PROTOCOL_TYPE } from "@/types/connector";
+import type { StreamEvent } from "@/types/stream";
+import { loggers } from "@/utils/logger";
+
+const THREAD_ID = "thread-1";
+
+const thinkingEvent: StreamEvent = {
+	event: "thinking_process",
+	data: { title: "working", description: "" },
+} as StreamEvent;
+
+async function* failingStream(): AsyncGenerator<StreamEvent, string, unknown> {
+	yield thinkingEvent;
+	throw new Error("boom: stream idle timeout");
+}
+
+async function* successStream(): AsyncGenerator<StreamEvent, string, unknown> {
+	yield thinkingEvent;
+	return "[Bot Called A2A Tool analysis-agent]\nanalysis result";
+}
+
+const drain = async (gen: AsyncGenerator<StreamEvent, string, unknown>) => {
+	const events: StreamEvent[] = [];
+	let r = await gen.next();
+	while (!r.done) {
+		events.push(r.value);
+		r = await gen.next();
+	}
+	return { events, result: r.value };
+};
+
+const buildModule = () => {
+	const module = new A2AModule();
+	// biome-ignore lint/suspicious/noExplicitAny: reach into private state for the test
+	(module as any).a2aConnectors.set("analysis-agent", {
+		name: "analysis-agent",
+		url: "http://fake",
+	});
+	return module;
+};
+
+describe("A2AModule retry behaviour", () => {
+	let errorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		errorSpy = jest.spyOn(loggers.a2a, "error").mockReturnValue(loggers.a2a);
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	it("sendTask retries once and returns the second attempt's result", async () => {
+		const module = buildModule();
+		const sendSpy = jest
+			// biome-ignore lint/suspicious/noExplicitAny: private method
+			.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementationOnce(failingStream)
+			.mockImplementationOnce(successStream);
+
+		const { result } = await drain(
+			module.sendTask({
+				connectorName: "analysis-agent",
+				message: "analyze",
+				threadId: THREAD_ID,
+			}),
+		);
+
+		expect(result).toBe("[Bot Called A2A Tool analysis-agent]\nanalysis result");
+		expect(sendSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("sendTask propagates the error when the retry also fails", async () => {
+		const module = buildModule();
+		const sendSpy = jest
+			// biome-ignore lint/suspicious/noExplicitAny: private method
+			.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementation(failingStream);
+
+		await expect(
+			drain(
+				module.sendTask({
+					connectorName: "analysis-agent",
+					message: "analyze",
+					threadId: THREAD_ID,
+				}),
+			),
+		).rejects.toThrow("boom: stream idle timeout");
+		expect(sendSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs the actual error message instead of an empty object", async () => {
+		const module = buildModule();
+		// biome-ignore lint/suspicious/noExplicitAny: private method
+		jest.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementation(failingStream);
+
+		await drain(
+			module.sendTask({
+				connectorName: "analysis-agent",
+				message: "analyze",
+				threadId: THREAD_ID,
+			}),
+		).catch(() => {});
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				error: expect.stringContaining("boom: stream idle timeout"),
+			}),
+		);
+	});
+
+	it("drops the stale A2A task mapping before retrying", async () => {
+		const module = buildModule();
+		// biome-ignore lint/suspicious/noExplicitAny: private state
+		(module as any).a2aTasks.set(THREAD_ID, "broken-task");
+		// biome-ignore lint/suspicious/noExplicitAny: private method
+		jest.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementation(failingStream);
+
+		await drain(
+			module.sendTask({
+				connectorName: "analysis-agent",
+				message: "analyze",
+				threadId: THREAD_ID,
+			}),
+		).catch(() => {});
+
+		// biome-ignore lint/suspicious/noExplicitAny: private state
+		expect((module as any).a2aTasks.has(THREAD_ID)).toBe(false);
+	});
+
+	it("useTool retries but returns a marked error string with the real message", async () => {
+		const module = buildModule();
+		const tool: ConnectorTool = {
+			connectorName: "analysis-agent",
+			toolName: "analysis-agent",
+			protocol: CONNECTOR_PROTOCOL_TYPE.A2A,
+			description: "",
+			// biome-ignore lint/suspicious/noExplicitAny: minimal tool stub
+		} as any;
+		const sendSpy = jest
+			// biome-ignore lint/suspicious/noExplicitAny: private method
+			.spyOn(module as any, "sendMessageToConnector")
+			.mockImplementation(failingStream);
+
+		const { result } = await drain(
+			module.useTool(tool, "analyze", THREAD_ID),
+		);
+
+		expect(sendSpy).toHaveBeenCalledTimes(2);
+		expect(result).toContain("[Bot Called A2A Tool analysis-agent]");
+		expect(result).toContain("boom: stream idle timeout");
+		expect(result).not.toContain("{}");
+	});
+});

--- a/tests/request-context-wiring.test.ts
+++ b/tests/request-context-wiring.test.ts
@@ -1,0 +1,40 @@
+import request from "supertest";
+import { AINAgent } from "@/index";
+import type { AuthModule, MemoryModule, ModelModule } from "@/modules";
+
+function fakeModules() {
+	const authModule = {
+		authenticate: async () => ({ isAuthenticated: true, userId: "u1" }),
+	} as unknown as AuthModule;
+	const modelModule = {} as unknown as ModelModule;
+	const memoryModule = {
+		getDocumentMemory: () => undefined,
+		getUserWorkflowMemory: () => undefined,
+		getScheduleRunMemory: () => undefined,
+		initialize: async () => undefined,
+	} as unknown as MemoryModule;
+	return { authModule, modelModule, memoryModule };
+}
+
+describe("AINAgent request-context wiring", () => {
+	it("assigns a request id to every request via the X-Request-Id header", async () => {
+		const agent = new AINAgent(
+			{ name: "test-agent", description: "test" },
+			fakeModules(),
+		);
+		const res = await request(agent.app).get("/");
+		expect(res.status).toBe(200);
+		expect(res.headers["x-request-id"]).toBeDefined();
+	});
+
+	it("reuses the client-provided request id", async () => {
+		const agent = new AINAgent(
+			{ name: "test-agent", description: "test" },
+			fakeModules(),
+		);
+		const res = await request(agent.app)
+			.get("/")
+			.set("X-Request-Id", "upstream-1");
+		expect(res.headers["x-request-id"]).toBe("upstream-1");
+	});
+});

--- a/tests/services/a2a-task-start-log.test.ts
+++ b/tests/services/a2a-task-start-log.test.ts
@@ -1,0 +1,48 @@
+import { A2AService } from "@/services/a2a.service";
+import type { QueryService } from "@/services/query.service";
+import { loggers } from "@/utils/logger";
+
+const makeRequestContext = () =>
+	({
+		userMessage: {
+			kind: "message",
+			messageId: "m1",
+			role: "user",
+			contextId: "thread-e2bee4bd",
+			metadata: { agentId: "agent-1", type: "CHAT" },
+			parts: [{ kind: "text", text: "analyze daily sales" }],
+		},
+		task: undefined,
+		// biome-ignore lint/suspicious/noExplicitAny: minimal A2A SDK stub
+	}) as any;
+
+describe("A2AService task start logging", () => {
+	it("logs task receipt before query handling starts, so a hang leaves a trace", async () => {
+		const infoSpy = jest
+			.spyOn(loggers.server, "info")
+			.mockReturnValue(loggers.server);
+
+		let handleQueryCalled = false;
+		const queryService = {
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			handleQuery: (..._args: any[]) => {
+				handleQueryCalled = true;
+				expect(infoSpy).toHaveBeenCalledWith(
+					expect.stringContaining("started"),
+					expect.objectContaining({ threadId: "thread-e2bee4bd" }),
+				);
+				return (async function* () {
+					yield { event: "text_chunk", data: { delta: "ok" } };
+				})();
+			},
+		} as unknown as QueryService;
+
+		const service = new A2AService(queryService);
+		const eventBus = { publish: jest.fn() };
+		// biome-ignore lint/suspicious/noExplicitAny: minimal event bus stub
+		await service.execute(makeRequestContext(), eventBus as any);
+
+		expect(handleQueryCalled).toBe(true);
+		infoSpy.mockRestore();
+	});
+});

--- a/tests/utils/intercept-console.test.ts
+++ b/tests/utils/intercept-console.test.ts
@@ -62,6 +62,25 @@ describe("interceptConsole", () => {
 		expect(console.log).toBe(patched);
 	});
 
+	it("does not recurse when the mirror path itself writes to the console", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		const consoleLogger = interceptConsole();
+		if (!consoleLogger) throw new Error("unreachable");
+
+		// Simulate winston/transport error handling calling console.error
+		// from inside the mirror write — without a guard this recurses
+		// until the stack overflows.
+		const errorSpy = jest
+			.spyOn(consoleLogger, "error")
+			.mockImplementation((() => {
+				console.error("transport failure");
+				return consoleLogger;
+			}) as never);
+
+		expect(() => console.error("original failure")).not.toThrow();
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("restoreConsole puts the original console back", () => {
 		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
 		interceptConsole();

--- a/tests/utils/intercept-console.test.ts
+++ b/tests/utils/intercept-console.test.ts
@@ -1,0 +1,72 @@
+import { interceptConsole, restoreConsole } from "@/utils/logger";
+
+describe("interceptConsole", () => {
+	const originalLog = console.log;
+	const originalPath = process.env.LOG_FILE_PATH;
+
+	afterEach(() => {
+		restoreConsole();
+		if (originalPath === undefined) delete process.env.LOG_FILE_PATH;
+		else process.env.LOG_FILE_PATH = originalPath;
+	});
+
+	it("does nothing when LOG_FILE_PATH is not set", () => {
+		delete process.env.LOG_FILE_PATH;
+		expect(interceptConsole()).toBeUndefined();
+		expect(console.log).toBe(originalLog);
+	});
+
+	it("routes console output to a winston logger while keeping stdout", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		const consoleLogger = interceptConsole();
+		expect(consoleLogger).toBeDefined();
+		if (!consoleLogger) throw new Error("unreachable");
+
+		const infoSpy = jest
+			.spyOn(consoleLogger, "info")
+			.mockReturnValue(consoleLogger);
+		const warnSpy = jest
+			.spyOn(consoleLogger, "warn")
+			.mockReturnValue(consoleLogger);
+
+		console.log("server started on port", 8080);
+		console.warn("careful");
+
+		expect(infoSpy).toHaveBeenCalledWith("server started on port 8080");
+		expect(warnSpy).toHaveBeenCalledWith("careful");
+	});
+
+	it("renders non-string arguments readably instead of [object Object]", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		const consoleLogger = interceptConsole();
+		if (!consoleLogger) throw new Error("unreachable");
+		const infoSpy = jest
+			.spyOn(consoleLogger, "info")
+			.mockReturnValue(consoleLogger);
+
+		console.log("config:", { port: 8080 });
+
+		expect(infoSpy).toHaveBeenCalledWith(
+			expect.stringContaining("port: 8080"),
+		);
+		expect(infoSpy).not.toHaveBeenCalledWith(
+			expect.stringContaining("[object Object]"),
+		);
+	});
+
+	it("is idempotent: a second call does not stack wrappers", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		interceptConsole();
+		const patched = console.log;
+		expect(interceptConsole()).toBeUndefined();
+		expect(console.log).toBe(patched);
+	});
+
+	it("restoreConsole puts the original console back", () => {
+		process.env.LOG_FILE_PATH = "/tmp/ain-adk-test-log";
+		interceptConsole();
+		expect(console.log).not.toBe(originalLog);
+		restoreConsole();
+		expect(console.log).toBe(originalLog);
+	});
+});

--- a/tests/utils/logger-context.test.ts
+++ b/tests/utils/logger-context.test.ts
@@ -2,6 +2,7 @@ import {
 	injectRequestContext,
 	logFileExtension,
 	resolveLogFormat,
+	serializeErrorValues,
 	textLogFormat,
 } from "@/utils/logger";
 import { runWithRequestContext } from "@/utils/request-context";
@@ -84,6 +85,30 @@ describe("textLogFormat", () => {
 			service: "Intent",
 		});
 		expect(info[MESSAGE]).toBe("12:00:00 [Intent] info: hello");
+	});
+});
+
+describe("serializeErrorValues", () => {
+	it("turns Error meta values into their stack string instead of {}", () => {
+		const info = transform(serializeErrorValues(), {
+			level: "error",
+			message: "Error communicating with agent:",
+			error: new Error("stream idle timeout"),
+		});
+		expect(typeof info.error).toBe("string");
+		expect(info.error).toContain("stream idle timeout");
+		expect(info.error).toContain("at "); // stack frames survive
+	});
+
+	it("leaves non-Error values untouched", () => {
+		const info = transform(serializeErrorValues(), {
+			level: "info",
+			message: "hello",
+			error: "already a string",
+			count: 3,
+		});
+		expect(info.error).toBe("already a string");
+		expect(info.count).toBe(3);
 	});
 });
 

--- a/tests/utils/logger-context.test.ts
+++ b/tests/utils/logger-context.test.ts
@@ -1,0 +1,135 @@
+import {
+	injectRequestContext,
+	logFileExtension,
+	resolveLogFormat,
+	textLogFormat,
+} from "@/utils/logger";
+import { runWithRequestContext } from "@/utils/request-context";
+
+const MESSAGE = Symbol.for("message");
+
+type TransformedInfo = Record<string | symbol, unknown>;
+
+const transform = (
+	format: { transform: (info: never) => unknown },
+	info: Record<string, unknown>,
+): TransformedInfo => {
+	const result = format.transform({ ...info } as never);
+	if (!result || typeof result === "boolean") {
+		throw new Error("format dropped the log entry");
+	}
+	return result as TransformedInfo;
+};
+
+describe("injectRequestContext", () => {
+	it("adds requestId, userId and threadId from the ambient context", () => {
+		runWithRequestContext(
+			{ requestId: "req-1", userId: "user-1", threadId: "thread-1" },
+			() => {
+				const info = transform(injectRequestContext(), {
+					level: "info",
+					message: "hello",
+				});
+				expect(info.requestId).toBe("req-1");
+				expect(info.userId).toBe("user-1");
+				expect(info.threadId).toBe("thread-1");
+			},
+		);
+	});
+
+	it("does not override values passed explicitly at the call site", () => {
+		runWithRequestContext(
+			{ requestId: "req-1", threadId: "ctx-thread" },
+			() => {
+				const info = transform(injectRequestContext(), {
+					level: "info",
+					message: "hello",
+					threadId: "explicit-thread",
+				});
+				expect(info.threadId).toBe("explicit-thread");
+			},
+		);
+	});
+
+	it("leaves the entry unchanged outside of a context", () => {
+		const info = transform(injectRequestContext(), {
+			level: "info",
+			message: "hello",
+		});
+		expect(info.requestId).toBeUndefined();
+	});
+});
+
+describe("textLogFormat", () => {
+	it("prefixes a short request id and keeps it out of the meta JSON", () => {
+		const info = transform(textLogFormat, {
+			level: "info",
+			message: "hello",
+			timestamp: "12:00:00",
+			service: "Intent",
+			requestId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+			threadId: "thread-1",
+		});
+		const line = info[MESSAGE] as string;
+		expect(line).toBe(
+			'12:00:00 [Intent] [req:abcd1234] info: hello | {"threadId":"thread-1"}',
+		);
+	});
+
+	it("keeps the original shape when there is no request id", () => {
+		const info = transform(textLogFormat, {
+			level: "info",
+			message: "hello",
+			timestamp: "12:00:00",
+			service: "Intent",
+		});
+		expect(info[MESSAGE]).toBe("12:00:00 [Intent] info: hello");
+	});
+});
+
+describe("resolveLogFormat", () => {
+	const originalFormat = process.env.LOG_FORMAT;
+
+	afterEach(() => {
+		if (originalFormat === undefined) delete process.env.LOG_FORMAT;
+		else process.env.LOG_FORMAT = originalFormat;
+	});
+
+	it("defaults file output to json and console output to text", () => {
+		delete process.env.LOG_FORMAT;
+		expect(resolveLogFormat("file")).toBe("json");
+		expect(resolveLogFormat("console")).toBe("text");
+	});
+
+	it("honours LOG_FORMAT as an override for both outputs", () => {
+		process.env.LOG_FORMAT = "text";
+		expect(resolveLogFormat("file")).toBe("text");
+		process.env.LOG_FORMAT = "json";
+		expect(resolveLogFormat("console")).toBe("json");
+	});
+});
+
+describe("logFileExtension", () => {
+	const originalFormat = process.env.LOG_FORMAT;
+
+	afterEach(() => {
+		if (originalFormat === undefined) delete process.env.LOG_FORMAT;
+		else process.env.LOG_FORMAT = originalFormat;
+	});
+
+	it("appends .jsonl to rotated files when file output is json", () => {
+		delete process.env.LOG_FORMAT;
+		expect(logFileExtension("logs/debug-log")).toBe(".jsonl");
+	});
+
+	it("adds nothing in text mode, keeping legacy file names", () => {
+		process.env.LOG_FORMAT = "text";
+		expect(logFileExtension("logs/debug-log")).toBe("");
+	});
+
+	it("adds nothing when the path already carries a json extension", () => {
+		delete process.env.LOG_FORMAT;
+		expect(logFileExtension("logs/app.jsonl")).toBe("");
+		expect(logFileExtension("logs/app.json")).toBe("");
+	});
+});

--- a/tests/utils/logger-file-integration.test.ts
+++ b/tests/utils/logger-file-integration.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getLogger } from "@/utils/logger";
+import { runWithRequestContext } from "@/utils/request-context";
+
+// Pins the composed format chain end-to-end: real DailyRotateFile
+// transport, JSON mode, context injection and Error serialization all at
+// once — the individual format units are tested elsewhere, but ordering
+// bugs only show up in the composition.
+describe("file logging integration", () => {
+	const originalPath = process.env.LOG_FILE_PATH;
+	let dir: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), "adk-log-itest-"));
+		process.env.LOG_FILE_PATH = path.join(dir, "itest-log");
+	});
+
+	afterEach(() => {
+		if (originalPath === undefined) delete process.env.LOG_FILE_PATH;
+		else process.env.LOG_FILE_PATH = originalPath;
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("writes a parseable .jsonl line carrying context and a real error string", async () => {
+		const logger = getLogger("ITest");
+		runWithRequestContext({ requestId: "req-int-1", userId: "u1" }, () => {
+			logger.error("integration line", { error: new Error("real cause") });
+		});
+
+		let lastLine = "";
+		const deadline = Date.now() + 4000;
+		while (Date.now() < deadline) {
+			const files = fs.readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+			if (files.length > 0) {
+				const content = fs.readFileSync(path.join(dir, files[0]), "utf8");
+				if (content.includes("integration line")) {
+					lastLine = content.trim().split("\n").at(-1) ?? "";
+					break;
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		logger.close();
+
+		expect(lastLine).not.toBe("");
+		const parsed = JSON.parse(lastLine);
+		expect(parsed).toMatchObject({
+			level: "error",
+			message: "integration line",
+			service: "ITest",
+			requestId: "req-int-1",
+			userId: "u1",
+		});
+		expect(typeof parsed.timestamp).toBe("string");
+		expect(typeof parsed.error).toBe("string");
+		expect(parsed.error).toContain("real cause");
+	});
+});

--- a/tests/utils/request-context.test.ts
+++ b/tests/utils/request-context.test.ts
@@ -1,0 +1,51 @@
+import {
+	getRequestContext,
+	runWithRequestContext,
+	updateRequestContext,
+} from "@/utils/request-context";
+
+describe("request-context", () => {
+	it("returns undefined outside of a context", () => {
+		expect(getRequestContext()).toBeUndefined();
+	});
+
+	it("exposes the context inside runWithRequestContext", () => {
+		runWithRequestContext({ requestId: "req-1" }, () => {
+			expect(getRequestContext()).toEqual({ requestId: "req-1" });
+		});
+	});
+
+	it("keeps the context across await boundaries", async () => {
+		await runWithRequestContext({ requestId: "req-async" }, async () => {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			expect(getRequestContext()?.requestId).toBe("req-async");
+		});
+	});
+
+	it("isolates concurrent contexts from each other", async () => {
+		const seen: string[] = [];
+		const task = (id: string, delay: number) =>
+			runWithRequestContext({ requestId: id }, async () => {
+				await new Promise((resolve) => setTimeout(resolve, delay));
+				seen.push(getRequestContext()?.requestId ?? "lost");
+			});
+		await Promise.all([task("req-a", 10), task("req-b", 1)]);
+		expect(seen.sort()).toEqual(["req-a", "req-b"]);
+	});
+
+	it("merges values into the current context with updateRequestContext", () => {
+		runWithRequestContext({ requestId: "req-2" }, () => {
+			updateRequestContext({ userId: "user-1", threadId: "thread-1" });
+			expect(getRequestContext()).toEqual({
+				requestId: "req-2",
+				userId: "user-1",
+				threadId: "thread-1",
+			});
+		});
+	});
+
+	it("is a no-op when updating outside of a context", () => {
+		expect(() => updateRequestContext({ userId: "user-x" })).not.toThrow();
+		expect(getRequestContext()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## 개요

동시 요청 환경에서 로그가 뒤섞여 추적 불가능한 문제를 해결하고, A2A 에러 처리 결함(에러가 `{}`로 소실, 실패가 completed로 둔갑)을 함께 수정합니다. 커밋 5개, 상세는 각 커밋 메시지 참조.

## 주요 동작

- **로그 상관관계**: 모든 로그 라인에 requestId/userId/threadId 자동 주입(콜사이트 무수정). 콘솔 `[req:xxxxxxxx]` 프리픽스, 파일은 JSON lines(.jsonl). 수신 `X-Request-Id` 재사용. 스케줄러 잡은 runId 사용.
- **HTTP 접근로그**: 요청 완료마다 method/path/status/durationMs 1줄. 클라이언트가 포기한 요청도 `aborted: true`로 기록.
- **A2A 에러 처리**: 실제 메시지+스택 로깅. 이벤트를 하나도 못 받은 실패(조용한 행)만 1회 재시도 — 이미 이벤트가 전달된 실패는 재시도 시 원격 이중 실행·이벤트 중복이 생기므로 즉시 실패 처리. 워크플로우 태스크는 `failed`로 기록, 대화형 경로는 에러 내용을 모델에 반환.
- **A2A `Task started` 로그**: 첫 await 전에 기록 — "요청이 안 왔다 vs 와서 멈췄다" 구분 가능.
- **interceptConsole 배선**: 시작/종료 배너가 로그 파일에 남음(멱등성·재귀 가드·util.inspect).

## 배포 주의사항

- `LOG_FILE_PATH` 사용 시 파일 출력이 JSON lines(.jsonl)로 변경. `LOG_FORMAT=text`로 롤백 가능(단, 접근로그 등 새 라인은 추가됨).
- 확장자 변경으로 audit 파일이 재생성되어 기존 `debug-log.2026-*` 파일은 보존기간 삭제에서 제외됨 → 배포 시 호스트별 1회 수동 삭제 필요.
- 다운스트림(local-agents 등)은 `rm -rf node_modules && pnpm install` 필요.

## 테스트

신규 테스트 41개(TDD), 전체 264개/37 스위트 통과, 빌드(ESM/CJS) 성공. 코드리뷰(Critical 0, Important 5) 반영 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)