### PR TITLE
feat: LocalArtifactStore, artifact DELETE endpoint, and doc sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,18 @@ pnpm dev        # Run TypeScript directly with tsx
      - Abstract `BaseModel` class for provider-agnostic implementation
      - Support for streaming and non-streaming responses
      - Unified tool/function conversion interface
+     - Optional canonical multipart `input` bridge alongside legacy `query: string`
    - **MemoryModule** (`src/modules/memory/`): Data persistence (required)
      - Thread management for conversation history
      - Intent storage and retrieval
-     - Workflow storage and retrieval
+     - Workflow template and user workflow storage
      - Agent metadata management
+     - Optional `IDocumentMemory` (enables document storage and `/api/document`)
+     - Optional `IScheduleRunMemory` (enables `/api/schedule-runs`)
+   - **ArtifactModule** (`src/modules/artifacts/`): Binary artifact storage (optional)
+     - `IArtifactStore` abstraction for pluggable storage backends
+     - `LocalArtifactStore`: filesystem implementation (binary + JSON metadata sidecar)
+     - Enables `/api/artifacts` upload/metadata/download/delete routes when configured
    - **MCPModule** (`src/modules/mcp/`): Model Context Protocol client connections (optional)
      - Tool discovery and execution from MCP servers
      - Protocol implementation via stdio
@@ -61,6 +68,7 @@ pnpm dev        # Run TypeScript directly with tsx
      - RESTful API for inter-agent communication
      - Agent discovery via well-known endpoints
      - Task delegation with context passing
+     - Multipart/artifact-reference exchange (no raw binary forwarding)
 
 3. **Configuration Layer** (`src/config/`)
    - `agent.ts`: Global agent instance access
@@ -69,24 +77,24 @@ pnpm dev        # Run TypeScript directly with tsx
    - `manifest.ts`: Agent manifest storage
 
 4. **DI Container** (`src/container/`)
-   - `index.ts`: Main Container class with convenience methods
-   - `services.ts`: ServiceContainer for service singletons
-     - ThreadService, IntentTriggerService, IntentFulfillService, AggregateService
-     - SingleIntentTriggerService, MultiIntentTriggerService
-     - QueryService, A2AService
-   - `controllers.ts`: ControllerContainer for controller singletons
-     - QueryController, IntentController
-     - ModelApiController, AgentApiController, ThreadApiController, IntentApiController, WorkflowApiController
+   - `index.ts`: single Container class exposing lazy singleton getters for all
+     services and controllers (e.g. `getQueryService()`, `getArtifactApiController()`)
+   - `container.reset()` clears singletons between tests
 
 5. **Service Layer** (`src/services/`)
    - `query.service.ts`: Query processing with intent detection and fulfillment
    - `thread.service.ts`: Thread management operations
    - `a2a.service.ts`: A2A protocol operations
-   - `intents/trigger.service.ts`: Intent triggering router (single/multi mode)
-   - `intents/single-trigger.service.ts`: Single intent triggering without query decomposition
-   - `intents/multi-trigger.service.ts`: Multi-intent triggering with query decomposition
+   - `artifact.service.ts`: Artifact metadata/upload/download/delete with ownership checks
+   - `pii.service.ts`: PII filtering (mask/reject modes)
+   - `tool-calling.service.ts`: Unified tool execution across MCP/A2A connectors
+   - `document-advice.service.ts`: Document advice generation
+   - `intents/trigger.service.ts`: Intent triggering (single/multi strategy chosen by `DISABLE_MULTI_INTENTS`)
    - `intents/fulfill.service.ts`: Intent fulfillment with tool execution
    - `intents/aggregate.service.ts`: Intelligent response aggregation for multi-intent results
+   - `user-workflow.service.ts`, `user-workflow-coordinator.service.ts`: User workflow CRUD and coordination
+   - `workflow-execution.service.ts` (+ `workflow-graph/`, `workflow-table/`, `workflow-response-composer`, `workflow-variable-*`): workflow definition execution and response block rendering
+   - `scheduler.service.ts`, `job-runner.service.ts`: Cron-scheduled workflow runs
 
 6. **Controller Layer** (`src/controllers/`)
    - `query.controller.ts`: Query endpoint handlers (both streaming and non-streaming)
@@ -95,7 +103,10 @@ pnpm dev        # Run TypeScript directly with tsx
    - `api/model.api.controller.ts`: Model management API
    - `api/agent.api.controller.ts`: Agent management API
    - `api/intent.api.controller.ts`: Intent management API
