### PR TITLE
Feat/text block present mode

### DIFF
--- a/src/services/workflow-response-composer.service.ts
+++ b/src/services/workflow-response-composer.service.ts
@@ -10,7 +10,14 @@ import type {
 	WorkflowTextBlock,
 } from "@/types/memory.js";
 import type { StreamEvent } from "@/types/stream.js";
+import { loggers } from "@/utils/logger.js";
 import { serializeTaskResults } from "@/utils/workflow-task-results.js";
+
+const GENERATE_TEXT_SYSTEM_PROMPT =
+	"Generate ONLY the new text described in Instructions. Task results and already-rendered blocks are reference context — never restate, echo, or repeat them in your output.";
+
+const PRESENT_TEXT_SYSTEM_PROMPT =
+	"Present the provided source content as directed by Instructions. The source content is your material: reorganize and format it exactly the way Instructions ask. Do not add facts or numbers that are not in the source content, and keep numbers and units exactly as written unless Instructions say otherwise.";
 
 export class WorkflowResponseComposer {
 	private modelModule: ModelModule;
@@ -70,11 +77,28 @@ export class WorkflowResponseComposer {
 			};
 		}
 
+		if (
+			block.mode === "present" &&
+			!this.hasPresentableSource(block, taskResults, renderedBlocks)
+		) {
+			loggers.agent.warn(
+				"Present-mode text block has no source content; rendering empty block",
+				{ blockId: block.blockId },
+			);
+			return {
+				blockId: block.blockId,
+				type: block.type,
+				content: "",
+			};
+		}
+
 		const content = yield* this.renderGeneratedTextBlock(
 			block,
 			taskResults,
 			renderedBlocks,
-			"Generate ONLY the new text described in Instructions. Task results and already-rendered blocks are reference context — never restate, echo, or repeat them in your output.",
+			block.mode === "present"
+				? PRESENT_TEXT_SYSTEM_PROMPT
+				: GENERATE_TEXT_SYSTEM_PROMPT,
 		);
 
 		const finalContent = content.endsWith("\n\n") ? content : `${content}\n\n`;
