### PR TITLE
feat(scheduler): log why a slot fill started (schedule trigger vs manual)

### DIFF
--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -500,7 +500,11 @@ export class DocumentApiController {
 			const result = await this.workflowExecutionService.fillDocumentSlot(
 				id,
 				slotId,
-				{ workflowId, executionVariables },
+				{
+					workflowId,
+					executionVariables,
+					initiator: { type: "manual", userId },
+				},
 			);
 			// fillDocumentSlot throws on failure, so resolving here means the
 			// manual fill succeeded — reconcile it into the auto-refresh ledger
@@ -537,7 +541,11 @@ export class DocumentApiController {
 				return this.workflowExecutionService.fillDocumentSlotStream(
 					id,
 					slotId,
-					{ workflowId, executionVariables },
+					{
+						workflowId,
+						executionVariables,
+						initiator: { type: "manual", userId },
+					},
 					signal,
 				);
 			},

--- a/src/services/scheduler.service.ts
+++ b/src/services/scheduler.service.ts
@@ -185,6 +185,14 @@ export class SchedulerService {
 		try {
 			const scheduleRunMemory = this.memoryModule.getScheduleRunMemory();
 			const startedAt = Date.now();
+			// Catch-up runs fire at boot, far from the cron time they stand in
+			// for — record the planned time so the gap is explainable from logs.
+			loggers.agent.info("Scheduled workflow run starting", {
+				workflowId,
+				trigger,
+				scheduledFor: new Date(scheduledFor).toISOString(),
+				delayMs: startedAt - scheduledFor,
+			});
 			await scheduleRunMemory?.createScheduleRun({
 				runId,
 				jobType: "WORKFLOW",
@@ -344,13 +352,23 @@ export class SchedulerService {
 			const documentMemory = this.memoryModule.getDocumentMemory();
 			const scheduleRunMemory = this.memoryModule.getScheduleRunMemory();
 			if (!documentMemory) return;
+			const startedAt = Date.now();
+			// "once" fires within a tick of runAt; "catchup" is a boot/tick
+			// recovery of an already-passed runAt, so it starts at an arbitrary
+			// time — log the planned time and the gap to make that visible.
+			loggers.agent.info("Auto-refresh run starting", {
+				documentId,
+				trigger,
+				scheduledFor: new Date(scheduledFor).toISOString(),
+				delayMs: startedAt - scheduledFor,
+			});
 			await scheduleRunMemory?.createScheduleRun({
 				runId,
 				jobType: "SLOT_REFRESH",
 				jobKey: documentId,
 				trigger,
 				scheduledFor,
-				startedAt: Date.now(),
+				startedAt,
 				status: "running",
 				attempts: 0,
 			});
@@ -413,6 +431,9 @@ export class SchedulerService {
 							await this.workflowExecutionService.fillDocumentSlot(
 								documentId,
 								slotId,
+								{
+									initiator: { type: "schedule", trigger, scheduledFor, runId },
+								},
 							);
 						},
 					});

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -18,6 +18,7 @@ import {
 	type WorkflowTaskResult,
 	type WorkflowTemplate,
 } from "@/types/memory.js";
+import type { SlotFillInitiator } from "@/types/schedule.js";
 import type { StreamEvent } from "@/types/stream.js";
 import { renderDocument } from "@/utils/document-render.js";
 import { loggers } from "@/utils/logger.js";
@@ -640,6 +641,7 @@ export class WorkflowExecutionService {
 		options?: {
 			workflowId?: string;
 			executionVariables?: Record<string, string>;
+			initiator?: SlotFillInitiator;
 		},
 		signal?: AbortSignal,
 	): Promise<{ documentId: string; slotId: string; content: string }> {
@@ -669,6 +671,8 @@ export class WorkflowExecutionService {
 		options?: {
 			workflowId?: string;
 			executionVariables?: Record<string, string>;
+			/** Who initiated this fill; logged so unexpected fills are traceable. */
+			initiator?: SlotFillInitiator;
 		},
 		signal?: AbortSignal,
 	): AsyncGenerator<StreamEvent> {
@@ -722,6 +726,29 @@ export class WorkflowExecutionService {
 				`Workflow ${workflowId} has no structured definition; cannot fill slot`,
 			);
 		}
+
+		// Fills can fire long after their cause (boot catch-up, delayed tick), so
+		// name the initiator here — "the log stream suddenly shows a fill" must be
+		// answerable from this line alone.
+		const initiator = options?.initiator;
+		loggers.agent.info("Document slot fill started", {
+			documentId,
+			slotId,
+			workflowId,
+			workflowTitle: workflow.title,
+			initiatedBy: initiator?.type ?? "unknown",
+			...(initiator?.type === "schedule"
+				? {
+						scheduleTrigger: initiator.trigger,
+						scheduleRunId: initiator.runId,
+						scheduledFor: new Date(initiator.scheduledFor).toISOString(),
+						scheduleDelayMs: Date.now() - initiator.scheduledFor,
+					}
+				: {}),
+			...(initiator?.type === "manual" && initiator.userId
+				? { requestedBy: initiator.userId }
+				: {}),
+		});
 
 		await this.updateSlot(documentMemory, document, slotId, {
 			status: "running",

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -80,6 +80,23 @@ export interface ScheduleRun {
 	noopReason?: ScheduleRunNoopReason;
 }
 
+/**
+ * Who initiated a document slot fill. Carried into the fill's start log so a
+ * fill appearing at an unexpected time is traceable to its origin: a
+ * scheduled auto-refresh run (with the run's trigger and planned fire time)
+ * vs. a manual fill API call (with the requesting user).
+ */
+export type SlotFillInitiator =
+	| {
+			type: "schedule";
+			trigger: ScheduleTrigger;
+			/** When the run was originally scheduled to fire (epoch ms). */
+			scheduledFor: number;
+			/** The schedule run this fill belongs to. */
+			runId: string;
+	  }
+	| { type: "manual"; userId?: string };
+
 export interface ScheduleRunFilter {
 	jobType?: ScheduleJobType;
 	jobKey?: string;

--- a/tests/services/scheduler.service.test.ts
+++ b/tests/services/scheduler.service.test.ts
@@ -346,7 +346,16 @@ describe("SchedulerService — document auto refresh", () => {
 		);
 		await m.scheduler.runAutoRefreshJob("doc-1", "catchup", Date.now());
 		expect(m.workflowExecutionService.fillDocumentSlot).toHaveBeenCalledTimes(1);
-		expect(m.workflowExecutionService.fillDocumentSlot).toHaveBeenCalledWith("doc-1", "s2");
+		expect(m.workflowExecutionService.fillDocumentSlot).toHaveBeenCalledWith(
+			"doc-1",
+			"s2",
+			{
+				initiator: expect.objectContaining({
+					type: "schedule",
+					trigger: "catchup",
+				}),
+			},
+		);
 	});
 
 	it("records how the target set was derived, with a reason per excluded slot", async () => {


### PR DESCRIPTION
## 배경

로그북 슬롯 fill이 예약 시각과 무관한 시간에 로그에 나타나도(예: 08-12 21:44) 그 실행이 **왜** 시작됐는지 알 수 있는 로그가 없었습니다. 조사 결과 해당 건은 스케쥴러가 아니라 수동 fill API 호출이었지만, 이를 판별하는 데 로거의 request-context 주입 동작까지 역추적이 필요했습니다.

## 변경 내용

- **스케쥴러 run-start 로그**: 워크플로우/오토리프레시 런 시작 시 `trigger`(cron/once/catchup), 원래 예약 시각(`scheduledFor`), 지연(`delayMs`)을 info로 기록. runId가 `[req:...]` 상관 ID로 이어집니다.
- **`fillDocumentSlot(Stream)`에 `initiator` 옵션 추가** (`SlotFillInitiator`, `types/schedule.ts`): fill 시작 시 `Document slot fill started` 로그에 `initiatedBy: schedule | manual | unknown`과 상세(스케쥴: trigger/runId/scheduledFor/delay, 수동: 요청 userId)를 남깁니다.
- fill API 엔드포인트(일반/스트림)는 `manual + userId`를, 스케쥴러는 자기 스케쥴 컨텍스트를 전달.

## 테스트

- `pnpm test` 299/299 통과 (스케쥴러 테스트 1건은 새 initiator 인자를 기대하도록 갱신)
- `pnpm build`, biome 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)