### PR TITLE
feat(scheduler): record how a slot-refresh run derived its targets

### DIFF
--- a/src/services/scheduler.service.ts
+++ b/src/services/scheduler.service.ts
@@ -4,7 +4,9 @@ import type { MemoryModule } from "@/modules/memory/memory.module.js";
 import type { Document, DocumentAutoRefresh } from "@/types/document.js";
 import type { UserWorkflow } from "@/types/memory.js";
 import type {
+	ScheduleRunExclusion,
 	ScheduleRunSlotResult,
+	ScheduleRunTargeting,
 	ScheduleTrigger,
 } from "@/types/schedule.js";
 import { loggers } from "@/utils/logger.js";
@@ -369,15 +371,26 @@ export class SchedulerService {
 					status: "success",
 					finishedAt: Date.now(),
 					attempts: 0,
+					noopReason: autoRefresh?.completedAt
+						? "auto_refresh_completed"
+						: "auto_refresh_inactive",
 				});
 				return;
 			}
 
-			const done = new Set(autoRefresh.doneSlotIds ?? []);
-			const targetIds = this.getAutoRefreshTargetSlotIds(
-				document,
-				autoRefresh,
-			).filter((slotId) => !done.has(slotId));
+			// Persisted BEFORE the first slot job is submitted: a run killed by a
+			// restart mid-way still shows what it set out to cover, and a run
+			// covering fewer slots than the document has stops being silent.
+			const targeting = this.deriveAutoRefreshTargeting(document, autoRefresh);
+			const targetIds = targeting.targetSlotIds;
+			await scheduleRunMemory?.updateScheduleRun(runId, { targeting });
+			if (targeting.excluded.length > 0) {
+				loggers.agent.info("Auto-refresh skipped some document slots", {
+					documentId,
+					targetSlotIds: targetIds,
+					excluded: targeting.excluded,
+				});
+			}
 
 			if (targetIds.length === 0) {
 				await documentMemory.completeAutoRefresh?.(documentId, Date.now());
@@ -385,6 +398,7 @@ export class SchedulerService {
 					status: "success",
 					finishedAt: Date.now(),
 					attempts: 0,
+					noopReason: "no_pending_slots",
 				});
 				return;
 			}
