### PR TITLE
feat: 목록 API 페이지네이션 — limit/offset 봉투, 날짜 범위 필터, summary view

### DIFF
--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -179,7 +179,9 @@ export class DocumentApiController {
 				return true;
 			});
 		}
-		items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		items.sort((a, b) =>
+			String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")),
+		);
 		const total = items.length;
 		if (options.limit !== undefined || options.offset) {
 			const start = options.offset ?? 0;

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -10,11 +10,15 @@ import {
 	type Document,
 	type DocumentAutoRefresh,
 	type DocumentFilter,
+	type DocumentFilterSet,
 	DocumentFormat,
+	type DocumentListOptions,
 	type DocumentSlot,
 	DocumentSource,
 } from "@/types/document.js";
+import type { PaginatedResult } from "@/types/list.js";
 import { parseAutoRefreshPayload } from "@/utils/auto-refresh-payload.js";
+import { parseListOptions } from "@/utils/parse-list-options.js";
 import { streamEventsToSSE } from "@/utils/sse-stream.js";
 
 export class DocumentApiController {
@@ -66,54 +70,129 @@ export class DocumentApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const documentMemory = this.memoryModule.getDocumentMemory();
-			const { workflowId, threadId, source, labels } = req.query as {
-				workflowId?: string;
-				threadId?: string;
-				source?: DocumentSource;
-				labels?: Record<string, string>;
-			};
+			const { workflowId, threadId, source, labels, dateFrom, dateTo, view } =
+				req.query as {
+					workflowId?: string;
+					threadId?: string;
+					source?: DocumentSource;
+					labels?: Record<string, string>;
+					dateFrom?: string;
+					dateTo?: string;
+					view?: string;
+				};
 			const baseFilter: DocumentFilter = {
 				workflowId,
 				threadId,
 				source,
 				labels,
+				dateFrom: typeof dateFrom === "string" ? dateFrom : undefined,
+				dateTo: typeof dateTo === "string" ? dateTo : undefined,
 			};
+			const listOptions = parseListOptions(
+				req.query as Record<string, unknown>,
+			);
+			const options: DocumentListOptions = {
+				...(listOptions ?? {}),
+				summary: view === "summary",
+			};
+
+			// RBAC scopes as an OR-set of (userId, filter) pairs. Single query
+			// (when the provider supports it) keeps skip/limit/count correct.
 			const authzFilters = res.locals.authzFilters as
 				| DocumentFilter[]
 				| undefined;
-
-			let documents: Document[];
+			let filterSets: DocumentFilterSet[];
 			if (res.locals.authzListAll) {
-				// admin / unrestricted
-				documents =
-					(await documentMemory?.listDocuments(undefined, baseFilter)) ?? [];
+				filterSets = [{ filter: baseFilter }];
 			} else if (authzFilters?.length) {
-				// own documents ∪ records each read-role permits (cross-user)
-				const own =
-					(await documentMemory?.listDocuments(userId, baseFilter)) ?? [];
-				const sets = await Promise.all(
-					authzFilters.map((f) =>
-						documentMemory?.listDocuments(undefined, {
+				filterSets = [
+					{ userId, filter: baseFilter },
+					...authzFilters.map((f) => ({
+						filter: {
 							...baseFilter,
 							labels: { ...(labels ?? {}), ...(f.labels ?? {}) },
-						}),
-					),
-				);
-				const byId = new Map<string, Document>();
-				for (const d of [own, ...sets].flat()) {
-					if (d) byId.set(d.documentId, d);
-				}
-				documents = [...byId.values()];
+						},
+					})),
+				];
 			} else {
-				// no authz (legacy) or no cross-user access → own documents only
-				documents =
-					(await documentMemory?.listDocuments(userId, baseFilter)) ?? [];
+				filterSets = [{ userId, filter: baseFilter }];
 			}
-			res.json(documents);
+
+			const { items, total } = await this.listDocumentsBySets(
+				documentMemory,
+				filterSets,
+				options,
+			);
+
+			if (listOptions) {
+				const body: PaginatedResult<Document> = {
+					items,
+					total,
+					limit: listOptions.limit,
+					offset: listOptions.offset,
+				};
+				res.json(body);
+			} else {
+				res.json(items);
+			}
 		} catch (error) {
 			next(error);
 		}
 	};
