### PR TITLE
feat: convert MCP tool binary outputs into stored artifacts

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -94,6 +94,7 @@ Completed groundwork so far:
 - re-synced this plan with the post-main-merge codebase: implemented part/event names, document modality, unified intent trigger service, current workflow structure, and settled Phase 0 decisions
 - added upload limit validation via `ArtifactModuleOptions` (`maxSizeBytes` → `ARTIFACT_TOO_LARGE` 413, `allowedMimeTypes` with `type/*` wildcards → `ARTIFACT_TYPE_NOT_ALLOWED` 415); unlimited when unconfigured
 - added thread-deletion artifact cleanup: optional `IArtifactStore.listByThread` (implemented by `LocalArtifactStore`), best-effort `ArtifactService.deleteThreadArtifacts` (never fails the thread deletion), wired into the thread delete API
+- converted MCP tool binary outputs (image/audio/resource-blob blocks) into stored artifacts with `artifact_ready` events; `MCPModule.useTool` is now an AsyncGenerator symmetric with A2A, and base64 payloads never reach model context (omission notes when no store is configured)
 
 Not completed yet:
 
@@ -103,7 +104,6 @@ Not completed yet:
 - preview extraction pipeline beyond `LocalArtifactStore`'s synchronous text preview (async PDF/document extraction)
 - `S3ArtifactStore` / `AzureBlobArtifactStore` implementations
 - provider-side adoption of the canonical `input` bridge (lives in ain-adk-providers)
-- MCP tool binary outputs → artifact conversion (tool image results are currently stringified into model context)
 - artifact lifecycle/cleanup: thread deletion does not touch artifacts, so orphaned binaries accumulate (see Lifecycle and Cleanup — now practically relevant since a real store implementation exists)
 
 ---

--- a/src/modules/mcp/mcp.module.ts
+++ b/src/modules/mcp/mcp.module.ts
@@ -3,14 +3,79 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
+import { getArtifactModule } from "@/config/modules.js";
 import {
 	CONNECTOR_PROTOCOL_TYPE,
 	type ConnectorTool,
 } from "@/types/connector.js";
 import type { MCPConfig } from "@/types/mcp.js";
+import type { ArtifactContentPart } from "@/types/memory.js";
+import type { StreamEvent } from "@/types/stream.js";
 import { loggers } from "@/utils/logger.js";
 import { withAdkThinkingArg } from "@/utils/tool-args.js";
+import type { IArtifactStore } from "../artifacts/base.artifact.js";
 import { MCPConnector } from "./mcp.connector.js";
+
+function safeGetArtifactStore(): IArtifactStore | undefined {
+	try {
+		return getArtifactModule()?.getStore();
+	} catch {
+		// Modules not initialized (standalone module usage): no artifact storage.
+		return undefined;
+	}
+}
+
+type BinaryBlock = { data: string; mimeType: string; name: string };
+
+/** Recognizes MCP binary content blocks: image/audio base64 and resource blobs. */
+function extractBinaryBlock(
+	block: unknown,
+	toolName: string,
+	index: number,
+): BinaryBlock | undefined {
+	if (!block || typeof block !== "object") {
+		return undefined;
+	}
+	const candidate = block as {
+		type?: string;
+		data?: unknown;
+		mimeType?: unknown;
+		resource?: { uri?: unknown; mimeType?: unknown; blob?: unknown };
+	};
+
+	if (
+		(candidate.type === "image" || candidate.type === "audio") &&
+		typeof candidate.data === "string" &&
+		typeof candidate.mimeType === "string"
+	) {
+		const subtype = candidate.mimeType.split("/")[1]?.split("+")[0] || "bin";
+		return {
+			data: candidate.data,
+			mimeType: candidate.mimeType,
+			name: `${toolName}-output-${index}.${subtype}`,
+		};
+	}
+
+	if (
+		candidate.type === "resource" &&
+		typeof candidate.resource?.blob === "string"
+	) {
+		const uri =
+			typeof candidate.resource.uri === "string" ? candidate.resource.uri : "";
+		return {
+			data: candidate.resource.blob,
+			mimeType:
+				typeof candidate.resource.mimeType === "string"
+					? candidate.resource.mimeType
+					: "application/octet-stream",
+			name:
+				uri.split("/").filter(Boolean).pop() ||
+				`${toolName}-output-${index}.bin`,
+		};
+	}
+
+	return undefined;
+}
 
 /**
  * Module for managing Model Context Protocol (MCP) server connections.
@@ -122,15 +187,21 @@ export class MCPModule {
 	/**
 	 * Executes a tool on its corresponding MCP server.
 	 *
+	 * Binary content blocks (image/audio/resource-blob) are stored through the
+	 * configured artifact store and yielded as `artifact_ready` events; the
+	 * serialized text result carries artifact references instead of base64
+	 * payloads. Without an artifact store, binary payloads are omitted.
+	 *
 	 * @param tool - The MCPTool instance to execute
 	 * @param _args - Arguments to pass to the tool
-	 * @returns Promise resolving to the tool's execution result
-	 * @throws Error if the MCP server for the tool is not found
+	 * @param context - Ownership/linkage metadata for stored artifacts
+	 * @returns AsyncGenerator yielding stream events and returning the text result
 	 */