-   - `api/workflow.api.controller.ts`: Workflow management API
+   - `api/artifact.api.controller.ts`: Artifact upload/metadata/download/delete API
+   - `api/document.api.controller.ts`: Document management API
+   - `api/workflow-template.api.controller.ts`: Workflow template API
+   - `api/user-workflow.api.controller.ts`: User workflow API
 
 7. **Tool Abstraction**
    - `ConnectorTool` type for protocol-agnostic tool representation
@@ -104,10 +115,16 @@ pnpm dev        # Run TypeScript directly with tsx
 
 8. **Type System** (`src/types/`)
    - `agent.ts`: Agent manifest and configuration types
-   - `memory.ts`: Thread, Intent, Workflow, and message types (includes FulfillmentResult)
+   - `memory.ts`: Thread, Intent, Workflow, and message types; canonical multipart
+     `MessageContentPart` union (`text`/`artifact`/`data`/`tool-call`/`tool-result`/`thought`/`document`)
+     with `schemaVersion: 2` messages and legacy read compatibility
+   - `message-input.ts`: Structured query input (`input.parts`), execution input boundaries
+   - `artifact.ts`: `ArtifactObject`, `ArtifactRef`, store input/output types
+   - `document.ts`: Document storage types
    - `stream.ts`: Streaming event and chunk types
-   - `tool.ts`: Tool interfaces and response types
-   - `auth.ts`: Authentication scheme interfaces
+   - `connector.ts`: Tool/connector interfaces and response types
+   - `auth.ts` / `authz.ts`: Authentication and authorization types
+   - `schedule.ts`: Schedule run types
    - `mcp.ts`: MCP-specific types
 
 ### Key Patterns
@@ -120,7 +137,7 @@ pnpm dev        # Run TypeScript directly with tsx
 3. **Tool Execution**: Tools are executed through a unified interface regardless of source (MCP/A2A)
 4. **Streaming Support**: Dual implementation pattern for query processing (streaming and non-streaming)
 5. **Logging**: Service-specific loggers with structured logging
-   - Available loggers: `agent`, `intent`, `intentStream`, `mcp`, `a2a`, `model`, `server`, `fol`
+   - Available loggers: `agent`, `intent`, `intentStream`, `mcp`, `a2a`, `model`, `server`, `fol`, `http`
 6. **Error Handling**:
    - Global error middleware for uncaught errors
    - Custom `AinHttpError` for HTTP-specific errors
@@ -148,12 +165,14 @@ pnpm dev        # Run TypeScript directly with tsx
    - Register modules via `setModules()` in AINAgent initialization
 
 4. **API Endpoints**
-   - Standard query endpoints: `/query`
-   - API for agent management: `/api`
+   - Standard query endpoints: `/query`, `/query/stream` (accept legacy `message: string` or structured `input.parts`)
+   - API for agent management: `/api` (`/api/model`, `/api/agent`, `/api/threads`, `/api/intent`, `/api/workflow-template`, `/api/user-workflow`)
+   - Conditional APIs: `/api/artifacts` (requires ArtifactModule), `/api/document` (requires IDocumentMemory), `/api/schedule-runs` (requires IScheduleRunMemory)
    - A2A endpoints: `/a2a` (only available in A2A server mode)
 
 5. **Testing**
    - Use Jest for unit tests
+   - Tests live in the top-level `tests/` directory (not `src/`) so they are excluded from build output
    - Test files should use `.test.ts` extension
    - Mock external dependencies appropriately
    - Use `container.reset()` to clear singleton instances between tests
@@ -171,7 +190,9 @@ The project uses environment variables for configuration. Key variables include:
 
 ### Intent System Architecture
 
-The library supports two intent triggering modes:
+The library supports two intent triggering modes, both implemented inside the
+single `IntentTriggerService` (`src/services/intents/trigger.service.ts`),
+which selects a strategy based on `DISABLE_MULTI_INTENTS`:
 
 1. **Multi-Intent Mode (Default)**
    - Decomposes queries into multiple subqueries
@@ -179,34 +200,43 @@ The library supports two intent triggering modes:
    - Collects all intent responses
    - Uses `AggregateService` to determine if responses need unification
    - LLM-based aggregation creates a cohesive final response if needed
-   - Services: `MultiIntentTriggerService`, `AggregateService`
 
 2. **Single-Intent Mode** (`DISABLE_MULTI_INTENTS=true`)
    - No query decomposition
    - Identifies single most relevant intent
    - Streams response directly without aggregation
    - Simplified prompts for faster processing
-   - Service: `SingleIntentTriggerService`
-
-The `IntentTriggerService` acts as a router, delegating to the appropriate service based on the environment variable.
 
 ### Workflow System
 