+
+	/**
+	 * Union of the filter sets via the provider's single-query method when
+	 * available; otherwise per-set fetch merged in memory. The fallback also
+	 * emulates date range, summary and offset/limit so old providers stay
+	 * correct (just slower).
+	 */
+	private async listDocumentsBySets(
+		memory: ReturnType<MemoryModule["getDocumentMemory"]>,
+		filterSets: DocumentFilterSet[],
+		options: DocumentListOptions,
+	): Promise<{ items: Document[]; total: number }> {
+		if (!memory) return { items: [], total: 0 };
+
+		if (memory.listDocumentsAny) {
+			const items = await memory.listDocumentsAny(filterSets, options);
+			const total =
+				options.limit !== undefined && memory.countDocumentsAny
+					? await memory.countDocumentsAny(filterSets)
+					: items.length;
+			return { items, total };
+		}
+
+		const sets = await Promise.all(
+			filterSets.map((s) => memory.listDocuments(s.userId, s.filter)),
+		);
+		const byId = new Map<string, Document>();
+		for (const d of sets.flat()) byId.set(d.documentId, d);
+
+		const { dateFrom, dateTo } = filterSets[0]?.filter ?? {};
+		let items = [...byId.values()];
+		if (dateFrom || dateTo) {
+			items = items.filter((d) => {
+				const date = d.labels?.date;
+				if (!date) return false;
+				if (dateFrom && date < dateFrom) return false;
+				if (dateTo && date > dateTo) return false;
+				return true;
+			});
+		}
+		items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		const total = items.length;
+		if (options.limit !== undefined || options.offset) {
+			const start = options.offset ?? 0;
+			items = items.slice(
+				start,
+				options.limit !== undefined ? start + options.limit : undefined,
+			);
+		}
+		if (options.summary) {
+			items = items.map(({ slots: _slots, ...rest }) => rest as Document);
+		}
+		return { items, total };
+	}
 
 	public handleGetDocument = async (
 		req: Request,

--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -179,8 +179,10 @@ export class DocumentApiController {
 				return true;
 			});
 		}
