### PR TITLE
feat: artifact upload size and mime-type limits

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -96,7 +96,7 @@ Completed groundwork so far:
 Not completed yet:
 
 - full multipart `MessageObject` migration across all runtime paths (inference is still normalized to text-first)
-- removal of the compatibility `text_chunk` stream event (breaking; wait until downstream consumers use canonical events)
+- removal of the compatibility `text_chunk` stream event (breaking; see the two-precondition note in the Stream Event Redesign section)
 - multipart form-data upload middleware (deferred until base64 JSON upload becomes a real limit)
 - preview extraction pipeline beyond `LocalArtifactStore`'s synchronous text preview (async PDF/document extraction)
 - `S3ArtifactStore` / `AzureBlobArtifactStore` implementations
@@ -525,6 +525,20 @@ Implemented event set:
 - `message_complete`
 - `error`
 - `text_chunk` (compatibility-only; to be removed once consumers migrate)
+
+`text_chunk` removal note (found 2026-08-20): the event is not only an outbound
+compatibility payload — internal code also consumes it as the text-accumulation
+signal. `workflow-execution.service`, `workflow-task-runner.service`,
+`a2a.service`, and `intents/fulfill.service` all branch on
+`event.event === "text_chunk"` to collect streamed text, and there are 10+ emit
+sites (fulfill, aggregate, query PII path, workflow-response-composer,
+document-advice, tool-calling, a2a). Removal therefore has two preconditions:
+
+1. external consumers (enterprise app, A2A peers) migrate to canonical events
+2. internal consumption sites switch to `part_delta` / `message_complete`
+
+Precondition 2 does not depend on external consumers and can be done now as a
+standalone refactor, which makes the eventual breaking removal much cheaper.
 
 Additional events that exist outside this plan's original scope (workflow and
 document features merged from main):

--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -92,6 +92,7 @@ Completed groundwork so far:
 - exported `LocalArtifactStore` from the public module surface and added focused store tests
 - added `DELETE /api/artifacts/:id` with ownership checks, completing the optional artifact CRUD surface
 - re-synced this plan with the post-main-merge codebase: implemented part/event names, document modality, unified intent trigger service, current workflow structure, and settled Phase 0 decisions
+- added upload limit validation via `ArtifactModuleOptions` (`maxSizeBytes` → `ARTIFACT_TOO_LARGE` 413, `allowedMimeTypes` with `type/*` wildcards → `ARTIFACT_TYPE_NOT_ALLOWED` 415); unlimited when unconfigured
 
 Not completed yet:
 
@@ -732,8 +733,8 @@ This area should be part of the plan from the start because artifacts introduce 
 
 Recommended considerations:
 
-- allowed mime-type policy
-- max file size per upload
+- allowed mime-type policy (implemented: `ArtifactModuleOptions.allowedMimeTypes`, `type/*` wildcards supported)
+- max file size per upload (implemented: `ArtifactModuleOptions.maxSizeBytes`)
 - total artifact quota per user or thread
 - optional malware scanning hook
 - ownership checks on artifact metadata and download access
@@ -834,7 +835,7 @@ All of these are now settled in code:
 - canonical `MessageObject`, `MessageContentPart`, `ArtifactObject`, and `ArtifactRef` shapes → `src/types/memory.ts`, `src/types/artifact.ts`
 - stream event vocabulary → `src/types/stream.ts` (see Stream Event Redesign above)
 - artifact lifecycle states (`uploaded`/`processing`/`ready`/`failed`) and preview lifecycle states (`pending`/`ready`/`failed`)