-The library provides built-in workflow management:
+Workflows are split into immutable templates and user-owned instances:
 
-- **Workflow Memory Interface**: Abstract methods in `BaseMemoryModule`
-  - `createWorkflow(workflow)`: Create new workflow
-  - `updateWorkflow(id, workflow)`: Update existing workflow
-  - `getWorkflow(id)`: Retrieve workflow by ID
-  - `listWorkflows(userId?)`: List workflows (optionally filtered by userId)
-  - `deleteWorkflow(id)`: Delete workflow
-- **Workflow API**: RESTful endpoints via `WorkflowApiController`
-  - `GET /api/workflows`: List workflows
-  - `GET /api/workflows/:id`: Get workflow details
-  - `POST /api/workflows`: Create new workflow
-  - `POST /api/workflows/update/:id`: Update workflow
-  - `POST /api/workflows/delete/:id`: Delete workflow
+- **WorkflowTemplate**: admin/system-defined blueprint with a structured
+  `definition` (tasks → response blocks: heading/text/graph/table) and a
+  variable schema
+- **UserWorkflow**: user-owned copy of a template with resolved variable
+  values, optional cron `schedule` + `timezone` for scheduled execution
+- **Execution**: `WorkflowExecutionService` runs tasks (optionally delegated
+  to A2A agents), then composes response blocks; `SchedulerService` +
+  `JobRunnerService` handle cron-based runs recorded via `IScheduleRunMemory`
+- **APIs**: `/api/workflow-template`, `/api/user-workflow`, `/api/schedule-runs`
 - **Display Query Support**: Queries can include optional `displayQuery` parameter for workflow visualization
+- Workflow content is text-first for now; execution boundaries use typed
+  `WorkflowExecutionInput` reserved for future structured input
+
+### Multi-Modal / Artifact Layer
+
+See `MULTIMODAL_ARTIFACT_PLAN.md` for the full migration plan and progress.
+
+- Messages are canonical multipart (`schemaVersion: 2`, `parts[]`); legacy
+  `content`-based records are normalized at read boundaries
+- `/query` accepts structured `input.parts` (text + artifact references) and
+  returns a canonical `message` plus compatibility `content`
+- Streaming emits canonical events (`message_start`, `part_delta`,
+  `message_complete`, `artifact_ready`, `tool_start`, `tool_output`) alongside
+  the compatibility `text_chunk`
+- Artifact binaries live in the optional `ArtifactModule` store, separate from
+  thread memory; messages store only artifact references
 
 ### Build Considerations
 

--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -14,7 +14,7 @@ Primary goals:
 
 ## Progress Snapshot
 
-Last updated: `2026-04-20`
+Last updated: `2026-08-19`
 
 Completed groundwork so far:
 
@@ -87,6 +87,9 @@ Completed groundwork so far:
 - added thread-level legacy message read adapters that expose canonical `schemaVersion: 2` message views
 - normalized thread read and write boundaries in thread, query, and thread API services
 - added focused tests covering legacy thread message reads, canonicalized writes, and query intent processing compatibility
+- added `DocumentContentPart` so main's rich document messages map into the canonical part union
+- added `LocalArtifactStore`, the first concrete `IArtifactStore` implementation (filesystem binary + JSON metadata sidecar, sha256 checksum, synchronous preview text for text-like mime types)
+- exported `LocalArtifactStore` from the public module surface and added focused store tests
 
 Not completed yet:
 

--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -91,13 +91,17 @@ Completed groundwork so far:
 - added `LocalArtifactStore`, the first concrete `IArtifactStore` implementation (filesystem binary + JSON metadata sidecar, sha256 checksum, synchronous preview text for text-like mime types)
 - exported `LocalArtifactStore` from the public module surface and added focused store tests
 - added `DELETE /api/artifacts/:id` with ownership checks, completing the optional artifact CRUD surface
+- re-synced this plan with the post-main-merge codebase: implemented part/event names, document modality, unified intent trigger service, current workflow structure, and settled Phase 0 decisions
 
 Not completed yet:
 
-- full multipart `MessageObject` migration across all runtime paths
-- full query/request/response contract refactor across streaming and provider-facing paths
-- artifact upload/download runtime APIs
-- stream event redesign
+- full multipart `MessageObject` migration across all runtime paths (inference is still normalized to text-first)
+- removal of the compatibility `text_chunk` stream event (breaking; wait until downstream consumers use canonical events)
+- multipart form-data upload middleware (deferred until base64 JSON upload becomes a real limit)
+- preview extraction pipeline beyond `LocalArtifactStore`'s synchronous text preview (async PDF/document extraction)
+- `S3ArtifactStore` / `AzureBlobArtifactStore` implementations
+- provider-side adoption of the canonical `input` bridge (lives in ain-adk-providers)
+- MCP tool binary outputs → artifact conversion (tool image results are currently stringified into model context)
 
 ---
 
