### PR TITLE
refactor: switch internal text_chunk consumers to canonical stream events

### DIFF
--- a/MULTIMODAL_ARTIFACT_PLAN.md
+++ b/MULTIMODAL_ARTIFACT_PLAN.md
@@ -95,6 +95,7 @@ Completed groundwork so far:
 - added upload limit validation via `ArtifactModuleOptions` (`maxSizeBytes` → `ARTIFACT_TOO_LARGE` 413, `allowedMimeTypes` with `type/*` wildcards → `ARTIFACT_TYPE_NOT_ALLOWED` 415); unlimited when unconfigured
 - added thread-deletion artifact cleanup: optional `IArtifactStore.listByThread` (implemented by `LocalArtifactStore`), best-effort `ArtifactService.deleteThreadArtifacts` (never fails the thread deletion), wired into the thread delete API
 - converted MCP tool binary outputs (image/audio/resource-blob blocks) into stored artifacts with `artifact_ready` events; `MCPModule.useTool` is now an AsyncGenerator symmetric with A2A, and base64 payloads never reach model context (omission notes when no store is configured)
+- switched internal `text_chunk` consumers to canonical events: a2a fallback accumulation and workflow non-stream accumulators read `part_delta`, and workflow streams now emit `message_start`/`part_delta`/`message_complete` with the persisted message identity (see the text_chunk removal note in Stream Event Redesign)
 
 Not completed yet:
 
@@ -531,19 +532,30 @@ Implemented event set:
 - `error`
 - `text_chunk` (compatibility-only; to be removed once consumers migrate)
 
-`text_chunk` removal note (found 2026-08-20): the event is not only an outbound
-compatibility payload — internal code also consumes it as the text-accumulation
-signal. `workflow-execution.service`, `workflow-task-runner.service`,
-`a2a.service`, and `intents/fulfill.service` all branch on
-`event.event === "text_chunk"` to collect streamed text, and there are 10+ emit
-sites (fulfill, aggregate, query PII path, workflow-response-composer,
-document-advice, tool-calling, a2a). Removal therefore has two preconditions:
+`text_chunk` removal note (found 2026-08-20, internal switch done 2026-08-21):
+internal `text_chunk` usage splits into two roles.
 
-1. external consumers (enterprise app, A2A peers) migrate to canonical events
-2. internal consumption sites switch to `part_delta` / `message_complete`
+Converted — consumers of canonical-bearing streams now read `part_delta` /
+`message_complete` instead of `text_chunk`:
 
-Precondition 2 does not depend on external consumers and can be done now as a
-standalone refactor, which makes the eventual breaking removal much cheaper.
+- `a2a.service` fallback text accumulation
+- `workflow-execution.service` non-stream accumulators (`executeWorkflow`,
+  `fillDocumentSlot`)
+- workflow streams now emit canonical `message_start` / `part_delta` /
+  `message_complete` (shared renderer wrapper mirroring the fulfill adapter),
+  so external workflow-stream consumers finally have a canonical migration path
+
+Remaining by design — `text_chunk` as the *internal delta primitive* between
+message-agnostic producers (tool-calling, workflow-response-composer,
+document-advice, aggregate) and their canonical wrappers/conversion boundaries
+(`fulfill.service` final-stream adapter, `workflow-task-runner` → `task_output`,
+`workflow-execution` response wrapper). These links never need to reach the
+wire, so they do not block external removal.
+
+Removal precondition left: external consumers (enterprise app, A2A peers)
+migrate to canonical events. After that, removal = stop *forwarding*
+`text_chunk` at the fulfill/workflow/query-PII boundaries — no internal
+consumer depends on it anymore.
 
 Additional events that exist outside this plan's original scope (workflow and
 document features merged from main):

--- a/src/services/a2a.service.ts
+++ b/src/services/a2a.service.ts
@@ -201,7 +201,7 @@ export class A2AService implements AgentExecutor {
 					return;
 				}
 