-	async useTool(
+	async *useTool(
 		tool: ConnectorTool,
 		_args?: Record<string, unknown>,
-	): Promise<string> {
+		context?: { userId?: string; threadId?: string },
+	): AsyncGenerator<StreamEvent, string, unknown> {
 		const { connectorName, toolName } = tool;
 		const connector = this.mcpConnectors.get(connectorName);
 		const client = connector?.client;
@@ -156,15 +227,89 @@ export class MCPModule {
 					? { timeout: requestTimeoutMs, resetTimeoutOnProgress: true }
 					: undefined,
 			);
-			const toolResult =
+			const { content, events } = await this.replaceBinaryBlocks(
+				toolName,
+				result.content,
+				context,
+			);
+			for (const event of events) {
+				yield event;
+			}
+			return (
 				`[Bot Called Tool ${toolName} with args ${JSON.stringify(_args)}]\n` +
-				JSON.stringify(result.content, null, 2);
-			return toolResult;
+				JSON.stringify(content, null, 2)
+			);
 		} catch (error) {
 			loggers.mcp.error("Failed to call tool", { error });
 			const toolResult = `[Bot Called Tool ${toolName} with args ${JSON.stringify(_args)}]\n${typeof error === "string" ? error : JSON.stringify(error, null, 2)}`;
 			return toolResult;
 		}
+	}
+
+	/**
+	 * Replaces binary content blocks with artifact references (when a store is
+	 * configured) or omission notes, so base64 payloads never reach model
+	 * context. Returns the sanitized content plus artifact_ready events.
+	 */
+	private async replaceBinaryBlocks(
+		toolName: string,
+		content: unknown,
+		context?: { userId?: string; threadId?: string },
+	): Promise<{ content: unknown; events: StreamEvent[] }> {
+		if (!Array.isArray(content)) {
+			return { content, events: [] };
+		}
+
+		const store = safeGetArtifactStore();
+		const events: StreamEvent[] = [];
+		const blocks = await Promise.all(
+			content.map(async (block, index) => {
+				const binary = extractBinaryBlock(block, toolName, index);
+				if (!binary) {
+					return block;
+				}
+
+				const bytes = Buffer.from(binary.data, "base64");
+				if (store) {
+					try {
+						const artifact = await store.put({
+							name: binary.name,
+							mimeType: binary.mimeType,
+							data: bytes,
+							userId: context?.userId,
+							threadId: context?.threadId,
+						});
+						const part: ArtifactContentPart = {
+							kind: "artifact",
+							artifactId: artifact.artifactId,
+							name: artifact.name,
+							mimeType: artifact.mimeType,
+							size: artifact.size,
+							downloadUrl: `/api/artifacts/${artifact.artifactId}/download`,
+						};
+						events.push({ event: "artifact_ready", data: part });
+						return { type: (block as { type?: string }).type, artifact: part };
+					} catch (error) {
+						loggers.mcp.warn("Failed to store tool binary output", {
+							toolName,
+							error,
+						});
+						return {
+							type: (block as { type?: string }).type,
+							mimeType: binary.mimeType,
+							note: `binary content omitted (${bytes.byteLength} bytes; failed to store artifact)`,
+						};
+					}
+				}
+
+				return {
+					type: (block as { type?: string }).type,
+					mimeType: binary.mimeType,
+					note: `binary content omitted (${bytes.byteLength} bytes; artifact storage not configured)`,
+				};
+			}),
+		);
+		return { content: blocks, events };
 	}
 
 	/**

--- a/src/services/tool-calling.service.ts
+++ b/src/services/tool-calling.service.ts
@@ -242,7 +242,10 @@ export class ToolCallingService {
 				toolName,
 				toolArgs: protocolArgs,
 			});
-			return await this.mcpModule.useTool(selectedTool, protocolArgs);
+			return yield* this.mcpModule.useTool(selectedTool, protocolArgs, {
+				userId: thread.userId,
+				threadId: thread.threadId,
+			});
 		}
 
 		if (

--- a/tests/modules/mcp.module.test.ts
+++ b/tests/modules/mcp.module.test.ts
@@ -1,0 +1,166 @@
+import { getArtifactModule } from "@/config/modules";
+import { MCPModule } from "@/modules/mcp/mcp.module";
+import { CONNECTOR_PROTOCOL_TYPE } from "@/types/connector";
+import type { StreamEvent } from "@/types/stream";
+
+jest.mock("@/config/modules", () => ({
+	getArtifactModule: jest.fn(),
+}));
+
+const TOOL = {
+	toolName: "srv-gen",
+	connectorName: "srv",
+	protocol: CONNECTOR_PROTOCOL_TYPE.MCP,
+};
+
+const PNG_BASE64 = Buffer.from("fake-png-bytes").toString("base64");
+
+function makeModule(callToolResult: unknown): MCPModule {
+	const module = new MCPModule();
+	module.addMCPConnector({ srv: {} as any });
+	(module as any).mcpConnectors.get("srv").client = {
+		callTool: jest.fn(async () => callToolResult),
+	};
+	return module;
+}
+
+async function drain(
+	gen: AsyncGenerator<StreamEvent, string, unknown>,
+): Promise<{ events: StreamEvent[]; result: string }> {
+	const events: StreamEvent[] = [];
+	let next = await gen.next();
+	while (!next.done) {
+		events.push(next.value);
+		next = await gen.next();
+	}
+	return { events, result: next.value };
+}
+
+describe("MCPModule.useTool binary outputs", () => {
+	beforeEach(() => {
+		jest.mocked(getArtifactModule).mockReset();
+	});
+
+	it("stores image blocks as artifacts and yields artifact_ready", async () => {
+		const put = jest.fn(async (input: any) => ({
+			artifactId: "art-1",
+			status: "ready" as const,
+			name: input.name,
+			mimeType: input.mimeType,
+			size: input.data.byteLength,
+			storageKey: "art-1.bin",
+			userId: input.userId,
+			threadId: input.threadId,
+			createdAt: 1,
+		}));
+		jest
+			.mocked(getArtifactModule)
+			.mockReturnValue({ getStore: () => ({ put }) } as any);
+
+		const module = makeModule({
+			content: [
+				{ type: "text", text: "generated!" },
+				{ type: "image", data: PNG_BASE64, mimeType: "image/png" },
+			],
+		});
+
+		const { events, result } = await drain(
+			module.useTool(TOOL, { q: 1 }, { userId: "user-1", threadId: "thread-1" }),
+		);
+
+		expect(events).toEqual([
+			{
+				event: "artifact_ready",
+				data: expect.objectContaining({
+					kind: "artifact",
+					artifactId: "art-1",
+					mimeType: "image/png",
+					downloadUrl: "/api/artifacts/art-1/download",
+				}),
+			},
+		]);
+		expect(put).toHaveBeenCalledWith(
+			expect.objectContaining({
+				mimeType: "image/png",
+				userId: "user-1",
+				threadId: "thread-1",
+			}),
+		);
+		expect(
+			new TextDecoder().decode(put.mock.calls[0][0].data as Uint8Array),
+		).toBe("fake-png-bytes");
+		expect(result).toContain("generated!");
+		expect(result).toContain("art-1");
+		expect(result).not.toContain(PNG_BASE64);
+	});
+
+	it("stores resource blob blocks as artifacts", async () => {
+		const put = jest.fn(async (input: any) => ({
+			artifactId: "art-2",
+			status: "ready" as const,
+			name: input.name,
+			mimeType: input.mimeType,
+			size: input.data.byteLength,
+			storageKey: "art-2.bin",
+			createdAt: 1,
+		}));
+		jest
+			.mocked(getArtifactModule)
+			.mockReturnValue({ getStore: () => ({ put }) } as any);
+
+		const module = makeModule({
+			content: [
+				{
+					type: "resource",
+					resource: {
+						uri: "file:///out/report.pdf",
+						mimeType: "application/pdf",
+						blob: PNG_BASE64,
+					},
+				},
+			],
+		});
+
+		const { events, result } = await drain(module.useTool(TOOL, {}));
+
+		expect(events).toHaveLength(1);
+		expect(put).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: "report.pdf",
+				mimeType: "application/pdf",
+			}),
+		);
+		expect(result).not.toContain(PNG_BASE64);
+	});
+
+	it("omits binary payloads when no artifact store is configured", async () => {
+		jest.mocked(getArtifactModule).mockReturnValue(undefined);
+
+		const module = makeModule({
+			content: [
+				{ type: "text", text: "hello" },
+				{ type: "image", data: PNG_BASE64, mimeType: "image/png" },
+			],
+		});
+
+		const { events, result } = await drain(module.useTool(TOOL, {}));
+
+		expect(events).toEqual([]);
+		expect(result).toContain("hello");
+		expect(result).not.toContain(PNG_BASE64);
+		expect(result).toContain("artifact storage not configured");
+	});
+
+	it("keeps text-only results unchanged", async () => {
+		jest.mocked(getArtifactModule).mockReturnValue(undefined);
+
+		const module = makeModule({
+			content: [{ type: "text", text: "plain answer" }],
+		});
+
+		const { events, result } = await drain(module.useTool(TOOL, {}));
+
+		expect(events).toEqual([]);
+		expect(result).toContain("plain answer");
+	});
+});

--- a/tests/services/intents/fulfill.service.test.ts
+++ b/tests/services/intents/fulfill.service.test.ts
@@ -277,7 +277,9 @@ describe("IntentFulfillService", () => {
 		let streamCallCount = 0;
 		const appendAssistantToolCallTurn = jest.fn();
 		const appendToolResult = jest.fn();
-		const useTool = jest.fn(async () => "tool result text");
+		const useTool = jest.fn(async function* () {
+			return "tool result text";
+		});
 		const modelModule = {
 			getModel: () => ({
 				generateMessages: () => [],
@@ -411,6 +413,7 @@ describe("IntentFulfillService", () => {
 		expect(useTool).toHaveBeenCalledWith(
 			expect.objectContaining({ toolName: "search" }),
 			{ query: "hello" },
+			expect.objectContaining({ threadId: expect.any(String) }),
 		);
 		expect(appendAssistantToolCallTurn).toHaveBeenCalledWith(
 			[],

--- a/tests/services/tool-calling.service.test.ts
+++ b/tests/services/tool-calling.service.test.ts
@@ -156,7 +156,9 @@ describe("ToolCallingService", () => {
 			streamOf([textChunk("final answer")]),
 		]);
 		const mcp = {
-			useTool: jest.fn(async () => "mcp result"),
+			useTool: jest.fn(async function* () {
+				return "mcp result";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 		const messages: unknown[] = [];
@@ -191,6 +193,47 @@ describe("ToolCallingService", () => {
 		expect(mcp.useTool).toHaveBeenCalledTimes(1);
 	});
 
+	it("forwards artifact_ready events from MCP tools and keeps the text result", async () => {
+		const model = makeModel([
+			streamOf([toolCallChunk(0, "call_1", "gen", '{"q":"foo"}')]),
+			streamOf([textChunk("final answer")]),
+		]);
+		const mcp = {
+			useTool: jest.fn(function* () {
+				yield {
+					event: "artifact_ready" as const,
+					data: { kind: "artifact" as const, artifactId: "art-9" },
+				};
+				return "mcp result with artifact art-9";
+			}),
+		} as unknown as MCPModule;
+		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
+
+		const { events } = await drain(
+			svc.run({
+				messages: [],
+				tools: [mcpTool("gen")],
+				query: "q",
+				thread: makeThread(),
+			}),
+		);
+
+		expect(events).toContainEqual({
+			event: "artifact_ready",
+			data: { kind: "artifact", artifactId: "art-9" },
+		});
+		expect(model.appendToolResult).toHaveBeenCalledWith(expect.anything(), {
+			toolCallId: "call_1",
+			toolName: "gen",
+			content: "mcp result with artifact art-9",
+		});
+		expect(mcp.useTool).toHaveBeenCalledWith(
+			expect.objectContaining({ toolName: "gen" }),
+			{ q: "foo" },
+			{ userId: "user-1", threadId: "thread-1" },
+		);
+	});
+
 	it("preserves streamed text alongside tool calls in the assistant turn", async () => {
 		const model = makeModel([
 			streamOf([
@@ -200,7 +243,9 @@ describe("ToolCallingService", () => {
 			streamOf([textChunk("done")]),
 		]);
 		const mcp = {
-			useTool: jest.fn(async () => "ok"),
+			useTool: jest.fn(async function* () {
+				return "ok";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 
@@ -228,7 +273,9 @@ describe("ToolCallingService", () => {
 			streamOf([textChunk("aggregated")]),
 		]);
 		const mcp = {
-			useTool: jest.fn(async (tool: ConnectorTool) => `result:${tool.toolName}`),
+			useTool: jest.fn(async function* (tool: ConnectorTool) {
+				return `result:${tool.toolName}`;
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 
@@ -320,7 +367,9 @@ describe("ToolCallingService", () => {
 		);
 		const model = makeModel(looping);
 		const mcp = {
-			useTool: jest.fn(async () => "x"),
+			useTool: jest.fn(async function* () {
+				return "x";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 
@@ -352,7 +401,9 @@ describe("ToolCallingService", () => {
 			{ name: "search" },
 		]);
 		const mcp = {
-			useTool: jest.fn(async () => "ok"),
+			useTool: jest.fn(async function* () {
+				return "ok";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 
@@ -384,7 +435,9 @@ describe("ToolCallingService", () => {
 			order.push("tool");
 		});
 		const mcp = {
-			useTool: jest.fn(async () => "ok"),
+			useTool: jest.fn(async function* () {
+				return "ok";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 
@@ -406,7 +459,9 @@ describe("ToolCallingService", () => {
 			streamOf([textChunk("done")]),
 		]);
 		const mcp = {
-			useTool: jest.fn(async () => "ok"),
+			useTool: jest.fn(async function* () {
+				return "ok";
+			}),
 		} as unknown as MCPModule;
 		const svc = new ToolCallingService(makeModelModule(model), undefined, mcp);
 


### PR DESCRIPTION
## Summary

Closes the last real in-repo multi-modal gap: MCP tools returning images/audio/binary resources no longer dump base64 into model context.

- **`MCPModule.useTool` → AsyncGenerator** — now yields `StreamEvent`s and returns the text result, symmetric with `A2AModule.useTool`. This is the contract change flagged in the plan; the only internal caller is `ToolCallingService`, and the SDK is 0.x.
- **Binary block handling** — MCP `image`/`audio` blocks (base64 + mimeType) and `resource` blocks with `blob` are:
  - stored via the configured artifact store (linked to the querying user/thread, so ownership checks and thread-deletion cleanup apply)
  - emitted as `artifact_ready` events through the existing fulfillment stream pipeline
  - replaced in the serialized tool result with compact artifact references (`artifactId`, `downloadUrl`, size) the model can cite
- **Degraded modes** — no artifact store configured, or store `put` failure: the payload is replaced with an omission note (byte count + reason); base64 never reaches model context either way. Tool execution itself never fails because of artifact storage.
- **`ToolCallingService`** — MCP branch delegates with `yield*` and passes `{ userId, threadId }` from the thread; A2A branch unchanged.

Note: artifacts stored from tool outputs bypass `ArtifactModuleOptions` upload limits by design — those limits target user uploads, not agent-generated outputs.

## Test plan

- `pnpm test` — 396 tests pass (5 new: image storage + artifact_ready, resource blob storage, no-store omission, text-only passthrough, tool-calling event forwarding; existing MCP mocks updated to the generator contract)
- `pnpm biome` / `pnpm build` — clean (pre-commit hooks run all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)