@@ -128,8 +132,7 @@ The current implementation is still text-first in important inference paths, but
 - [src/types/memory.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/types/memory.ts)
 - [src/types/stream.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/types/stream.ts)
 - [src/modules/models/base.model.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/modules/models/base.model.ts)
-- [src/services/intents/single-trigger.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/intents/single-trigger.service.ts)
-- [src/services/intents/multi-trigger.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/intents/multi-trigger.service.ts)
+- [src/services/intents/trigger.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/intents/trigger.service.ts)
 - [src/services/intents/fulfill.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/intents/fulfill.service.ts)
 - [src/services/a2a.service.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/services/a2a.service.ts)
 - [src/modules/a2a/a2a.module.ts](/Users/shyun/comcom/ain-agent/ain-adk/src/modules/a2a/a2a.module.ts)
@@ -167,33 +170,45 @@ content: {
 }
 ```
 
-To a multipart-first model:
+To a multipart-first model. The implemented union in `src/types/memory.ts`
+(`MessageContentPart`) is:
 
 ```ts
-type ContentPart =
+type MessageContentPart =
   | { kind: "text"; text: string }
   | {
-      kind: "file";
+      kind: "artifact"; // implemented name for the planned "file" kind
       artifactId: string;
-      name: string;
-      mimeType: string;
-      size: number;
+      name?: string;
+      mimeType?: string;
+      size?: number;
       downloadUrl?: string;
       previewText?: string;
     }
   | { kind: "data"; mimeType: string; data: unknown }
   | { kind: "tool-call"; toolCallId: string; toolName: string; args: unknown }
   | { kind: "tool-result"; toolCallId: string; toolName: string; result: unknown }