@@ -196,26 +220,48 @@ export class WorkflowResponseComposer {
 		taskResults: WorkflowTaskResult[],
 		renderedBlocks: WorkflowRenderedBlock[],
 	): string {
+		const present = block.mode === "present";
 		const sections: string[] = [];
 
 		if (taskResults.length > 0) {
 			sections.push(
-				`Task results (reference context — do not restate):\n${serializeTaskResults(taskResults)}`,
+				present
+					? `Source content (task results):\n${serializeTaskResults(taskResults)}`
+					: `Task results (reference context — do not restate):\n${serializeTaskResults(taskResults)}`,
 			);
 		}
 
 		const blocksText = this.serializeRenderedBlocks(renderedBlocks);
 		if (blocksText) {
 			sections.push(
-				`Already-rendered blocks (reference context — do not repeat):\n${blocksText}`,
+				present
+					? `Source content (rendered blocks):\n${blocksText}`
+					: `Already-rendered blocks (reference context — do not repeat):\n${blocksText}`,
 			);
 		}
 
 		sections.push(
-			`Instructions:\n${block.prompt}\n\nOutput only the new text described above. Do not include any reference context.`,
+			present
+				? `Instructions:\n${block.prompt}`
+				: `Instructions:\n${block.prompt}\n\nOutput only the new text described above. Do not include any reference context.`,
 		);
 
 		return sections.join("\n\n");
+	}
+
+	private hasPresentableSource(
+		block: WorkflowTextBlock,
+		taskResults: Record<string, WorkflowTaskResult>,
+		renderedBlocks: WorkflowRenderedBlock[],
+	): boolean {
+		const results = this.getSourceTaskResults(block, taskResults);
+		if (results.some((result) => result.content?.trim())) {
+			return true;
+		}
+		const blocksText = this.serializeRenderedBlocks(
+			this.getSourceRenderedBlocks(block, renderedBlocks),
+		);
+		return blocksText.length > 0;
 	}
 
 	private getSourceRenderedBlocks(

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -211,6 +211,13 @@ export interface WorkflowTextBlock {
 	blockId: string;
 	type: "text";
 	prompt: string;
+	/**
+	 * Absent/"generate": write new commentary; source context must not be
+	 * restated. "present": source content is the output material — the block
+	 * prompt controls how it is organized; facts absent from the source must
+	 * not be added.
+	 */
+	mode?: "generate" | "present";
 	sourceTaskIds?: string[];
 	sourceBlockIds?: string[];
 }

--- a/src/utils/attached-documents.ts
+++ b/src/utils/attached-documents.ts
@@ -9,8 +9,8 @@ const ATTACHED_DOCUMENTS_FOOTER = `---
 
 /**
  * Collects attached document ids for the current turn: ids recorded on
- * earlier messages' `metadata.documentIds` (chronological), then the current
- * request's ids. Deduped, order-preserving.
+ * earlier messages' `metadata.documentIds` / `metadata.documentId`
+ * (chronological), then the current request's ids. Deduped, order-preserving.
  */
 export function collectAttachedDocumentIds(
 	thread: ThreadObject,
@@ -29,6 +29,12 @@ export function collectAttachedDocumentIds(
 		if (Array.isArray(metaIds)) {
 			for (const id of metaIds) add(id);
 		}
+		// A workflow result message records its output document under the
+		// singular `documentId` (workflow-execution.service.ts) and stores the
+		// message itself as a reference-only document part. Treating it as an
+		// attachment is what lets follow-up turns discuss the workflow output —
+		// and it applies retroactively to threads written before this change.
+		add(message.metadata?.documentId);
 	}
 	for (const id of requestDocumentIds ?? []) add(id);
 	return ids;

--- a/src/utils/message-content.ts
+++ b/src/utils/message-content.ts
@@ -1,0 +1,46 @@
+import type { MessageObject } from "@/types/memory";
+
+/**
+ * Flattens a stored message's content into prompt text.
+ *
+ * `MessageContentObject.parts` is `unknown[]` and its shape depends on
+ * `content.type` — `"text"` holds plain strings, while `"rich"`/`"document"`
+ * hold {@link MessagePart} OBJECTS. Model providers must never hand one of
+ * those objects to a chat API as `content`: OpenAI-compatible endpoints reject
+ * the whole request with `400 Invalid type for 'messages[N].content'`, which
+ * breaks every later turn in the thread because the message is persisted.
+ *
+ * Document parts render as a short label only. The body is not inlined here —
+ * `injectAttachedDocuments` resolves it to fresh text once per turn, so
+ * embedding a (possibly stale) copy per history entry would duplicate it.
+ *
+ * Total function: returns `""` for empty, unknown or malformed content rather
+ * than leaking a non-string value.
+ */
+export function messageToPromptText(message: MessageObject): string {
+	const parts = message?.content?.parts;
+	if (!Array.isArray(parts)) return "";
+
+	const rendered: string[] = [];
+	for (const part of parts) {
+		if (typeof part === "string") {
+			if (part) rendered.push(part);
+			continue;
+		}
+		if (!part || typeof part !== "object") continue;
+
+		const { type, text, documentId, title } = part as Record<string, unknown>;
+		if (type === "text" && typeof text === "string") {
+			if (text) rendered.push(text);
+			continue;
+		}
+		if (type === "document" && typeof documentId === "string") {
+			const label =
+				typeof title === "string" && title.trim() ? title : documentId;
+			rendered.push(`[문서: ${label}]`);
+		}
+		// Unknown part shape: skipped on purpose — dropping a segment is
+		// recoverable, emitting an object is a hard 400.
+	}
+	return rendered.join("\n");
+}

--- a/tests/services/workflow-response-composer.service.test.ts
+++ b/tests/services/workflow-response-composer.service.test.ts
@@ -95,6 +95,72 @@ describe("WorkflowResponseComposer", () => {
 		expect(result.content).toBe("summary\n\n");
 	});
 
+	it("presents source content with the present-mode system prompt", async () => {
+		const generateMessages = jest.fn(({ query, systemPrompt }) => [
+			{ role: "user", query, systemPrompt },
+		]);
+		const modelModule = {
+			getModel: () => ({
+				generateMessages,
+				fetchStreamWithContextMessage: jest.fn(() => streamText("정리된 문장")),
+			}),
+			getModelOptions: () => ({}),
+		} as unknown as ModelModule;
+		const composer = new WorkflowResponseComposer(modelModule);
+
+		const { result } = await collectGenerator(
+			composer.renderResponseBlock(
+				{
+					blockId: "atoms",
+					type: "text",
+					mode: "present",
+					sourceTaskIds: ["task-1"],
+					prompt: "task-1의 분석 문장을 수치 그대로 불릿으로 정리",
+				},
+				taskResults,
+				[],
+			),
+		);
+
+		const call = generateMessages.mock.calls[0][0];
+		expect(call.systemPrompt).toContain("source content");
+		expect(call.systemPrompt).not.toContain("never restate");
+		expect(call.query).toContain("Source content (task results):");
+		expect(call.query).toContain("Sales data collected.");
+		expect(call.query).not.toContain("do not restate");
+		expect(call.query).not.toContain("Do not include any reference context");
+		expect(result.content).toBe("정리된 문장\n\n");
+	});
+
+	it("renders empty content without calling the model when a present-mode block has no source", async () => {
+		const generateMessages = jest.fn();
+		const modelModule = {
+			getModel: () => ({
+				generateMessages,
+				fetchStreamWithContextMessage: jest.fn(),
+			}),
+			getModelOptions: () => ({}),
+		} as unknown as ModelModule;
+		const composer = new WorkflowResponseComposer(modelModule);
+
+		const { result } = await collectGenerator(
+			composer.renderResponseBlock(
+				{
+					blockId: "atoms",
+					type: "text",
+					mode: "present",
+					sourceTaskIds: ["missing-task"],
+					prompt: "정리해 출력",
+				},
+				taskResults,
+				[],
+			),
+		);
+
+		expect(generateMessages).not.toHaveBeenCalled();
+		expect(result.content).toBe("");
+	});
+
 	it("includes referenced rendered table blocks when extracting graph data", async () => {
 		const generateMessages = jest.fn(({ query }) => [{ role: "user", query }]);
 		const modelModule = {

--- a/tests/utils/attached-documents.test.ts
+++ b/tests/utils/attached-documents.test.ts
@@ -84,6 +84,25 @@ describe("collectAttachedDocumentIds", () => {
 	it("returns empty for a thread with no attachments", () => {
 		expect(collectAttachedDocumentIds(makeThread())).toEqual([]);
 	});
+
+	// A workflow result message records its output document under the singular
+	// `documentId` key (workflow-execution.service.ts), not `documentIds` — so
+	// follow-up turns saw no attachment and the model lost the workflow output.
+	it("collects a workflow message's singular documentId", () => {
+		const thread = makeThread([
+			{ metadata: { workflowId: "w1", workflowRun: true, documentId: "doc-w" } },
+		]);
+		expect(collectAttachedDocumentIds(thread)).toEqual(["doc-w"]);
+	});
+
+	it("dedupes a singular documentId against plural ids and request ids", () => {
+		const thread = makeThread([
+			{ metadata: { documentIds: ["doc-a"] } },
+			{ metadata: { documentId: "doc-a" } },
+			{ metadata: { documentId: 42 } },
+		]);
+		expect(collectAttachedDocumentIds(thread, ["doc-a"])).toEqual(["doc-a"]);
+	});
 });
 
 describe("injectAttachedDocuments", () => {

--- a/tests/utils/message-content.test.ts
+++ b/tests/utils/message-content.test.ts
@@ -1,0 +1,72 @@
+import { MessageRole, type MessageObject } from "@/types/memory";
+import { messageToPromptText } from "@/utils/message-content";
+
+function makeMessage(
+	content: { type: string; parts: unknown[] },
+	metadata?: Record<string, unknown>,
+): MessageObject {
+	return {
+		messageId: "m1",
+		role: MessageRole.MODEL,
+		timestamp: 0,
+		content,
+		metadata,
+	} as unknown as MessageObject;
+}
+
+describe("messageToPromptText", () => {
+	it("returns the string part of a legacy text message unchanged", () => {
+		expect(
+			messageToPromptText(makeMessage({ type: "text", parts: ["안녕하세요"] })),
+		).toBe("안녕하세요");
+	});
+
+	// Regression: a workflow run persists { type: "rich", parts: [DocumentPart] }.
+	// Passing that object straight through as chat `content` made Azure reject the
+	// whole request with 400 "Invalid type for 'messages[N].content'".
+	it("renders a document part as a label, never an object", () => {
+		const text = messageToPromptText(
+			makeMessage({
+				type: "rich",
+				parts: [{ type: "document", documentId: "doc-1", title: "7월 리포트" }],
+			}),
+		);
+		expect(typeof text).toBe("string");
+		expect(text).toContain("7월 리포트");
+	});
+
+	it("falls back to the documentId when the document part has no title", () => {
+		const text = messageToPromptText(
+			makeMessage({
+				type: "document",
+				parts: [{ type: "document", documentId: "doc-9" }],
+			}),
+		);
+		expect(text).toContain("doc-9");
+	});
+
+	it("joins mixed text and document parts of a rich message in order", () => {
+		const text = messageToPromptText(
+			makeMessage({
+				type: "rich",
+				parts: [
+					{ type: "text", text: "결과입니다." },
+					{ type: "document", documentId: "doc-1", title: "리포트" },
+				],
+			}),
+		);
+		expect(text.indexOf("결과입니다.")).toBeLessThan(text.indexOf("리포트"));
+	});
+
+	it("returns a string for malformed or empty content instead of undefined", () => {
+		expect(messageToPromptText(makeMessage({ type: "text", parts: [] }))).toBe(
+			"",
+		);
+		expect(
+			messageToPromptText(makeMessage({ type: "rich", parts: [null, 42] })),
+		).toBe("");
+		expect(
+			messageToPromptText({ content: undefined } as unknown as MessageObject),
+		).toBe("");
+	});
+});


### PR DESCRIPTION
## Summary

Two related pieces of workflow-output handling:

1. **`present` mode for workflow text blocks** — lets a text block reorganize source content instead of writing new commentary about it.
2. **Safe history flattening for document messages** — stops rich/document message parts from being handed to chat APIs as `content`, and lets a workflow's output document stay attached across follow-up turns.

Both land on the path where a workflow renders a document and the user then keeps talking about it.

## 1. `present` mode for text blocks

`WorkflowTextBlock` gains `mode?: "generate" | "present"`. Absent or `"generate"` is the existing behaviour, unchanged — the block writes new text and the system prompt forbids restating task results or already-rendered blocks (anti-echo).

`mode: "present"` inverts that contract: the source content **is** the output material. The block prompt controls how it is organized and formatted, while the system prompt forbids adding facts or numbers absent from the source and requires numbers and units to be kept exactly as written unless the prompt says otherwise. The prompt sections are relabelled accordingly — what generate mode presents as `Task results (reference context — do not restate)` becomes `Source content (task results)`, and the "output only the new text, do not include any reference context" tail is dropped.

A present-mode block whose sources yield no content **renders empty and logs a warning** rather than calling the model. Without that guard, a present block with nothing to present is a direct invitation to fabricate — the one failure mode this mode is most exposed to.

## 2. Document messages in history and attachments

**`src/utils/message-content.ts` (new): `messageToPromptText(message)`.** `MessageContentObject.parts` is `unknown[]` whose shape depends on `content.type`: `"text"` holds plain strings, but `"rich"`/`"document"` hold part *objects*. Handing one of those objects to an OpenAI-compatible chat API as `content` makes it reject the entire request with `400 Invalid type for 'messages[N].content'` — and because the offending message is persisted, every later turn in that thread fails too, not just the one that produced it.

The helper is total: it returns `""` for empty, unknown or malformed content rather than leaking a non-string value, and skips unrecognized part shapes on purpose (dropping a segment is recoverable; emitting an object is a hard 400). Document parts render as a short label only — the body is deliberately not inlined, because `injectAttachedDocuments` already resolves it to fresh text once per turn, so embedding a copy per history entry would both duplicate it and risk serving a stale one.

**`collectAttachedDocumentIds` also reads singular `metadata.documentId`.** A workflow result message records its output document under `documentId` (see `workflow-execution.service.ts`) and stores the message itself as a reference-only document part. Collecting it as an attachment is what allows follow-up turns to discuss the workflow output. This applies retroactively: threads written before this change pick it up too, since it reads existing metadata rather than requiring new writes.

## Compatibility

- `mode` is optional; every existing text block keeps its current prompts and output verbatim.
- No schema migration. The attachment change reads metadata that workflow execution already writes.
- Behaviour change worth noting in review: threads that ran a workflow before this branch will now carry that output document into subsequent turns' context. That is the intent, but it does mean those turns see more context than they did yesterday.

## Verification

- Full suite: **294 tests / 42 suites pass**; `pnpm build` (dual ESM/CJS via tsup) succeeds.
- New coverage: `tests/utils/message-content.test.ts`, `tests/utils/attached-documents.test.ts`, and additions to `tests/services/workflow-response-composer.service.test.ts` — 20 tests across those three suites.
- Not covered by automated tests: the actual prompt quality of present mode. Whether a present block reorganizes faithfully is a model-behaviour question and needs a real workflow run to judge.

## Release ordering (blocks a downstream PR)

`ain-adk-providers#fix/model-history-object-content` imports `@ainetwork/adk/utils/message-content` to fix the same 400 in the azure and gemini providers. That module does not exist in the published `0.8.4`, and the provider packages declare `@ainetwork/adk: ^0.8.4`, so **this PR must merge and ship a release (0.8.5+) before those packages are published**, otherwise external consumers get an unresolvable import. Provider peer ranges need bumping to the new version as part of that release.