-- error code vocabulary (`ARTIFACT_STORE_NOT_CONFIGURED`, `ARTIFACT_NOT_FOUND`, `ARTIFACT_ACCESS_DENIED`, `ARTIFACT_NOT_READY`, `INVALID_ARTIFACT_UPLOAD`, ...)
+- error code vocabulary (`ARTIFACT_STORE_NOT_CONFIGURED`, `ARTIFACT_NOT_FOUND`, `ARTIFACT_ACCESS_DENIED`, `ARTIFACT_NOT_READY`, `ARTIFACT_TOO_LARGE`, `ARTIFACT_TYPE_NOT_ALLOWED`, `INVALID_ARTIFACT_UPLOAD`, ...)
 - first-milestone workflow stance: text-only
 - query output returns both canonical `message` and compatibility `content`
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ interface AINAgentModules {
   modelModule: ModelModule;    // Required - AI model integrations
   memoryModule: MemoryModule;  // Required - thread/intent/workflow storage
   artifactModule?: ArtifactModule; // Optional - artifact storage and download handling
-  // e.g. new ArtifactModule(new LocalArtifactStore({ baseDir: "./artifacts" }))
+  // e.g. new ArtifactModule(new LocalArtifactStore({ baseDir: "./artifacts" }),
+  //        { maxSizeBytes: 10_000_000, allowedMimeTypes: ["image/*", "application/pdf"] })
   a2aModule?: A2AModule;       // Optional - agent-to-agent communication
   mcpModule?: MCPModule;       // Optional - MCP server connections
 }

--- a/src/modules/artifacts/artifact.module.ts
+++ b/src/modules/artifacts/artifact.module.ts
@@ -1,13 +1,29 @@
 import type { IArtifactStore } from "./base.artifact.js";
 
+export type ArtifactModuleOptions = {
+	/** Maximum upload size in bytes. Unlimited when unset. */
+	maxSizeBytes?: number;
+	/** Allowed upload mime types; supports "type/*" wildcards. All allowed when unset. */
+	allowedMimeTypes?: string[];
+};
+
 export class ArtifactModule {
 	private artifactStore: IArtifactStore;
+	private options: ArtifactModuleOptions;
 
-	constructor(artifactStore: IArtifactStore) {
+	constructor(
+		artifactStore: IArtifactStore,
+		options: ArtifactModuleOptions = {},
+	) {
 		this.artifactStore = artifactStore;
+		this.options = options;
 	}
 
 	public getStore(): IArtifactStore {
 		return this.artifactStore;
+	}
+
+	public getOptions(): ArtifactModuleOptions {
+		return this.options;
 	}
 }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,8 @@
 export { A2AModule } from "./a2a/a2a.module.js";
-export { ArtifactModule } from "./artifacts/artifact.module.js";
+export {
+	ArtifactModule,
+	type ArtifactModuleOptions,
+} from "./artifacts/artifact.module.js";
 export type { IArtifactStore } from "./artifacts/base.artifact.js";
 export { LocalArtifactStore } from "./artifacts/local.artifact.js";
 export { AuthModule } from "./auth/auth.module.js";

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -88,10 +88,40 @@ export class ArtifactService {
 		await this.getStore().delete(artifactId);
 	}
 
+	private assertUploadAllowed(input: Omit<ArtifactPutInput, "userId">): void {
+		const { maxSizeBytes, allowedMimeTypes } =
+			this.artifactModule?.getOptions?.() ?? {};
+
+		if (maxSizeBytes !== undefined && input.data.byteLength > maxSizeBytes) {
+			throw new AinHttpError(
+				StatusCodes.REQUEST_TOO_LONG,
+				`Artifact exceeds the maximum upload size of ${maxSizeBytes} bytes`,
+				"ARTIFACT_TOO_LARGE",
+			);
+		}
+
+		if (
+			allowedMimeTypes &&
+			!allowedMimeTypes.some(
+				(allowed) =>
+					allowed === input.mimeType ||
+					(allowed.endsWith("/*") &&
+						input.mimeType.startsWith(allowed.slice(0, -1))),
+			)
+		) {
+			throw new AinHttpError(
+				StatusCodes.UNSUPPORTED_MEDIA_TYPE,
+				`Artifact mime type '${input.mimeType}' is not allowed`,
+				"ARTIFACT_TYPE_NOT_ALLOWED",
+			);
+		}
+	}
+
 	public async uploadArtifact(
 		userId: string,
 		input: Omit<ArtifactPutInput, "userId">,
 	): Promise<ArtifactObject> {
+		this.assertUploadAllowed(input);
 		return this.getStore().put({
 			...input,
 			userId,

--- a/tests/modules/artifacts/artifact.module.test.ts
+++ b/tests/modules/artifacts/artifact.module.test.ts
@@ -14,4 +14,21 @@ describe("ArtifactModule", () => {
 
 		expect(module.getStore()).toBe(store);
 	});
+
+	it("returns configured upload options, defaulting to empty", () => {
+		const store: IArtifactStore = {
+			put: jest.fn(),
+			get: jest.fn(),
+			delete: jest.fn(),
+			openDownload: jest.fn(),
+		};
+
+		expect(new ArtifactModule(store).getOptions()).toEqual({});
+		expect(
+			new ArtifactModule(store, {
+				maxSizeBytes: 1024,
+				allowedMimeTypes: ["application/pdf"],
+			}).getOptions(),
+		).toEqual({ maxSizeBytes: 1024, allowedMimeTypes: ["application/pdf"] });
+	});
 });

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -55,6 +55,92 @@ describe("ArtifactService", () => {
 		});
 	});
 