@@ -493,9 +507,10 @@ export class SchedulerService {
 	}
 
 	/**
-	 * Target slot ids for a document's auto-refresh: an explicit allowlist, or
-	 * (default) every slot with a binding. Shared by {@link runAutoRefreshJob}
-	 * and {@link reconcileManualSlotFill} so the two stay in sync.
+	 * Candidate slot ids for a document's auto-refresh: an explicit allowlist,
+	 * or (default) every slot with a binding. Shared by
+	 * {@link deriveAutoRefreshTargeting} and {@link reconcileManualSlotFill} so
+	 * the two stay in sync.
 	 */
 	private getAutoRefreshTargetSlotIds(
 		document: Document,
@@ -505,6 +520,56 @@ export class SchedulerService {
 			.filter((slot) => slot.binding)
 			.map((slot) => slot.slotId);
 		return autoRefresh.slotIds ?? boundSlotIds;
+	}
+
+	/**
+	 * Expands {@link getAutoRefreshTargetSlotIds} into the derivation recorded
+	 * on the run: what the document offered, what this run will actually
+	 * submit, and every slot dropped along the way with its reason. Three
+	 * different filters can shrink the target set (no binding, an explicit
+	 * allowlist, the done ledger) and none of them left a trace before — a
+	 * 3-of-6 run and a genuine 3-slot run looked identical in storage.
+	 */
+	private deriveAutoRefreshTargeting(
+		document: Document,
+		autoRefresh: DocumentAutoRefresh,
+	): ScheduleRunTargeting {
+		const slots = document.slots ?? [];
+		const documentSlotIds = slots.map((slot) => slot.slotId);
+		const bound = new Set(
+			slots.filter((slot) => slot.binding).map((slot) => slot.slotId),
+		);
+		const candidates = this.getAutoRefreshTargetSlotIds(document, autoRefresh);
+		const candidateSet = new Set(candidates);
+		const done = new Set(autoRefresh.doneSlotIds ?? []);
+
+		const targetSlotIds: string[] = [];
+		const excluded: ScheduleRunExclusion[] = [];
+		for (const slotId of candidates) {
+			if (done.has(slotId)) {
+				excluded.push({ slotId, reason: "already_done" });
+			} else {
+				targetSlotIds.push(slotId);
+			}
+		}
+		// Slots the document carries that never became candidates at all.
+		for (const slotId of documentSlotIds) {
+			if (candidateSet.has(slotId)) continue;
+			excluded.push({
+				slotId,
+				reason: bound.has(slotId) ? "not_in_slot_ids" : "no_binding",
+			});
+		}
+
+		return {
+			documentSlotIds,
+			// Omitted rather than set to undefined: mongoose stores an explicit
+			// undefined as null, which does not match the optional string[] type
+			// that readers of the stored run see.
+			...(autoRefresh.slotIds ? { requestedSlotIds: autoRefresh.slotIds } : {}),
+			targetSlotIds,
+			excluded,
+		};
 	}
 
 	/**

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -16,6 +16,47 @@ export interface ScheduleRunSlotResult {
 	error?: string;
 }
 
+/** Why a slot on the document was left out of a run's target set. */
+export type ScheduleRunExclusionReason =
+	/** No binding, so the slot is not auto-refreshable at all. */
+	| "no_binding"
+	/** A bound slot dropped by an explicit `autoRefresh.slotIds` allowlist. */
+	| "not_in_slot_ids"
+	/** Already ledgered in `doneSlotIds` by an earlier run or a manual fill. */
+	| "already_done";
+
+export interface ScheduleRunExclusion {
+	slotId: string;
+	reason: ScheduleRunExclusionReason;
+}
+
+/**
+ * How a SLOT_REFRESH run derived its target slots, written before the slot
+ * jobs are submitted.
+ *
+ * `slotResults` alone cannot tell "the slot ran and failed" apart from "the
+ * slot was never a target": a run that silently covers 3 of a document's 6
+ * slots is indistinguishable from a clean 3-slot success. Recording the
+ * derivation makes that auditable after the fact, and — because it is
+ * persisted up front — it survives a run interrupted by a restart.
+ */
+export interface ScheduleRunTargeting {
+	/** Every slot on the document at run time, in document order. */
+	documentSlotIds: string[];
+	/** The explicit allowlist from `autoRefresh.slotIds`, when one was set. */
+	requestedSlotIds?: string[];
+	/** Slots submitted to the JobRunner — 1:1 with `slotResults`. */
+	targetSlotIds: string[];
+	/** Slots on the document this run did not touch, and why. */
+	excluded: ScheduleRunExclusion[];
+}
+
+/** Why a run finished successfully without submitting a single slot job. */
+export type ScheduleRunNoopReason =
+	| "auto_refresh_inactive"
+	| "auto_refresh_completed"
+	| "no_pending_slots";
+
 export interface ScheduleRun {
 	runId: string;
 	jobType: ScheduleJobType;
@@ -33,6 +74,10 @@ export interface ScheduleRun {
 	error?: string;
 	/** Per-slot outcomes (SLOT_REFRESH only). */
 	slotResults?: ScheduleRunSlotResult[];
+	/** How the target slot set was derived (SLOT_REFRESH only). */
+	targeting?: ScheduleRunTargeting;
+	/** Set when the run succeeded without doing any work. */
+	noopReason?: ScheduleRunNoopReason;
 }
 
 export interface ScheduleRunFilter {

--- a/tests/services/scheduler.service.test.ts
+++ b/tests/services/scheduler.service.test.ts
@@ -349,6 +349,111 @@ describe("SchedulerService — document auto refresh", () => {
 		expect(m.workflowExecutionService.fillDocumentSlot).toHaveBeenCalledWith("doc-1", "s2");
 	});
 
+	it("records how the target set was derived, with a reason per excluded slot", async () => {
+		const m = makeMocks();
+		m.documentMemory.getDocument.mockResolvedValue(makeLogbookDocument());
+		await m.scheduler.runAutoRefreshJob("doc-1", "once", Date.now());
+
+		expect(m.scheduleRunMemory.updateScheduleRun).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				targeting: {
+					documentSlotIds: ["s1", "s2", "no-binding"],
+					requestedSlotIds: undefined,
+					targetSlotIds: ["s1", "s2"],
+					excluded: [{ slotId: "no-binding", reason: "no_binding" }],
+				},
+			}),
+		);
+	});
+
+	it("records the targeting BEFORE any slot job runs, so an interrupted run keeps its plan", async () => {
+		const m = makeMocks();
+		m.documentMemory.getDocument.mockResolvedValue(makeLogbookDocument());
+		const order: string[] = [];
+		m.scheduleRunMemory.updateScheduleRun.mockImplementation(
+			async (_runId: string, patch: Record<string, unknown>) => {
+				order.push(patch.targeting ? "targeting" : "final");
+			},
+		);
+		m.workflowExecutionService.fillDocumentSlot.mockImplementation(async () => {
+			order.push("fill");
+			return {};
+		});
+		await m.scheduler.runAutoRefreshJob("doc-1", "once", Date.now());
+
+		expect(order[0]).toBe("targeting");
+		expect(order).toContain("fill");
+	});
+
+	it("records already_done exclusions when doneSlotIds narrows the set", async () => {
+		const m = makeMocks();
+		m.documentMemory.getDocument.mockResolvedValue(
+			makeLogbookDocument({
+				autoRefresh: { runAt: 0, active: true, doneSlotIds: ["s1"] },
+			}),
+		);
+		await m.scheduler.runAutoRefreshJob("doc-1", "catchup", Date.now());
+
+		expect(m.scheduleRunMemory.updateScheduleRun).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				targeting: expect.objectContaining({
+					targetSlotIds: ["s2"],
+					excluded: expect.arrayContaining([
+						{ slotId: "s1", reason: "already_done" },
+						{ slotId: "no-binding", reason: "no_binding" },
+					]),
+				}),
+			}),
+		);
+	});
+
+	it("records not_in_slot_ids exclusions when an explicit allowlist narrows the set", async () => {
+		const m = makeMocks();
+		m.documentMemory.getDocument.mockResolvedValue(
+			makeLogbookDocument({
+				autoRefresh: { runAt: 0, active: true, slotIds: ["s1"] },
+			}),
+		);
+		await m.scheduler.runAutoRefreshJob("doc-1", "once", Date.now());
+
+		expect(m.scheduleRunMemory.updateScheduleRun).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				targeting: expect.objectContaining({
+					requestedSlotIds: ["s1"],
+					targetSlotIds: ["s1"],
+					excluded: expect.arrayContaining([
+						{ slotId: "s2", reason: "not_in_slot_ids" },
+						{ slotId: "no-binding", reason: "no_binding" },
+					]),
+				}),
+			}),
+		);
+	});
+
+	it("labels a no-work success run with noopReason instead of a bare success", async () => {
+		const cases: Array<[Record<string, unknown>, string]> = [
+			[{ runAt: 0, active: false }, "auto_refresh_inactive"],
+			[{ runAt: 0, active: true, completedAt: 123 }, "auto_refresh_completed"],
+			[{ runAt: 0, active: true, doneSlotIds: ["s1", "s2"] }, "no_pending_slots"],
+		];
+		for (const [autoRefresh, noopReason] of cases) {
+			const m = makeMocks();
+			m.documentMemory.getDocument.mockResolvedValue(
+				makeLogbookDocument({ autoRefresh }),
+			);
+			await m.scheduler.runAutoRefreshJob("doc-1", "once", Date.now());
+
+			expect(m.workflowExecutionService.fillDocumentSlot).not.toHaveBeenCalled();
+			expect(m.scheduleRunMemory.updateScheduleRun).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ status: "success", noopReason }),
+			);
+		}
+	});
+
 	it("treats a resolving fill whose slot persisted 'failed' as a failed slot (no content produced)", async () => {
 		const m = makeMocks();
 		// fillDocumentSlot resolves for BOTH slots, but s2's persisted status is


### PR DESCRIPTION
A SLOT_REFRESH run stored only slotResults, so a run covering 3 of a document's 6 slots was indistinguishable from a genuine 3-slot success. The three filters that can shrink the target set — a slot with no binding, an explicit autoRefresh.slotIds allowlist, and the doneSlotIds ledger — all left no trace, which made a partial run untraceable after the fact.

Add ScheduleRun.targeting: the document's slots, the requested allowlist, the submitted targets, and every excluded slot with its reason (no_binding / not_in_slot_ids / already_done). It is persisted before the first slot job is submitted, so a run interrupted by a restart still records what it set out to cover.

Add ScheduleRun.noopReason to separate the three paths that finish "success" without submitting a single job: auto_refresh_inactive, auto_refresh_completed, no_pending_slots.