-		items.sort((a, b) =>
-			String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")),
+		items.sort(
+			(a, b) =>
+				String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")) ||
+				b.documentId.localeCompare(a.documentId),
 		);
 		const total = items.length;
 		if (options.limit !== undefined || options.offset) {

--- a/src/controllers/api/user-workflow.api.controller.ts
+++ b/src/controllers/api/user-workflow.api.controller.ts
@@ -5,7 +5,9 @@ import type { UserWorkflowService } from "@/services/user-workflow.service.js";
 import type { UserWorkflowCoordinatorService } from "@/services/user-workflow-coordinator.service.js";
 import type { WorkflowExecutionService } from "@/services/workflow-execution.service.js";
 import { AinHttpError } from "@/types/agent.js";
+import type { PaginatedResult } from "@/types/list.js";
 import { MessageRole, type UserWorkflow } from "@/types/memory.js";
+import { parseListOptions } from "@/utils/parse-list-options.js";
 import { streamEventsToSSE } from "@/utils/sse-stream.js";
 
 export class UserWorkflowApiController {
@@ -38,14 +40,44 @@ export class UserWorkflowApiController {
 	}
 
 	public handleGetAllWorkflows = async (
-		_req: Request,
+		req: Request,
 		res: Response,
 		next: NextFunction,
 	) => {
 		try {
 			const userId = res.locals.userId || "";
-			const workflows = await this.userWorkflowService.listWorkflows(userId);
-			res.json(workflows);
+			const listOptions = parseListOptions(
+				req.query as Record<string, unknown>,
+			);
+			if (!listOptions) {
+				res.json(await this.userWorkflowService.listWorkflows(userId));
+				return;
+			}
+			const [fetched, count] = await Promise.all([
+				this.userWorkflowService.listWorkflows(userId, listOptions),
+				this.userWorkflowService.countWorkflows(userId),
+			]);
+			let items = fetched;
+			let total = count;
+			if (total === undefined) {
+				// Legacy provider ignored the options and returned everything —
+				// emulate the same sort/slice contract here.
+				const sorted = [...fetched].sort((a, b) =>
+					(b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+				);
+				total = sorted.length;
+				items = sorted.slice(
+					listOptions.offset,
+					listOptions.offset + listOptions.limit,
+				);
+			}
+			const body: PaginatedResult<UserWorkflow> = {
+				items,
+				total,
+				limit: listOptions.limit,
+				offset: listOptions.offset,
+			};
+			res.json(body);
 		} catch (error) {
 			next(error);
 		}

--- a/src/controllers/api/user-workflow.api.controller.ts
+++ b/src/controllers/api/user-workflow.api.controller.ts
@@ -62,8 +62,13 @@ export class UserWorkflowApiController {
 			if (total === undefined) {
 				// Legacy provider ignored the options and returned everything —
 				// emulate the same sort/slice contract here.
-				const sorted = [...fetched].sort((a, b) =>
-					(b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+				const updatedAtMs = (w: UserWorkflow): number => {
+					if (!w.updatedAt) return 0;
+					const t = new Date(w.updatedAt).getTime();
+					return Number.isNaN(t) ? 0 : t;
+				};
+				const sorted = [...fetched].sort(
+					(a, b) => updatedAtMs(b) - updatedAtMs(a),
 				);
 				total = sorted.length;
 				items = sorted.slice(

--- a/src/controllers/api/user-workflow.api.controller.ts
+++ b/src/controllers/api/user-workflow.api.controller.ts
@@ -68,7 +68,9 @@ export class UserWorkflowApiController {
 					return Number.isNaN(t) ? 0 : t;
 				};
 				const sorted = [...fetched].sort(
-					(a, b) => updatedAtMs(b) - updatedAtMs(a),
+					(a, b) =>
+						updatedAtMs(b) - updatedAtMs(a) ||
+						b.workflowId.localeCompare(a.workflowId),
 				);
 				total = sorted.length;
 				items = sorted.slice(

--- a/src/modules/memory/base.memory.ts
+++ b/src/modules/memory/base.memory.ts
@@ -1,4 +1,11 @@
-import type { Document, DocumentFilter, DocumentSlot } from "@/types/document";
+import type {
+	Document,
+	DocumentFilter,
+	DocumentFilterSet,
+	DocumentListOptions,
+	DocumentSlot,
+} from "@/types/document";
+import type { ListOptions } from "@/types/list";
 import type {
 	Intent,
 	MessageObject,
@@ -116,7 +123,18 @@ export interface IUserWorkflowMemory {
 		workflow: Partial<UserWorkflow>,
 	): Promise<void>;
 	deleteUserWorkflow(workflowId: string, userId: string): Promise<void>;
-	listUserWorkflows(userId?: string): Promise<UserWorkflow[]>;
+	/**
+	 * When `options` is given, implementations sort by `updatedAt` desc and
+	 * apply offset/limit at the store. Implementations that also provide
+	 * countUserWorkflows are trusted to honor `options`; without it the
+	 * controller re-sorts/slices in memory (legacy providers ignore options).
+	 */
+	listUserWorkflows(
+		userId?: string,
+		options?: ListOptions,
+	): Promise<UserWorkflow[]>;
+	/** Total workflows for the user. Ships with ListOptions support above. */
+	countUserWorkflows?(userId?: string): Promise<number>;
 	/** List all active scheduled workflows across all users (used by scheduler) */
 	listActiveScheduledWorkflows(): Promise<UserWorkflow[]>;
 }
@@ -148,6 +166,18 @@ export interface IDocumentMemory {
 	): Promise<void>;
 	deleteDocument(documentId: string): Promise<void>;
 	listDocuments(userId?: string, filter?: DocumentFilter): Promise<Document[]>;
+	/**
+	 * Union (OR) of filter sets in a single query, sorted `updatedAt` desc.
+	 * Enables correct DB-level skip/limit/count across RBAC scopes. Optional:
+	 * when absent the controller falls back to per-set listDocuments plus
+	 * in-memory merge/sort/slice.
+	 */
+	listDocumentsAny?(
+		filters: DocumentFilterSet[],
+		options?: DocumentListOptions,
+	): Promise<Document[]>;
+	/** Total count for the union of filter sets. Ships with listDocumentsAny. */
+	countDocumentsAny?(filters: DocumentFilterSet[]): Promise<number>;
 	/** Documents with an active, incomplete autoRefresh (used by the scheduler). */
 	listAutoRefreshPendingDocuments?(): Promise<Document[]>;
 	/** Atomically append a slot to autoRefresh.doneSlotIds ($addToSet semantics). */

--- a/src/services/user-workflow.service.ts
+++ b/src/services/user-workflow.service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { MemoryModule } from "@/modules/index.js";
+import type { ListOptions } from "@/types/list.js";
 import type { UserWorkflow } from "@/types/memory.js";
 import type { WorkflowVariableResolver } from "./workflow-variable-resolver.service.js";
 
@@ -75,9 +76,18 @@ export class UserWorkflowService {
 		return memory.getUserWorkflow(workflowId);
 	}
 
-	async listWorkflows(userId?: string): Promise<UserWorkflow[]> {
+	async listWorkflows(
+		userId?: string,
+		options?: ListOptions,
+	): Promise<UserWorkflow[]> {
 		const memory = this.memoryModule.getUserWorkflowMemory();
-		return memory.listUserWorkflows(userId);
+		return memory.listUserWorkflows(userId, options);
+	}
+
+	/** undefined = provider has no count support (legacy). */
+	async countWorkflows(userId?: string): Promise<number | undefined> {
+		const memory = this.memoryModule.getUserWorkflowMemory();
+		return memory.countUserWorkflows?.(userId);
 	}
 
 	async listActiveScheduledWorkflows(): Promise<UserWorkflow[]> {

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,3 +1,4 @@
+import type { ListOptions } from "./list.js";
 import type { WorkflowRenderedBlock } from "./memory.js";
 
 /**
@@ -161,4 +162,24 @@ export type DocumentFilter = {
 	threadId?: string;
 	source?: DocumentSource;
 	labels?: Record<string, string | string[]>;
+	/**
+	 * Inclusive range over `labels.date` (YYYY-MM-DD strings — lexicographic
+	 * order equals chronological order, so bounds like `2026-02-31` are safe).
+	 */
+	dateFrom?: string;
+	dateTo?: string;
 };
+
+/** One (userId, filter) scope; a list query is the union (OR) of its sets. */
+export type DocumentFilterSet = {
+	userId?: string;
+	filter?: DocumentFilter;
+};
+
+export type DocumentListOptions = ListOptions & {
+	/** Omit heavy fields (`slots`) from returned documents. */
+	summary?: boolean;
+};
+
+/** List-view shape returned by `view=summary` — `slots` omitted. */
+export type DocumentSummary = Omit<Document, "slots">;

--- a/src/types/list.ts
+++ b/src/types/list.ts
@@ -1,0 +1,16 @@
+/** Pagination options for list queries (`?limit=&offset=`). */
+export interface ListOptions {
+	limit?: number;
+	offset?: number;
+}
+
+/**
+ * Envelope returned by list endpoints when the request carries `limit`.
+ * Requests without `limit` get the legacy bare array instead.
+ */
+export interface PaginatedResult<T> {
+	items: T[];
+	total: number;
+	limit: number;
+	offset: number;
+}

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -482,4 +482,7 @@ export interface UserWorkflow {
 	nextRunAt?: number;
 	/** Thread ID of the last execution result */
 	lastThreadId?: string;
+
+	/** ISO 8601 timestamp of the last update (used for sorting in list endpoints) */
+	updatedAt?: string;
 }

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -483,6 +483,14 @@ export interface UserWorkflow {
 	/** Thread ID of the last execution result */
 	lastThreadId?: string;
 
-	/** ISO 8601 timestamp of the last update (used for sorting in list endpoints) */
+	/**
+	 * ISO 8601 timestamp of the last update (used for sorting in list endpoints).
+	 * Typed as `string`, but the mongodb provider stores this via mongoose
+	 * `timestamps: true`, so at runtime it can be a `Date` instance (it only
+	 * serializes to an ISO string once it crosses HTTP as JSON). Treat as
+	 * `string | Date` when consuming this field in-process; comparators that
+	 * sort on it should coerce (e.g. `String(x.updatedAt ?? "")`) rather than
+	 * assume `.localeCompare` is available.
+	 */
 	updatedAt?: string;
 }

--- a/src/utils/parse-list-options.ts
+++ b/src/utils/parse-list-options.ts
@@ -1,0 +1,26 @@
+import type { ListOptions } from "@/types/list.js";
+
+export const MAX_LIST_LIMIT = 100;
+
+/**
+ * Parses `?limit=&offset=` into pagination options.
+ *
+ * Returns undefined when `limit` is absent or unparseable — the caller then
+ * serves the legacy bare-array response. Garbage never 400s: pagination is
+ * an opt-in enhancement, not a validation surface.
+ */
+export function parseListOptions(
+	query: Record<string, unknown>,
+): Required<ListOptions> | undefined {
+	if (typeof query.limit !== "string" || query.limit === "") return undefined;
+	const limit = Number(query.limit);
+	if (!Number.isFinite(limit)) return undefined;
+	const rawOffset = typeof query.offset === "string" ? Number(query.offset) : 0;
+	const offset = Number.isFinite(rawOffset)
+		? Math.max(0, Math.floor(rawOffset))
+		: 0;
+	return {
+		limit: Math.min(Math.max(1, Math.floor(limit)), MAX_LIST_LIMIT),
+		offset,
+	};
+}

--- a/tests/controllers/document-authz.test.ts
+++ b/tests/controllers/document-authz.test.ts
@@ -15,9 +15,9 @@ function res(locals: Record<string, unknown>): Response {
 
 describe("DocumentApiController authz", () => {
 	it("list: uses authzFilters — own ∪ each filter, merged/deduped", async () => {
-		const ownDoc = { documentId: "own-1", userId: "u1" };
-		const logbookDoc = { documentId: "lb-1", userId: "other" };
-		const sharedDoc = { documentId: "shared", userId: "u1" };
+		const ownDoc = { documentId: "own-1", userId: "u1", updatedAt: "2026-08-01T00:00:00.000Z" };
+		const logbookDoc = { documentId: "lb-1", userId: "other", updatedAt: "2026-08-02T00:00:00.000Z" };
+		const sharedDoc = { documentId: "shared", userId: "u1", updatedAt: "2026-08-03T00:00:00.000Z" };
 		// First call (own): returns ownDoc + sharedDoc; second call (filter): returns logbookDoc + sharedDoc
 		const listDocuments = jest
 			.fn()

--- a/tests/controllers/document-list.test.ts
+++ b/tests/controllers/document-list.test.ts
@@ -113,17 +113,24 @@ describe("handleGetAllDocuments", () => {
 			doc("old", { updatedAt: "2026-08-01T00:00:00.000Z" }),
 			doc("new", { updatedAt: "2026-08-03T00:00:00.000Z" }),
 			doc("mid", { updatedAt: "2026-08-02T00:00:00.000Z" }),
+			// Pins null/Date-safety: a missing updatedAt must not throw in the
+			// legacy in-memory sort fallback, and should sort last (treated as "").
+			doc("none", { updatedAt: undefined as never }),
 		];
 		const controller = makeController({ listDocuments: async () => docs });
 		const res = mockRes();
 		await controller.handleGetAllDocuments(
-			mockReq({ limit: "2", offset: "0" }),
+			mockReq({ limit: "3", offset: "1" }),
 			res,
 			next,
 		);
 		const body = res._json as { items: Document[]; total: number };
-		expect(body.total).toBe(3);
-		expect(body.items.map((d) => d.documentId)).toEqual(["new", "mid"]);
+		expect(body.total).toBe(4);
+		expect(body.items.map((d) => d.documentId)).toEqual([
+			"mid",
+			"old",
+			"none",
+		]);
 	});
 
 	it("legacy provider + view=summary → slots stripped", async () => {

--- a/tests/controllers/document-list.test.ts
+++ b/tests/controllers/document-list.test.ts
@@ -1,0 +1,170 @@
+import type { NextFunction, Request, Response } from "express";
+import { DocumentApiController } from "@/controllers/api/document.api.controller";
+import type { MemoryModule } from "@/modules/index";
+import type { Document } from "@/types/document";
+import { DocumentSource } from "@/types/document";
+
+function doc(id: string, over: Partial<Document> = {}): Document {
+	return {
+		documentId: id,
+		userId: "u1",
+		title: id,
+		content: "",
+		source: DocumentSource.MANUAL,
+		version: 1,
+		createdAt: "2026-08-01T00:00:00.000Z",
+		updatedAt: "2026-08-01T00:00:00.000Z",
+		slots: [{ slotId: "s1" }],
+		...over,
+	} as Document;
+}
+
+function makeController(docMemory: object) {
+	const memoryModule = {
+		getDocumentMemory: () => docMemory,
+	} as unknown as MemoryModule;
+	return new DocumentApiController(
+		memoryModule,
+		{} as never,
+		{} as never,
+		{} as never,
+	);
+}
+
+function mockRes(): Response & { _json?: unknown } {
+	const res: any = { locals: { userId: "u1" } };
+	res.json = (b: unknown) => {
+		res._json = b;
+		return res;
+	};
+	res.status = () => res;
+	return res;
+}
+
+function mockReq(query: Record<string, unknown> = {}): Request {
+	return { query, params: {} } as unknown as Request;
+}
+
+const next: NextFunction = (err?: unknown) => {
+	if (err) throw err;
+};
+
+describe("handleGetAllDocuments", () => {
+	it("no limit + legacy provider → bare array", async () => {
+		const controller = makeController({
+			listDocuments: async () => [doc("a"), doc("b")],
+		});
+		const res = mockRes();
+		await controller.handleGetAllDocuments(mockReq(), res, next);
+		expect(Array.isArray(res._json)).toBe(true);
+		expect((res._json as Document[]).map((d) => d.documentId)).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("limit + capable provider → envelope with provider results", async () => {
+		const listDocumentsAny = jest.fn(async () => [doc("a")]);
+		const countDocumentsAny = jest.fn(async () => 42);
+		const controller = makeController({ listDocumentsAny, countDocumentsAny });
+		const res = mockRes();
+		await controller.handleGetAllDocuments(
+			mockReq({ limit: "15", offset: "30", view: "summary" }),
+			res,
+			next,
+		);
+		expect(res._json).toEqual({
+			items: [doc("a")],
+			total: 42,
+			limit: 15,
+			offset: 30,
+		});
+		expect(listDocumentsAny).toHaveBeenCalledWith(
+			[{ userId: "u1", filter: expect.any(Object) }],
+			{ limit: 15, offset: 30, summary: true },
+		);
+	});
+
+	it("builds one filter set per authz scope with merged labels", async () => {
+		const listDocumentsAny = jest.fn(async () => []);
+		const controller = makeController({
+			listDocumentsAny,
+			countDocumentsAny: async () => 0,
+		});
+		const res = mockRes();
+		res.locals.authzFilters = [{ labels: { workplace: "seoul" } }];
+		await controller.handleGetAllDocuments(
+			mockReq({ labels: { category: "logbook" } }),
+			res,
+			next,
+		);
+		const sets = listDocumentsAny.mock.calls[0][0];
+		expect(sets).toHaveLength(2);
+		expect(sets[0].userId).toBe("u1");
+		expect(sets[1].userId).toBeUndefined();
+		expect(sets[1].filter.labels).toEqual({
+			category: "logbook",
+			workplace: "seoul",
+		});
+	});
+
+	it("legacy provider + limit → in-memory sort desc, slice, honest total", async () => {
+		const docs = [
+			doc("old", { updatedAt: "2026-08-01T00:00:00.000Z" }),
+			doc("new", { updatedAt: "2026-08-03T00:00:00.000Z" }),
+			doc("mid", { updatedAt: "2026-08-02T00:00:00.000Z" }),
+		];
+		const controller = makeController({ listDocuments: async () => docs });
+		const res = mockRes();
+		await controller.handleGetAllDocuments(
+			mockReq({ limit: "2", offset: "0" }),
+			res,
+			next,
+		);
+		const body = res._json as { items: Document[]; total: number };
+		expect(body.total).toBe(3);
+		expect(body.items.map((d) => d.documentId)).toEqual(["new", "mid"]);
+	});
+
+	it("legacy provider + view=summary → slots stripped", async () => {
+		const controller = makeController({
+			listDocuments: async () => [doc("a")],
+		});
+		const res = mockRes();
+		await controller.handleGetAllDocuments(
+			mockReq({ view: "summary" }),
+			res,
+			next,
+		);
+		expect((res._json as Document[])[0]).not.toHaveProperty("slots");
+	});
+
+	it("legacy provider + date range → filtered in memory", async () => {
+		const controller = makeController({
+			listDocuments: async () => [
+				doc("jul", { labels: { date: "2026-07-31" } }),
+				doc("aug", { labels: { date: "2026-08-01" } }),
+				doc("nodate"),
+			],
+		});
+		const res = mockRes();
+		await controller.handleGetAllDocuments(
+			mockReq({ dateFrom: "2026-08-01", dateTo: "2026-08-31" }),
+			res,
+			next,
+		);
+		expect((res._json as Document[]).map((d) => d.documentId)).toEqual([
+			"aug",
+		]);
+	});
+
+	it("authz union in legacy path dedupes by documentId", async () => {
+		const controller = makeController({
+			listDocuments: async () => [doc("dup")],
+		});
+		const res = mockRes();
+		res.locals.authzFilters = [{ labels: { workplace: "seoul" } }];
+		await controller.handleGetAllDocuments(mockReq(), res, next);
+		expect(res._json as Document[]).toHaveLength(1);
+	});
+});

--- a/tests/controllers/document-list.test.ts
+++ b/tests/controllers/document-list.test.ts
@@ -57,9 +57,11 @@ describe("handleGetAllDocuments", () => {
 		const res = mockRes();
 		await controller.handleGetAllDocuments(mockReq(), res, next);
 		expect(Array.isArray(res._json)).toBe(true);
+		// equal updatedAt → documentId desc tiebreaker keeps ordering
+		// deterministic across requests (page-boundary stability)
 		expect((res._json as Document[]).map((d) => d.documentId)).toEqual([
-			"a",
 			"b",
+			"a",
 		]);
 	});
 

--- a/tests/controllers/user-workflow-list.test.ts
+++ b/tests/controllers/user-workflow-list.test.ts
@@ -68,7 +68,7 @@ describe("handleGetAllWorkflows", () => {
 			listWorkflows: async () => [
 				wf("old", "2026-08-01"),
 				wf("new", "2026-08-03"),
-				wf("mid", "2026-08-02"),
+				{ workflowId: "mid", userId: "u1", updatedAt: new Date("2026-08-02") } as UserWorkflow,
 			],
 			countWorkflows: async () => undefined,
 		});

--- a/tests/controllers/user-workflow-list.test.ts
+++ b/tests/controllers/user-workflow-list.test.ts
@@ -1,0 +1,85 @@
+import type { NextFunction, Request, Response } from "express";
+import { UserWorkflowApiController } from "@/controllers/api/user-workflow.api.controller";
+import type { UserWorkflow } from "@/types/memory";
+
+function wf(id: string, updatedAt: string): UserWorkflow {
+	return { workflowId: id, userId: "u1", updatedAt } as UserWorkflow;
+}
+
+function makeController(service: object) {
+	return new UserWorkflowApiController(
+		service as never,
+		{} as never,
+		{} as never,
+		{} as never,
+	);
+}
+
+function mockRes(): Response & { _json?: unknown } {
+	const res: any = { locals: { userId: "u1" } };
+	res.json = (b: unknown) => {
+		res._json = b;
+		return res;
+	};
+	return res;
+}
+
+const next: NextFunction = (err?: unknown) => {
+	if (err) throw err;
+};
+
+describe("handleGetAllWorkflows", () => {
+	it("no limit → bare array (legacy)", async () => {
+		const controller = makeController({
+			listWorkflows: async () => [wf("a", "2026-08-01")],
+		});
+		const res = mockRes();
+		await controller.handleGetAllWorkflows(
+			{ query: {} } as unknown as Request,
+			res,
+			next,
+		);
+		expect(Array.isArray(res._json)).toBe(true);
+	});
+
+	it("limit + count-capable provider → envelope, options passed through", async () => {
+		const listWorkflows = jest.fn(async () => [wf("a", "2026-08-01")]);
+		const controller = makeController({
+			listWorkflows,
+			countWorkflows: async () => 7,
+		});
+		const res = mockRes();
+		await controller.handleGetAllWorkflows(
+			{ query: { limit: "5", offset: "10" } } as unknown as Request,
+			res,
+			next,
+		);
+		expect(res._json).toEqual({
+			items: [wf("a", "2026-08-01")],
+			total: 7,
+			limit: 5,
+			offset: 10,
+		});
+		expect(listWorkflows).toHaveBeenCalledWith("u1", { limit: 5, offset: 10 });
+	});
+
+	it("limit + legacy provider (no count) → in-memory sort/slice, honest total", async () => {
+		const controller = makeController({
+			listWorkflows: async () => [
+				wf("old", "2026-08-01"),
+				wf("new", "2026-08-03"),
+				wf("mid", "2026-08-02"),
+			],
+			countWorkflows: async () => undefined,
+		});
+		const res = mockRes();
+		await controller.handleGetAllWorkflows(
+			{ query: { limit: "2", offset: "0" } } as unknown as Request,
+			res,
+			next,
+		);
+		const body = res._json as { items: UserWorkflow[]; total: number };
+		expect(body.total).toBe(3);
+		expect(body.items.map((w) => w.workflowId)).toEqual(["new", "mid"]);
+	});
+});

--- a/tests/utils/parse-list-options.test.ts
+++ b/tests/utils/parse-list-options.test.ts
@@ -1,0 +1,51 @@
+import {
+	MAX_LIST_LIMIT,
+	parseListOptions,
+} from "@/utils/parse-list-options";
+
+describe("parseListOptions", () => {
+	it("returns undefined when limit is absent (legacy bare-array path)", () => {
+		expect(parseListOptions({})).toBeUndefined();
+		expect(parseListOptions({ offset: "10" })).toBeUndefined();
+	});
+
+	it("parses limit and offset", () => {
+		expect(parseListOptions({ limit: "15", offset: "30" })).toEqual({
+			limit: 15,
+			offset: 30,
+		});
+	});
+
+	it("defaults offset to 0", () => {
+		expect(parseListOptions({ limit: "15" })).toEqual({ limit: 15, offset: 0 });
+	});
+
+	it("clamps limit to [1, MAX_LIST_LIMIT] and floors decimals", () => {
+		expect(parseListOptions({ limit: "0" })).toEqual({ limit: 1, offset: 0 });
+		expect(parseListOptions({ limit: "-5" })).toEqual({ limit: 1, offset: 0 });
+		expect(parseListOptions({ limit: "9999" })).toEqual({
+			limit: MAX_LIST_LIMIT,
+			offset: 0,
+		});
+		expect(parseListOptions({ limit: "10.9" })).toEqual({ limit: 10, offset: 0 });
+	});
+
+	it("clamps negative offset to 0", () => {
+		expect(parseListOptions({ limit: "10", offset: "-3" })).toEqual({
+			limit: 10,
+			offset: 0,
+		});
+	});
+
+	it("returns undefined on unparseable limit", () => {
+		expect(parseListOptions({ limit: "abc" })).toBeUndefined();
+		expect(parseListOptions({ limit: ["10"] as never })).toBeUndefined();
+	});
+
+	it("ignores unparseable offset", () => {
+		expect(parseListOptions({ limit: "10", offset: "abc" })).toEqual({
+			limit: 10,
+			offset: 0,
+		});
+	});
+});


### PR DESCRIPTION
## 개요

목록 엔드포인트(document, user-workflow)에 하위호환 페이지네이션을 도입합니다.
로그북/Documents 화면이 전 기간 문서를 본문(slots)까지 통째로 받아오던 페이로드 문제의 서버측 해결입니다.

## 변경 사항

- **공통 규약**: `ListOptions`/`PaginatedResult<T>` 타입 + `parseListOptions` 유틸 (limit `[1,100]` 클램프, 파싱 불가 값은 무시)
  - 응답 봉투 `{items, total, limit, offset}`는 **요청에 `limit` 파라미터가 있을 때만** — 없으면 기존 bare array 그대로 (배포된 클라이언트 무영향)
- **DocumentFilter 확장**: `dateFrom`/`dateTo` (`labels.date` YYYY-MM-DD 포함 범위, 사전순=날짜순)
- **신규 타입**: `DocumentFilterSet`, `DocumentListOptions`, `DocumentSummary`
- **메모리 인터페이스** (optional — 기존 provider 안 깨짐): `IDocumentMemory.listDocumentsAny/countDocumentsAny`, `IUserWorkflowMemory.listUserWorkflows(options)/countUserWorkflows`
- **document 컨트롤러**: RBAC 3분기(union+dedupe)를 필터셋 배열로 단일화 → provider가 지원하면 DB 레벨 skip/limit/count, 미지원(구 provider)이면 인메모리 폴백(날짜 필터·정렬·slice·summary 스트립, 정확한 total)
- **user-workflow 컨트롤러**: 동일 봉투 규약 + 레거시 폴백
- **정렬 안정성**: `updatedAt desc` + `documentId`/`workflowId` desc tiebreaker (동일 updatedAt 문서의 페이지 경계 중복/누락 방지), Date/null-safe comparator

## 동작 변화 (의도됨)

- `limit` 없는 문서 목록 응답도 이제 `updatedAt desc`로 정렬되어 반환됩니다. 현재 소비자(wise 두 페이지)는 모두 클라이언트에서 재정렬하므로 무영향입니다.

## 테스트

- `pnpm test` 281/281 (신규: parseListOptions 7, document 컨트롤러 8, user-workflow 컨트롤러 3)
- 공유 dev Mongo 대상 스모크: 봉투/summary(-slots)/날짜범위/count 실데이터 검증 완료