+	it("rejects uploads larger than the configured max size", async () => {
+		const put = jest.fn();
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put,
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+			getOptions: () => ({ maxSizeBytes: 4 }),
+		} as any);
+
+		await expect(
+			service.uploadArtifact("user-1", {
+				name: "big.bin",
+				mimeType: "application/octet-stream",
+				data: new Uint8Array([1, 2, 3, 4, 5]),
+			}),
+		).rejects.toMatchObject({
+			status: 413,
+			code: "ARTIFACT_TOO_LARGE",
+		});
+		expect(put).not.toHaveBeenCalled();
+	});
+
+	it("rejects uploads with a disallowed mime type", async () => {
+		const put = jest.fn();
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put,
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+			getOptions: () => ({ allowedMimeTypes: ["application/pdf", "image/*"] }),
+		} as any);
+
+		await expect(
+			service.uploadArtifact("user-1", {
+				name: "script.sh",
+				mimeType: "text/x-shellscript",
+				data: new Uint8Array([1]),
+			}),
+		).rejects.toMatchObject({
+			status: 415,
+			code: "ARTIFACT_TYPE_NOT_ALLOWED",
+		});
+		expect(put).not.toHaveBeenCalled();
+	});
+
+	it("allows uploads matching a mime wildcard within the size limit", async () => {
+		const put = jest.fn(async (input) => ({
+			artifactId: "art-1",
+			status: "ready" as const,
+			name: input.name,
+			mimeType: input.mimeType,
+			size: input.data.length,
+			storageKey: "art-1.bin",
+			createdAt: 100,
+		}));
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put,
+					delete: jest.fn(),
+					openDownload: jest.fn(),
+				}) as any,
+			getOptions: () => ({
+				maxSizeBytes: 10,
+				allowedMimeTypes: ["image/*"],
+			}),
+		} as any);
+
+		await expect(
+			service.uploadArtifact("user-1", {
+				name: "pic.png",
+				mimeType: "image/png",
+				data: new Uint8Array([1, 2, 3]),
+			}),
+		).resolves.toMatchObject({ artifactId: "art-1" });
+		expect(put).toHaveBeenCalled();
+	});
+
 	it("returns artifact metadata when the user owns the artifact", async () => {
 		const get = jest.fn(async () => ({
 			artifactId: "art-1",


### PR DESCRIPTION
## Summary

- `ArtifactModule` now accepts optional `{ maxSizeBytes, allowedMimeTypes }` upload policy options (`type/*` wildcards supported), exported as `ArtifactModuleOptions`
- `ArtifactService` rejects oversized uploads with 413 `ARTIFACT_TOO_LARGE` and disallowed types with 415 `ARTIFACT_TYPE_NOT_ALLOWED` before touching the store
- Unconfigured modules keep the previous unlimited behavior (backward compatible)
- Completes the artifact error-code vocabulary defined in `MULTIMODAL_ARTIFACT_PLAN.md`; README example and plan progress updated

Also carries one small docs commit that was accidentally pushed to the already-merged #153 branch: the `text_chunk` internal-consumption finding recorded in the plan's Stream Event Redesign section.

## Test plan

- `pnpm test` — 384 tests pass (4 new: size rejection, mime rejection, wildcard allow, module options)
- `pnpm biome` / `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)