-  | { kind: "thought"; title: string; description?: string };
+  | { kind: "thought"; title: string; description?: string }
+  | { kind: "document"; documentId: string; title?: string };
 
 type MessageObject = {
   messageId: string;
   role: "USER" | "SYSTEM" | "MODEL" | "TOOL";
-  parts: ContentPart[];
+  parts: MessageContentPart[];
   timestamp: number;
   metadata?: Record<string, unknown>;
 };
 ```
+
+Document modality note (merged from main's document system):
+
+- documents are a separate modality from artifacts: a `document` part references
+  the document store (`IDocumentMemory`, `/api/document`), while an `artifact`
+  part references the binary artifact store (`ArtifactModule`)
+- document parts store only `documentId` + a label hint; clients resolve the
+  latest document content on render, so message history never embeds bodies
+- query input can carry `documentIds`, which are injected into fulfillment
+  context in-memory (never persisted into the thread) via `injectAttachedDocuments`
 
 Recommended changes:
 
@@ -450,12 +465,12 @@ Toward returning structured output:
 
 ## 3. Artifact APIs
 
-Recommended new endpoints:
+Recommended new endpoints (all implemented):
 
-- `POST /api/artifacts`
+- `POST /api/artifacts` (JSON/base64 upload)
 - `GET /api/artifacts/:id`
 - `GET /api/artifacts/:id/download`
-- optional `DELETE /api/artifacts/:id`
+- `DELETE /api/artifacts/:id`
 
 Upload handling note:
 
@@ -472,10 +487,9 @@ Recommended options:
 - authenticated proxy download through ADK routes
 - signed URL generation by the artifact store
 
-Default recommendation:
-
-- use authenticated proxy downloads as the simplest secure baseline
-- allow stores such as S3 or Azure Blob to return signed URLs where appropriate
+Decided and implemented: authenticated proxy downloads through
+`GET /api/artifacts/:id/download` with ownership checks. Stores such as S3 or
+Azure Blob may still return signed URLs where appropriate in the future.
 
 The selected strategy should be consistent with the existing auth middleware and user ownership checks.
 
@@ -498,34 +512,27 @@ Recommended direction:
 
 ## Stream Event Redesign
 
-The current stream event model is too text-centric.
+The canonical event vocabulary is now implemented in `src/types/stream.ts`.
 
-Recommended future event set:
+Implemented event set:
 
 - `thread_id`
 - `message_start`
 - `part_delta`
 - `artifact_ready`
-- `tool_call`
-- `tool_result`
+- `tool_start` / `tool_output` (implemented names for the planned `tool_call` / `tool_result`)
 - `thinking_process`
 - `message_complete`
 - `error`
+- `text_chunk` (compatibility-only; to be removed once consumers migrate)
 
-Example direction:
+Additional events that exist outside this plan's original scope (workflow and
+document features merged from main):
 
-```ts
-type StreamEvent =
-  | { event: "thread_id"; data: ThreadMetadata }
-  | { event: "message_start"; data: { messageId: string; role: MessageRole } }
-  | { event: "part_delta"; data: { kind: "text"; delta: string } }
-  | { event: "artifact_ready"; data: ArtifactRef }
-  | { event: "tool_call"; data: ToolCallPayload }
-  | { event: "tool_result"; data: ToolResultPayload }
-  | { event: "thinking_process"; data: { title: string; description: string } }
-  | { event: "message_complete"; data: { messageId: string } }
-  | { event: "error"; data: { message: string } };
-```
+- `document_id`
+- `task_output` / `task_result` (workflow task progress)
+- `intent_process`
+- `collection_name`
 
 This keeps streaming extensible for both text and downloadable outputs.
 
@@ -607,10 +614,17 @@ Additional recommendation:
 
 Workflow support should remain text-first for now, but the design should not block a future multimodal workflow model.
 
+Note: the workflow system has since evolved (merged from main) into
+`WorkflowTemplate` / `UserWorkflow` with structured `definition` blocks
+(tasks → heading/text/graph/table), cron scheduling, and dedicated
+`/api/workflow-template` / `/api/user-workflow` / `/api/schedule-runs` routes.
+The text-first stance below still applies to workflow *content* (prompts and
+variable substitution), independent of that structural evolution.
+
 Short-term recommendation:
 
 - keep workflow execution input as text-only
-- keep workflow templates and variable resolution centered on string substitution
+- keep workflow content and variable resolution centered on string substitution
 - avoid expanding workflow APIs to multipart in the first milestone
 
 Long-term design guidance:
@@ -801,12 +815,14 @@ Additional recommendation:
 
 ## Phase 0. Contract Freeze and ADR-Level Decisions
 
-- finalize canonical `MessageObject`, `ContentPart`, `ArtifactObject`, and `ArtifactRef` shapes
-- finalize stream event vocabulary
-- finalize artifact lifecycle states and preview lifecycle states
-- finalize error code vocabulary
-- finalize the first-milestone workflow stance as text-only
-- finalize whether query output returns both `message` and a compatibility `content`
+All of these are now settled in code:
+
+- canonical `MessageObject`, `MessageContentPart`, `ArtifactObject`, and `ArtifactRef` shapes → `src/types/memory.ts`, `src/types/artifact.ts`
+- stream event vocabulary → `src/types/stream.ts` (see Stream Event Redesign above)
+- artifact lifecycle states (`uploaded`/`processing`/`ready`/`failed`) and preview lifecycle states (`pending`/`ready`/`failed`)
+- error code vocabulary (`ARTIFACT_STORE_NOT_CONFIGURED`, `ARTIFACT_NOT_FOUND`, `ARTIFACT_ACCESS_DENIED`, `ARTIFACT_NOT_READY`, `INVALID_ARTIFACT_UPLOAD`, ...)
+- first-milestone workflow stance: text-only
+- query output returns both canonical `message` and compatibility `content`
 
 This phase is intentionally small but important. It reduces rework in every later phase.
 

--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -90,6 +90,7 @@ Completed groundwork so far:
 - added `DocumentContentPart` so main's rich document messages map into the canonical part union
 - added `LocalArtifactStore`, the first concrete `IArtifactStore` implementation (filesystem binary + JSON metadata sidecar, sha256 checksum, synchronous preview text for text-like mime types)
 - exported `LocalArtifactStore` from the public module surface and added focused store tests
+- added `DELETE /api/artifacts/:id` with ownership checks, completing the optional artifact CRUD surface
 
 Not completed yet:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ interface AINAgentModules {
   modelModule: ModelModule;    // Required - AI model integrations
   memoryModule: MemoryModule;  // Required - thread/intent/workflow storage
   artifactModule?: ArtifactModule; // Optional - artifact storage and download handling
+  // e.g. new ArtifactModule(new LocalArtifactStore({ baseDir: "./artifacts" }))
   a2aModule?: A2AModule;       // Optional - agent-to-agent communication
   mcpModule?: MCPModule;       // Optional - MCP server connections
 }

--- a/src/controllers/api/artifact.api.controller.ts
+++ b/src/controllers/api/artifact.api.controller.ts
@@ -130,6 +130,21 @@ export class ArtifactApiController {
 		}
 	};
 
+	public handleDeleteArtifact = async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	) => {
+		try {
+			const { id: artifactId } = req.params as { id: string };
+			const userId = res.locals.userId || "";
+			await this.artifactService.deleteArtifact(userId, artifactId);
+			res.status(StatusCodes.NO_CONTENT).send();
+		} catch (error) {
+			next(error);
+		}
+	};
+
 	public handleDownloadArtifact = async (
 		req: Request,
 		res: Response,

--- a/src/modules/artifacts/local.artifact.ts
+++ b/src/modules/artifacts/local.artifact.ts
@@ -1,0 +1,115 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+	ArtifactDownloadResult,
+	ArtifactObject,
+	ArtifactPutInput,
+} from "@/types/artifact";
+import type { IArtifactStore } from "./base.artifact.js";
+
+const SAFE_ARTIFACT_ID = /^[A-Za-z0-9-]+$/;
+const PREVIEW_MAX_CHARS = 4000;
+const TEXT_LIKE_MIME_TYPES = new Set([
+	"application/json",
+	"application/xml",
+	"application/javascript",
+]);
+
+function isTextLike(mimeType: string): boolean {
+	return mimeType.startsWith("text/") || TEXT_LIKE_MIME_TYPES.has(mimeType);
+}
+
+/**
+ * Filesystem-backed artifact store for local development and simple
+ * single-node deployments. Each artifact is stored as a binary file plus a
+ * JSON metadata sidecar under `baseDir`.
+ */
+export class LocalArtifactStore implements IArtifactStore {
+	private baseDir: string;
+
+	constructor(options: { baseDir: string }) {
+		this.baseDir = options.baseDir;
+	}
+
+	private metadataPath(artifactId: string): string {
+		return path.join(this.baseDir, `${artifactId}.json`);
+	}
+
+	private binaryPath(artifactId: string): string {
+		return path.join(this.baseDir, `${artifactId}.bin`);
+	}
+
+	public async put(input: ArtifactPutInput): Promise<ArtifactObject> {
+		const artifactId = randomUUID();
+		const data = input.data;
+
+		const artifact: ArtifactObject = {
+			artifactId,
+			userId: input.userId,
+			threadId: input.threadId,
+			messageId: input.messageId,
+			status: "ready",
+			name: input.name,
+			mimeType: input.mimeType,
+			size: data.byteLength,
+			checksum: createHash("sha256").update(data).digest("hex"),
+			storageKey: `${artifactId}.bin`,
+			metadata: input.metadata,
+			createdAt: Date.now(),
+		};
+
+		if (isTextLike(input.mimeType)) {
+			artifact.previewText = new TextDecoder()
+				.decode(data)
+				.slice(0, PREVIEW_MAX_CHARS);
+			artifact.previewStatus = "ready";
+		}
+
+		await mkdir(this.baseDir, { recursive: true });
+		await writeFile(this.binaryPath(artifactId), data);
+		await writeFile(this.metadataPath(artifactId), JSON.stringify(artifact));
+		return artifact;
+	}
+
+	public async get(artifactId: string): Promise<ArtifactObject | undefined> {
+		if (!SAFE_ARTIFACT_ID.test(artifactId)) {
+			return undefined;
+		}
+		try {
+			const raw = await readFile(this.metadataPath(artifactId), "utf8");
+			return JSON.parse(raw) as ArtifactObject;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				return undefined;
+			}
+			throw error;
+		}
+	}
+
+	public async delete(artifactId: string): Promise<void> {
+		if (!SAFE_ARTIFACT_ID.test(artifactId)) {
+			return;
+		}
+		await rm(this.metadataPath(artifactId), { force: true });
+		await rm(this.binaryPath(artifactId), { force: true });
+	}
+
+	public async openDownload(
+		artifactId: string,
+	): Promise<ArtifactDownloadResult> {
+		const artifact = await this.get(artifactId);
+		if (!artifact) {
+			throw new Error("Artifact not found");
+		}
+
+		const body = await readFile(this.binaryPath(artifactId));
+		return {
+			body: new Uint8Array(body),
+			mimeType: artifact.mimeType,
+			fileName: artifact.name,
+			contentLength: artifact.size,
+			metadata: artifact.metadata,
+		};
+	}
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,6 +1,7 @@
 export { A2AModule } from "./a2a/a2a.module.js";
 export { ArtifactModule } from "./artifacts/artifact.module.js";
 export type { IArtifactStore } from "./artifacts/base.artifact.js";
+export { LocalArtifactStore } from "./artifacts/local.artifact.js";
 export { AuthModule } from "./auth/auth.module.js";
 export { MCPModule } from "./mcp/mcp.module.js";
 export type {

--- a/src/routes/api/artifacts.routes.ts
+++ b/src/routes/api/artifacts.routes.ts
@@ -44,6 +44,11 @@ export const createArtifactApiRouter = (): Router => {
 		checkArtifactModule,
 		artifactApiController.handleDownloadArtifact,
 	);
+	router.delete(
+		"/:id",
+		checkArtifactModule,
+		artifactApiController.handleDeleteArtifact,
+	);
 
 	return router;
 };

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -80,6 +80,14 @@ export class ArtifactService {
 		return this.getStore().openDownload(artifactId);
 	}
 
+	public async deleteArtifact(
+		userId: string,
+		artifactId: string,
+	): Promise<void> {
+		await this.getArtifact(userId, artifactId);
+		await this.getStore().delete(artifactId);
+	}
+
 	public async uploadArtifact(
 		userId: string,
 		input: Omit<ArtifactPutInput, "userId">,

--- a/tests/controllers/api/artifact.api.controller.test.ts
+++ b/tests/controllers/api/artifact.api.controller.test.ts
@@ -114,6 +114,32 @@ describe("ArtifactApiController", () => {
 		expect(next).not.toHaveBeenCalled();
 	});
 
+	it("deletes artifacts and responds with 204", async () => {
+		const deleteArtifact = jest.fn(async () => {});
+		const controller = new ArtifactApiController({
+			uploadArtifact: jest.fn(),
+			getArtifact: jest.fn(),
+			openDownload: jest.fn(),
+			deleteArtifact,
+		} as any);
+
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const req = { params: { id: "art-1" } } as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			status,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleDeleteArtifact(req, res, next);
+
+		expect(deleteArtifact).toHaveBeenCalledWith("user-1", "art-1");
+		expect(status).toHaveBeenCalledWith(204);
+		expect(send).toHaveBeenCalled();
+		expect(next).not.toHaveBeenCalled();
+	});
+
 	it("streams artifact downloads with headers", async () => {
 		const controller = new ArtifactApiController({
 			uploadArtifact: jest.fn(),

--- a/tests/modules/artifacts/local-artifact-store.test.ts
+++ b/tests/modules/artifacts/local-artifact-store.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { LocalArtifactStore } from "@/modules/artifacts/local.artifact";
+
+describe("LocalArtifactStore", () => {
+	let baseDir: string;
+	let store: LocalArtifactStore;
+
+	beforeEach(() => {
+		baseDir = mkdtempSync(path.join(tmpdir(), "ain-adk-artifacts-"));
+		store = new LocalArtifactStore({ baseDir });
+	});
+
+	afterEach(() => {
+		rmSync(baseDir, { recursive: true, force: true });
+	});
+
+	it("puts an artifact and returns a ready artifact object", async () => {
+		const artifact = await store.put({
+			name: "hello.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("hello world"),
+			userId: "user-1",
+			threadId: "thread-1",
+		});
+
+		expect(artifact.artifactId).toBeTruthy();
+		expect(artifact.status).toBe("ready");
+		expect(artifact.name).toBe("hello.txt");
+		expect(artifact.mimeType).toBe("text/plain");
+		expect(artifact.size).toBe(11);
+		expect(artifact.userId).toBe("user-1");
+		expect(artifact.threadId).toBe("thread-1");
+		expect(artifact.checksum).toMatch(/^[0-9a-f]{64}$/);
+		expect(artifact.createdAt).toBeGreaterThan(0);
+	});
+
+	it("persists metadata so get() works across store instances", async () => {
+		const artifact = await store.put({
+			name: "hello.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("hello world"),
+		});
+
+		const reopened = new LocalArtifactStore({ baseDir });
+		const fetched = await reopened.get(artifact.artifactId);
+
+		expect(fetched).toEqual(artifact);
+	});
+
+	it("returns undefined for an unknown artifact id", async () => {
+		await expect(store.get("missing")).resolves.toBeUndefined();
+	});
+
+	it("opens a download with the stored bytes and metadata", async () => {
+		const artifact = await store.put({
+			name: "hello.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("hello world"),
+		});
+
+		const download = await store.openDownload(artifact.artifactId);
+
+		expect(new TextDecoder().decode(download.body)).toBe("hello world");
+		expect(download.mimeType).toBe("text/plain");
+		expect(download.fileName).toBe("hello.txt");
+		expect(download.contentLength).toBe(11);
+	});
+
+	it("throws when downloading an unknown artifact", async () => {
+		await expect(store.openDownload("missing")).rejects.toThrow(
+			"Artifact not found",
+		);
+	});
+
+	it("deletes an artifact and its binary", async () => {
+		const artifact = await store.put({
+			name: "hello.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("hello world"),
+		});
+
+		await store.delete(artifact.artifactId);
+
+		await expect(store.get(artifact.artifactId)).resolves.toBeUndefined();
+		await expect(store.openDownload(artifact.artifactId)).rejects.toThrow(
+			"Artifact not found",
+		);
+	});
+
+	it("extracts preview text for text-like artifacts", async () => {
+		const artifact = await store.put({
+			name: "notes.md",
+			mimeType: "text/markdown",
+			data: new TextEncoder().encode("# Title\nbody"),
+		});
+
+		expect(artifact.previewText).toBe("# Title\nbody");
+		expect(artifact.previewStatus).toBe("ready");
+	});
+
+	it("skips preview text for binary artifacts", async () => {
+		const artifact = await store.put({
+			name: "image.png",
+			mimeType: "image/png",
+			data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+		});
+
+		expect(artifact.previewText).toBeUndefined();
+		expect(artifact.previewStatus).toBeUndefined();
+	});
+
+	it("rejects artifact ids that escape the base directory", async () => {
+		await expect(store.get("../evil")).resolves.toBeUndefined();
+		await expect(store.openDownload("../evil")).rejects.toThrow(
+			"Artifact not found",
+		);
+	});
+});

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -146,6 +146,63 @@ describe("ArtifactService", () => {
 		expect(openDownload).toHaveBeenCalledWith("art-1");
 	});
 
+	it("deletes artifacts the user owns", async () => {
+		const del = jest.fn(async () => {});
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: async () => ({
+						artifactId: "art-1",
+						userId: "user-1",
+						status: "ready" as const,
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						storageKey: "artifacts/report.pdf",
+						createdAt: 100,
+					}),
+					put: jest.fn(),
+					delete: del,
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(service.deleteArtifact("user-1", "art-1")).resolves.toBeUndefined();
+		expect(del).toHaveBeenCalledWith("art-1");
+	});
+
+	it("rejects deletion of another user's artifact", async () => {
+		const del = jest.fn(async () => {});
+
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: async () => ({
+						artifactId: "art-1",
+						userId: "other-user",
+						status: "ready" as const,
+						name: "report.pdf",
+						mimeType: "application/pdf",
+						size: 1024,
+						storageKey: "artifacts/report.pdf",
+						createdAt: 100,
+					}),
+					put: jest.fn(),
+					delete: del,
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(service.deleteArtifact("user-1", "art-1")).rejects.toMatchObject(
+			{
+				message: "Artifact access denied",
+				code: "ARTIFACT_ACCESS_DENIED",
+			},
+		);
+		expect(del).not.toHaveBeenCalled();
+	});
+
 	it("resolves query artifact parts with store metadata", async () => {
 		const get = jest.fn(async () => ({
 			artifactId: "art-1",


### PR DESCRIPTION
## Summary

- **`LocalArtifactStore`** — first concrete `IArtifactStore` implementation, making the already-built artifact upload/download/query-reference flows actually usable without a custom store. Stores binaries plus JSON metadata sidecars under a base directory, computes sha256 checksums, extracts synchronous preview text for text-like mime types (4000-char cap), and guards against path traversal. Exported from the public module surface with a README example.
- **`DELETE /api/artifacts/:id`** — completes the optional artifact CRUD surface from the multimodal plan. Reuses the same ownership check as metadata/download access, so cross-user deletion is rejected with `ARTIFACT_ACCESS_DENIED`.
- **Docs sync** — `MULTIMODAL_ARTIFACT_PLAN.md` and `CLAUDE.md` re-synced with the post-main-merge codebase: rewrote the stale not-completed list, updated impacted files after intent-trigger unification, documented implemented part/event names (`kind: "artifact"`, `tool_start`/`tool_output`), added the document-vs-artifact modality note, reflected the WorkflowTemplate/UserWorkflow structure, and marked Phase 0 contract decisions and the proxy download strategy as settled.

Follow-up work (upload limits, text_chunk finding note) moved to #154.

## Test plan

- `pnpm test` — 380 tests pass (12 new: 9 LocalArtifactStore, 2 delete service ownership, 1 delete controller)
- `pnpm biome` / `pnpm build` — clean (pre-commit hooks run all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)