-				if (event.event === "text_chunk") {
+				if (event.event === "part_delta" && event.data.part.kind === "text") {
 					finalResponseText += event.data.delta;
 				} else if (event.event === "message_complete") {
 					finalResponseText = serializeMessageForModelFallback(

--- a/src/services/workflow-execution.service.ts
+++ b/src/services/workflow-execution.service.ts
@@ -8,6 +8,7 @@ import {
 	DocumentSource,
 } from "@/types/document.js";
 import {
+	type MessageObject,
 	MessageRole,
 	type ThreadMetadata,
 	type ThreadObject,
@@ -22,6 +23,7 @@ import type { SlotFillInitiator } from "@/types/schedule.js";
 import type { StreamEvent } from "@/types/stream.js";
 import { renderDocument } from "@/utils/document-render.js";
 import { loggers } from "@/utils/logger.js";
+import { normalizeMessageObject } from "@/utils/message.js";
 import {
 	appendRichMessageToThread,
 	appendTextMessageToThread,
@@ -34,6 +36,12 @@ import { WorkflowTableService } from "./workflow-table.service.js";
 import { WorkflowTaskRunner } from "./workflow-task-runner.service.js";
 import { WorkflowVariableExtractionService } from "./workflow-variable-extraction.service.js";
 import type { WorkflowVariableResolver } from "./workflow-variable-resolver.service.js";
+
+/** Canonical message identity shared between streaming deltas and persistence. */
+type WorkflowMessageState = {
+	messageId: string;
+	started: boolean;
+};
 
 type WorkflowExecutionResult = {
 	content: string;
@@ -89,7 +97,10 @@ export class WorkflowExecutionService {
 		for await (const event of stream) {
 			if (event.event === "thread_id") {
 				threadId = event.data.threadId;
-			} else if (event.event === "text_chunk") {
+			} else if (
+				event.event === "part_delta" &&
+				event.data.part.kind === "text"
+			) {
 				content += event.data.delta;
 			}
 		}
@@ -143,16 +154,22 @@ export class WorkflowExecutionService {
 			},
 		};
 
+		const messageState: WorkflowMessageState = {
+			messageId: randomUUID(),
+			started: false,
+		};
 		const { finalContent, renderedBlocks, executionError } =
 			yield* this.renderStructuredDefinition(
 				definition,
 				thread,
 				workflowId,
 				signal,
+				messageState,
 			);
 
 		const responseContent =
 			finalContent || (executionError ? `오류: ${executionError.message}` : "");
+		let savedMessage: MessageObject | undefined;
 		try {
 			const documentMemory = this.memoryModule.getDocumentMemory();
 			if (documentMemory && !executionError && finalContent) {
@@ -174,7 +191,7 @@ export class WorkflowExecutionService {
 					createdAt: now,
 					updatedAt: now,
 				});
-				await appendRichMessageToThread(
+				savedMessage = await appendRichMessageToThread(
 					this.memoryModule,
 					thread,
 					MessageRole.MODEL,
@@ -184,11 +201,12 @@ export class WorkflowExecutionService {
 						workflowRun: true,
 						documentId,
 					},
+					messageState.messageId,
 				);
 			} else {
 				// No document memory (or execution failed): keep the legacy
 				// inline text message with structured blocks in metadata.
-				await appendTextMessageToThread(
+				savedMessage = await appendTextMessageToThread(
 					this.memoryModule,
 					thread,
 					MessageRole.MODEL,
@@ -199,6 +217,7 @@ export class WorkflowExecutionService {
 						responseBlocks: renderedBlocks,
 						...(executionError ? { error: executionError.message } : {}),
 					},
+					messageState.messageId,
 				);
 			}
 		} catch (saveError) {
@@ -207,6 +226,22 @@ export class WorkflowExecutionService {
 				threadId: thread.threadId,
 				error: saveError,
 			});
+		}
+
+		if (savedMessage) {
+			if (!messageState.started) {
+				yield {
+					event: "message_start",
+					data: {
+						messageId: messageState.messageId,
+						role: MessageRole.MODEL,
+					},
+				};
+			}
+			yield {
+				event: "message_complete",
+				data: { message: normalizeMessageObject(savedMessage) },
+			};
 		}
 
 		try {
@@ -318,6 +353,10 @@ export class WorkflowExecutionService {
 		thread: ThreadObject,
 		workflowId: string,
 		signal?: AbortSignal,
+		messageState: WorkflowMessageState = {
+			messageId: randomUUID(),
+			started: false,
+		},
 	): AsyncGenerator<
 		StreamEvent,
 		{
@@ -478,8 +517,31 @@ export class WorkflowExecutionService {
 				while (!result.done) {
 					if (result.value.event === "text_chunk") {
 						finalContent += result.value.data.delta;
+						yield result.value;
+						// Canonical wrapper around the composer's text_chunk primitive,
+						// mirroring the fulfill-service final-stream adapter.
+						if (!messageState.started) {
+							messageState.started = true;
+							yield {
+								event: "message_start",
+								data: {
+									messageId: messageState.messageId,
+									role: MessageRole.MODEL,
+								},
+							};
+						}
+						yield {
+							event: "part_delta",
+							data: {
+								messageId: messageState.messageId,
+								partIndex: 0,
+								part: { kind: "text" },
+								delta: result.value.data.delta,
+							},
+						};
+					} else {
+						yield result.value;
 					}
-					yield result.value;
 					result = await stream.next();
 				}
 				renderedBlocks.push(result.value);
@@ -657,7 +719,7 @@ export class WorkflowExecutionService {
 			options,
 			signal,
 		)) {
-			if (event.event === "text_chunk") {
+			if (event.event === "part_delta" && event.data.part.kind === "text") {
 				content += event.data.delta;
 			}
 		}

--- a/src/utils/thread-messages.ts
+++ b/src/utils/thread-messages.ts
@@ -11,9 +11,10 @@ export function createTextMessage(
 	role: MessageRole,
 	content: string,
 	metadata?: Record<string, unknown>,
+	messageId?: string,
 ): MessageObject {
 	return {
-		messageId: randomUUID(),
+		messageId: messageId ?? randomUUID(),
 		role,
 		timestamp: Date.now(),
 		content: { type: "text", parts: [content] },
@@ -41,12 +42,14 @@ export async function appendTextMessageToThread(
 	role: MessageRole,
 	content: string,
 	metadata?: Record<string, unknown>,
-): Promise<void> {
-	const message = createTextMessage(role, content, metadata);
+	messageId?: string,
+): Promise<MessageObject> {
+	const message = createTextMessage(role, content, metadata, messageId);
 	thread.messages.push(message);
 	await memoryModule
 		.getThreadMemory()
 		?.addMessagesToThread(thread.userId, thread.threadId, [message]);
+	return message;
 }
 
 /**
@@ -59,9 +62,10 @@ export function createRichMessage(
 	role: MessageRole,
 	parts: MessagePart[],
 	metadata?: Record<string, unknown>,
+	messageId?: string,
 ): MessageObject {
 	return {
-		messageId: randomUUID(),
+		messageId: messageId ?? randomUUID(),
 		role,
 		timestamp: Date.now(),
 		content: { type: "rich", parts },
@@ -75,10 +79,12 @@ export async function appendRichMessageToThread(
 	role: MessageRole,
 	parts: MessagePart[],
 	metadata?: Record<string, unknown>,
-): Promise<void> {
-	const message = createRichMessage(role, parts, metadata);
+	messageId?: string,
+): Promise<MessageObject> {
+	const message = createRichMessage(role, parts, metadata, messageId);
 	thread.messages.push(message);
 	await memoryModule
 		.getThreadMemory()
 		?.addMessagesToThread(thread.userId, thread.threadId, [message]);
+	return message;
 }

--- a/tests/services/a2a.service.test.ts
+++ b/tests/services/a2a.service.test.ts
@@ -66,6 +66,62 @@ describe("A2AService", () => {
 		});
 	});
 
+	it("accumulates fallback text from canonical part_delta when message_complete is absent", async () => {
+		const a2aService = new A2AService({
+			handleQuery: async function* () {
+				yield {
+					event: "message_start" as const,
+					data: { messageId: "msg-3", role: MessageRole.MODEL },
+				};
+				yield {
+					event: "part_delta" as const,
+					data: {
+						messageId: "msg-3",
+						partIndex: 0,
+						part: { kind: "text" as const },
+						delta: "partial ",
+					},
+				};
+				yield {
+					event: "part_delta" as const,
+					data: {
+						messageId: "msg-3",
+						partIndex: 0,
+						part: { kind: "text" as const },
+						delta: "answer",
+					},
+				};
+				return undefined;
+			},
+		} as any);
+
+		const publish = jest.fn();
+		await a2aService.execute(
+			{
+				userMessage: {
+					contextId: "thread-1",
+					metadata: {
+						agentId: "agent-1",
+						type: ThreadType.CHAT,
+					},
+					parts: [{ kind: "text", text: "hello" }],
+				},
+			} as any,
+			{ publish } as any,
+		);
+
+		expect(publish.mock.calls[1][0]).toMatchObject({
+			kind: "status-update",
+			status: {
+				state: "completed",
+				message: {
+					parts: [{ kind: "text", text: "partial answer" }],
+				},
+			},
+			final: true,
+		});
+	});
+
 	it("maps inbound file parts to structured input and publishes artifact updates", async () => {
 		const finalMessage = {
 			messageId: "msg-2",

--- a/tests/services/workflow-execution.service.test.ts
+++ b/tests/services/workflow-execution.service.test.ts
@@ -155,6 +155,9 @@ describe("WorkflowExecutionService", () => {
 			"task_result",
 			"thinking_process",
 			"text_chunk",
+			"message_start",
+			"part_delta",
+			"message_complete",
 		]);
 		expect(
 			events.find(
@@ -163,6 +166,121 @@ describe("WorkflowExecutionService", () => {
 					event.data.delta === "unexpected early text",
 			),
 		).toBeUndefined();
+	});
+
+	it("emits canonical message events around the workflow response", async () => {
+		const workflow = {
+			workflowId: "workflow-1",
+			userId: "user-1",
+			title: "Daily Report",
+			content: "Daily Report",
+			active: true,
+			definition: {
+				tasks: [
+					{ taskId: "task-1", title: "Collect data", prompt: "Collect data" },
+				],
+				response: {
+					blocks: [
+						{ blockId: "block-1", type: "heading" as const, text: "Summary" },
+					],
+				},
+			},
+		};
+		const userWorkflowService = {
+			getWorkflow: jest.fn(async () => workflow),
+			updateWorkflow: jest.fn(async () => undefined),
+		} as unknown as UserWorkflowService;
+		const workflowVariableResolver = {
+			resolveForExecution: jest.fn(() => ({
+				query: workflow.content,
+				displayQuery: workflow.title,
+				definition: workflow.definition,
+			})),
+		} as unknown as WorkflowVariableResolver;
+		const addMessagesToThread = jest.fn(async () => undefined);
+		const memoryModule = {
+			getThreadMemory: () => ({
+				createThread: jest.fn(async () => ({
+					type: ThreadType.WORKFLOW,
+					userId: workflow.userId,
+					threadId: "thread-1",
+					title: workflow.title,
+					workflowId: workflow.workflowId,
+				})),
+				addMessagesToThread,
+			}),
+			getDocumentMemory: () => undefined,
+		} as unknown as MemoryModule;
+
+		const service = new WorkflowExecutionService(
+			userWorkflowService,
+			workflowVariableResolver,
+			{} as ModelModule,
+			memoryModule,
+			{} as ToolCallingService,
+		);
+
+		(service as any).workflowTaskRunner = {
+			executeTask: async function* () {
+				return {
+					taskId: "task-1",
+					title: "Collect data",
+					status: "completed",
+					content: "task result body",
+					startedAt: 1,
+					completedAt: 2,
+				} satisfies WorkflowTaskResult;
+			},
+		};
+		(service as any).workflowResponseComposer = {
+			renderResponseBlock: async function* () {
+				yield {
+					event: "text_chunk",
+					data: { delta: "## Summary\n\n" },
+				} satisfies StreamEvent;
+				return {
+					blockId: "block-1",
+					type: "heading",
+					content: "## Summary\n\n",
+				};
+			},
+		};
+
+		const events = await collectEvents(
+			service.executeWorkflowStream(workflow.workflowId),
+		);
+
+		const messageStart = events.find((e) => e.event === "message_start") as any;
+		const partDelta = events.find((e) => e.event === "part_delta") as any;
+		const messageComplete = events.find(
+			(e) => e.event === "message_complete",
+		) as any;
+
+		expect(messageStart).toBeDefined();
+		expect(partDelta).toMatchObject({
+			data: {
+				messageId: messageStart.data.messageId,
+				partIndex: 0,
+				part: { kind: "text" },
+				delta: "## Summary\n\n",
+			},
+		});
+		expect(messageComplete).toMatchObject({
+			data: {
+				message: {
+					messageId: messageStart.data.messageId,
+					schemaVersion: 2,
+					parts: [{ kind: "text", text: "## Summary\n\n" }],
+				},
+			},
+		});
+		expect(addMessagesToThread).toHaveBeenCalledWith("user-1", "thread-1", [
+			expect.objectContaining({ messageId: messageStart.data.messageId }),
+		]);
+
+		// canonical events come after the compat text_chunk of the same delta
+		const eventNames = events.map((e) => e.event);
+		expect(eventNames).toContain("text_chunk");
 	});
 
 	it("creates a document and appends a rich reference message when document memory is available", async () => {


### PR DESCRIPTION
## Summary

Completes precondition 2 from the plan's `text_chunk` removal note — no internal consumer depends on `text_chunk` anymore, so the eventual breaking removal becomes a forwarding-only change at the fulfill/workflow/query boundaries.

- **Workflow streams gain canonical message events** — the shared `renderStructuredDefinition` wrapper emits `message_start` on the first response delta and `part_delta` per delta (mirroring the fulfill-service adapter), and `executeWorkflowStream` emits `message_complete` with the normalized persisted message. The `part_delta` messageId matches the persisted thread message via a shared `WorkflowMessageState`, so external workflow-stream consumers now have a canonical migration path (this was the missing enabler for precondition 1).
- **Internal accumulators converted to `part_delta`** — `a2a.service` fallback text accumulation, `WorkflowExecutionService.executeWorkflow`, and `fillDocumentSlot`.
- **Left as the internal delta primitive (by design)** — `text_chunk` between message-agnostic producers (tool-calling, response-composer, document-advice, aggregate) and their canonical wrappers/conversion boundaries (fulfill adapter, task-runner → `task_output`, workflow response wrapper). These links never reach the wire.
- `appendTextMessageToThread` / `appendRichMessageToThread` now accept an optional `messageId` and return the created message (additive).
- Plan doc's removal note updated to reflect the converted/remaining split.

## Test plan

- `pnpm test` — 398 tests pass (2 new: workflow canonical message trio with persisted-id match, a2a part_delta fallback accumulation; 1 pinned event-sequence test updated for the new events)
- `pnpm biome` / `pnpm build` — clean (pre-commit hooks run all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)