### PR TITLE
feat(document): let the list narrow to the caller's own documents

### DIFF
--- a/src/controllers/api/document.api.controller.ts
+++ b/src/controllers/api/document.api.controller.ts
@@ -70,16 +70,25 @@ export class DocumentApiController {
 		try {
 			const userId = res.locals.userId || "";
 			const documentMemory = this.memoryModule.getDocumentMemory();
-			const { workflowId, threadId, source, labels, dateFrom, dateTo, view } =
-				req.query as {
-					workflowId?: string;
-					threadId?: string;
-					source?: DocumentSource;
-					labels?: Record<string, string>;
-					dateFrom?: string;
-					dateTo?: string;
-					view?: string;
-				};
+			const {
+				workflowId,
+				threadId,
+				source,
+				labels,
+				dateFrom,
+				dateTo,
+				view,
+				mine,
+			} = req.query as {
+				workflowId?: string;
+				threadId?: string;
+				source?: DocumentSource;
+				labels?: Record<string, string>;
+				dateFrom?: string;
+				dateTo?: string;
+				view?: string;
+				mine?: string;
+			};
 			const baseFilter: DocumentFilter = {
 				workflowId,
 				threadId,
@@ -102,7 +111,12 @@ export class DocumentApiController {
 				| DocumentFilter[]
 				| undefined;
 			let filterSets: DocumentFilterSet[];
-			if (res.locals.authzListAll) {
+			if (mine === "1" || mine === "true") {
+				// Caller-requested narrowing to its own rows (e.g. a "my documents"
+				// page). Always narrower than the read policy allows, so it needs no
+				// authz of its own.
+				filterSets = [{ userId, filter: baseFilter }];
+			} else if (res.locals.authzListAll) {
 				filterSets = [{ filter: baseFilter }];
 			} else if (authzFilters?.length) {
 				filterSets = [

--- a/tests/controllers/document-list.test.ts
+++ b/tests/controllers/document-list.test.ts
@@ -167,6 +167,20 @@ describe("handleGetAllDocuments", () => {
 		]);
 	});
 
+	it("mine=1 narrows to the caller's own rows even when authz opens the list", async () => {
+		const seen: unknown[] = [];
+		const controller = makeController({
+			listDocumentsAny: async (sets: unknown) => {
+				seen.push(sets);
+				return [doc("a")];
+			},
+		});
+		const res = mockRes();
+		res.locals.authzListAll = true; // read-open policy would list everyone
+		await controller.handleGetAllDocuments(mockReq({ mine: "1" }), res, next);
+		expect(seen[0]).toEqual([{ userId: "u1", filter: expect.anything() }]);
+	});
+
 	it("authz union in legacy path dedupes by documentId", async () => {
 		const controller = makeController({
 			listDocuments: async () => [doc("dup")],


### PR DESCRIPTION
The list endpoint's scope came entirely from the read policy, which is open by default (RoleResolver.listFilter returns null → authzListAll), so every authenticated user saw every user's documents. That is right for shared records like log books but wrong for a personal "my documents" view, and the two share one endpoint.

Add a `mine=1` query param that narrows the query to the caller's own rows before the authz branches. It is always narrower than the policy allows, so it needs no authorization of its own, and callers that omit it keep today's behavior.