### PR TITLE
feat: clean up thread artifacts on thread deletion

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -93,6 +93,7 @@ Completed groundwork so far:
 - added `DELETE /api/artifacts/:id` with ownership checks, completing the optional artifact CRUD surface
 - re-synced this plan with the post-main-merge codebase: implemented part/event names, document modality, unified intent trigger service, current workflow structure, and settled Phase 0 decisions
 - added upload limit validation via `ArtifactModuleOptions` (`maxSizeBytes` → `ARTIFACT_TOO_LARGE` 413, `allowedMimeTypes` with `type/*` wildcards → `ARTIFACT_TYPE_NOT_ALLOWED` 415); unlimited when unconfigured
+- added thread-deletion artifact cleanup: optional `IArtifactStore.listByThread` (implemented by `LocalArtifactStore`), best-effort `ArtifactService.deleteThreadArtifacts` (never fails the thread deletion), wired into the thread delete API
 
 Not completed yet:
 

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -248,7 +248,10 @@ class Container {
 
 	getThreadApiController(): ThreadApiController {
 		if (!this._threadApiController) {
-			this._threadApiController = new ThreadApiController(getMemoryModule());
+			this._threadApiController = new ThreadApiController(
+				getMemoryModule(),
+				this.getArtifactService(),
+			);
 		}
 		return this._threadApiController;
 	}

--- a/src/controllers/api/threads.api.controller.ts
+++ b/src/controllers/api/threads.api.controller.ts
@@ -1,14 +1,17 @@
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import type { MemoryModule } from "@/modules/index.js";
+import type { ArtifactService } from "@/services/artifact.service";
 import type { ThreadFilter } from "@/types/memory.js";
 import { normalizeThreadObject } from "@/utils/message.js";
 
 export class ThreadApiController {
 	private memoryModule: MemoryModule;
+	private artifactService?: ArtifactService;
 
-	constructor(memoryModule: MemoryModule) {
+	constructor(memoryModule: MemoryModule, artifactService?: ArtifactService) {
 		this.memoryModule = memoryModule;
+		this.artifactService = artifactService;
 	}
 
 	public handleGetThread = async (
@@ -41,6 +44,7 @@ export class ThreadApiController {
 			const userId = res.locals.userId || "";
 			const threadMemory = this.memoryModule.getThreadMemory();
 			await threadMemory?.deleteThread(userId, threadId);
+			await this.artifactService?.deleteThreadArtifacts(userId, threadId);
 			res.status(StatusCodes.OK).send();
 		} catch (error) {
 			next(error);

--- a/src/modules/artifacts/base.artifact.ts
+++ b/src/modules/artifacts/base.artifact.ts
@@ -9,4 +9,6 @@ export interface IArtifactStore {
 	get(artifactId: string): Promise<ArtifactObject | undefined>;
 	delete(artifactId: string): Promise<void>;
 	openDownload(artifactId: string): Promise<ArtifactDownloadResult>;
+	/** Optional: enables thread-deletion artifact cleanup when implemented. */
+	listByThread?(threadId: string): Promise<ArtifactObject[]>;
 }

--- a/src/modules/artifacts/local.artifact.ts
+++ b/src/modules/artifacts/local.artifact.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
 	ArtifactDownloadResult,
@@ -93,6 +93,29 @@ export class LocalArtifactStore implements IArtifactStore {
 		}
 		await rm(this.metadataPath(artifactId), { force: true });
 		await rm(this.binaryPath(artifactId), { force: true });
+	}
+
+	// ponytail: O(n) sidecar scan per call; index by threadId if stores grow large
+	public async listByThread(threadId: string): Promise<ArtifactObject[]> {
+		let entries: string[];
+		try {
+			entries = await readdir(this.baseDir);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				return [];
+			}
+			throw error;
+		}
+
+		const artifacts = await Promise.all(
+			entries
+				.filter((entry) => entry.endsWith(".json"))
+				.map((entry) => this.get(entry.slice(0, -".json".length))),
+		);
+		return artifacts.filter(
+			(artifact): artifact is ArtifactObject =>
+				artifact !== undefined && artifact.threadId === threadId,
+		);
 	}
 
 	public async openDownload(

--- a/src/services/artifact.service.ts
+++ b/src/services/artifact.service.ts
@@ -10,6 +10,7 @@ import type {
 	QueryArtifactInputPart,
 	QueryMessageInput,
 } from "@/types/message-input";
+import { loggers } from "@/utils/logger.js";
 
 export class ArtifactService {
 	private artifactModule?: ArtifactModule;
@@ -78,6 +79,36 @@ export class ArtifactService {
 	): Promise<ArtifactDownloadResult> {
 		await this.getArtifact(userId, artifactId);
 		return this.getStore().openDownload(artifactId);
+	}
+
+	/**
+	 * Best-effort cleanup of a deleted thread's artifacts. Never throws:
+	 * thread deletion must not fail because binaries could not be removed.
+	 * No-ops when no artifact module is configured or the store does not
+	 * implement `listByThread`.
+	 */
+	public async deleteThreadArtifacts(
+		userId: string,
+		threadId: string,
+	): Promise<void> {
+		try {
+			const store = this.artifactModule?.getStore();
+			if (!store?.listByThread) {
+				return;
+			}
+
+			const artifacts = await store.listByThread(threadId);
+			await Promise.all(
+				artifacts
+					.filter((artifact) => !artifact.userId || artifact.userId === userId)
+					.map((artifact) => store.delete(artifact.artifactId)),
+			);
+		} catch (error) {
+			loggers.agent.warn("Failed to clean up thread artifacts", {
+				threadId,
+				error,
+			});
+		}
 	}
 
 	public async deleteArtifact(

--- a/tests/controllers/api/threads.api.controller.test.ts
+++ b/tests/controllers/api/threads.api.controller.test.ts
@@ -54,4 +54,31 @@ describe("ThreadApiController", () => {
 		});
 		expect(next).not.toHaveBeenCalled();
 	});
+
+	it("cleans up thread artifacts when deleting a thread", async () => {
+		const deleteThread = jest.fn(async () => {});
+		const deleteThreadArtifacts = jest.fn(async () => {});
+		const controller = new ThreadApiController(
+			{
+				getThreadMemory: () => ({ deleteThread }),
+			} as any,
+			{ deleteThreadArtifacts } as any,
+		);
+
+		const send = jest.fn();
+		const status = jest.fn().mockReturnValue({ send });
+		const req = { params: { id: "thread-1" } } as unknown as Request;
+		const res = {
+			locals: { userId: "user-1" },
+			status,
+		} as unknown as Response;
+		const next = jest.fn() as NextFunction;
+
+		await controller.handleDeleteThread(req, res, next);
+
+		expect(deleteThread).toHaveBeenCalledWith("user-1", "thread-1");
+		expect(deleteThreadArtifacts).toHaveBeenCalledWith("user-1", "thread-1");
+		expect(status).toHaveBeenCalledWith(200);
+		expect(next).not.toHaveBeenCalled();
+	});
 });

--- a/tests/modules/artifacts/local-artifact-store.test.ts
+++ b/tests/modules/artifacts/local-artifact-store.test.ts
@@ -111,6 +111,37 @@ describe("LocalArtifactStore", () => {
 		expect(artifact.previewStatus).toBeUndefined();
 	});
 
+	it("lists artifacts belonging to a thread", async () => {
+		const first = await store.put({
+			name: "a.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("a"),
+			threadId: "thread-1",
+		});
+		await store.put({
+			name: "b.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("b"),
+			threadId: "thread-2",
+		});
+		const third = await store.put({
+			name: "c.txt",
+			mimeType: "text/plain",
+			data: new TextEncoder().encode("c"),
+			threadId: "thread-1",
+		});
+
+		const listed = await store.listByThread("thread-1");
+
+		expect(listed.map((a) => a.artifactId).sort()).toEqual(
+			[first.artifactId, third.artifactId].sort(),
+		);
+	});
+
+	it("returns an empty list for a thread without artifacts", async () => {
+		await expect(store.listByThread("missing-thread")).resolves.toEqual([]);
+	});
+
 	it("rejects artifact ids that escape the base directory", async () => {
 		await expect(store.get("../evil")).resolves.toBeUndefined();
 		await expect(store.openDownload("../evil")).rejects.toThrow(

--- a/tests/services/artifact.service.test.ts
+++ b/tests/services/artifact.service.test.ts
@@ -289,6 +289,82 @@ describe("ArtifactService", () => {
 		expect(del).not.toHaveBeenCalled();
 	});
 
+	it("deletes a thread's artifacts owned by (or unowned for) the user", async () => {
+		const del = jest.fn(async () => {});
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put: jest.fn(),
+					delete: del,
+					openDownload: jest.fn(),
+					listByThread: async () => [
+						{ artifactId: "art-mine", userId: "user-1", threadId: "thread-1" },
+						{ artifactId: "art-unowned", threadId: "thread-1" },
+						{
+							artifactId: "art-other",
+							userId: "other-user",
+							threadId: "thread-1",
+						},
+					],
+				}) as any,
+		} as any);
+
+		await service.deleteThreadArtifacts("user-1", "thread-1");
+
+		expect(del.mock.calls.map((c) => c[0]).sort()).toEqual([
+			"art-mine",
+			"art-unowned",
+		]);
+	});
+
+	it("skips thread artifact cleanup when the store cannot list by thread", async () => {
+		const del = jest.fn();
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put: jest.fn(),
+					delete: del,
+					openDownload: jest.fn(),
+				}) as any,
+		} as any);
+
+		await expect(
+			service.deleteThreadArtifacts("user-1", "thread-1"),
+		).resolves.toBeUndefined();
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("never throws from thread artifact cleanup", async () => {
+		const service = new ArtifactService({
+			getStore: () =>
+				({
+					get: jest.fn(),
+					put: jest.fn(),
+					delete: jest.fn(async () => {
+						throw new Error("disk error");
+					}),
+					openDownload: jest.fn(),
+					listByThread: async () => [
+						{ artifactId: "art-1", userId: "user-1", threadId: "thread-1" },
+					],
+				}) as any,
+		} as any);
+
+		await expect(
+			service.deleteThreadArtifacts("user-1", "thread-1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("no-ops thread artifact cleanup without an artifact module", async () => {
+		const service = new ArtifactService(undefined);
+
+		await expect(
+			service.deleteThreadArtifacts("user-1", "thread-1"),
+		).resolves.toBeUndefined();
+	});
+
 	it("resolves query artifact parts with store metadata", async () => {
 		const get = jest.fn(async () => ({
 			artifactId: "art-1",


### PR DESCRIPTION
## Summary

Implements the plan's lifecycle baseline: deleting a thread now cleans up its artifacts instead of leaving orphaned binaries.

- **`IArtifactStore.listByThread?`** — new optional store method; stores that don't implement it skip cleanup gracefully (no breaking change for existing implementers)
- **`LocalArtifactStore.listByThread`** — metadata sidecar scan filtered by `threadId` (O(n) per call, noted for future indexing)
- **`ArtifactService.deleteThreadArtifacts`** — best-effort: deletes only artifacts linked to the deleted thread and owned by (or unowned for) the requesting user; never throws, so thread deletion always succeeds even if binary cleanup fails (failures are logged)
- **`DELETE /api/threads/:id`** — now triggers artifact cleanup after the thread record is removed; `ThreadApiController` takes an optional `ArtifactService` wired via the container

Deliberately out of scope (per plan): deferred/background deletion jobs and cross-thread reference counting — artifacts are scoped to one thread by their `threadId` linkage.

## Test plan

- `pnpm test` — 391 tests pass (7 new: 2 store listByThread, 4 service cleanup semantics, 1 controller wiring)
- `pnpm biome` / `pnpm build` — clean (pre-commit hooks run all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)